### PR TITLE
feat: add rewrite_paragraph and return paragraph refs from all edit methods

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "docx-editor",
   "description": "Comprehensive document creation, editing, and analysis with support for tracked changes, comments, formatting preservation, and text extraction",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": {
     "name": "pablospe"
   },

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Pure Python library for Word document track changes and comments, without requir
 
 - **Hash-Anchored Paragraph References**: `list_paragraphs()` returns stable, hash-based paragraph IDs for safe, unambiguous targeting
 - **Batch Editing**: Atomic `batch_edit()` with upfront hash validation across all operations
+- **Paragraph Rewrite**: `rewrite_paragraph()` with automatic word-level diffing — specify desired text, get fine-grained tracked changes
 - **Track Changes**: Replace, delete, and insert text with revision tracking
 - **Cross-Boundary Editing**: Find and replace text spanning multiple XML elements and revision boundaries
 - **Mixed-State Editing**: Atomic decomposition for text spanning `<w:ins>`/`<w:del>` boundaries
@@ -83,6 +84,10 @@ with Document.open("contract.docx", author="Editor") as doc:
     doc.replace("30 days", "60 days", paragraph="P2#f3c1")
     doc.delete("obsolete text", paragraph="P5#d4e5")
     doc.insert_after("Section 5", " (as amended)", paragraph="P3#b2c4")
+
+    # Rewrite entire paragraph (automatic word-level diff)
+    doc.rewrite_paragraph("P2#f3c1",
+        "The board shall approve the updated proposal.")
 
     # Comments
     doc.add_comment("Section 5", "Please review")

--- a/README.md
+++ b/README.md
@@ -73,15 +73,16 @@ from docx_editor import Document
 import os
 
 author = os.environ.get("USER") or "Reviewer"
-with Document.open("contract.docx", author="Editor") as doc:
+with Document.open("contract.docx", author=author) as doc:
     # Step 1: List paragraphs with hash-anchored references
     for p in doc.list_paragraphs():
         print(p)
     # Output: P1#a7b2| Introduction to the contract...
     #         P2#f3c1| The committee shall review...
 
-    # Step 2: Edit using paragraph references (safe, unambiguous)
-    doc.replace("30 days", "60 days", paragraph="P2#f3c1")
+    # Step 2: Edit — each method returns the new paragraph ref
+    r = doc.replace("30 days", "60 days", paragraph="P2#f3c1")
+    doc.replace("net", "gross", paragraph=r)  # chain without list_paragraphs()
     doc.delete("obsolete text", paragraph="P5#d4e5")
     doc.insert_after("Section 5", " (as amended)", paragraph="P3#b2c4")
 

--- a/docx_editor/__init__.py
+++ b/docx_editor/__init__.py
@@ -30,7 +30,7 @@ Example:
 __version__ = "0.0.1"
 
 from .comments import Comment
-from .document import Document, EditResult
+from .document import Document
 from .exceptions import (
     CommentError,
     DocumentNotFoundError,
@@ -60,7 +60,6 @@ from .xml_editor import (
 __all__ = [
     # Main classes
     "Document",
-    "EditResult",
     "EditOperation",
     "Revision",
     "Comment",

--- a/docx_editor/__init__.py
+++ b/docx_editor/__init__.py
@@ -30,7 +30,7 @@ Example:
 __version__ = "0.0.1"
 
 from .comments import Comment
-from .document import Document
+from .document import Document, EditResult
 from .exceptions import (
     CommentError,
     DocumentNotFoundError,
@@ -60,6 +60,7 @@ from .xml_editor import (
 __all__ = [
     # Main classes
     "Document",
+    "EditResult",
     "EditOperation",
     "Revision",
     "Comment",

--- a/docx_editor/document.py
+++ b/docx_editor/document.py
@@ -12,7 +12,26 @@ from .comments import Comment, CommentManager
 from .exceptions import WorkspaceSyncError
 from .track_changes import EditOperation, Revision, RevisionManager
 from .workspace import Workspace
-from .xml_editor import DocxXMLEditor, build_text_map, compute_paragraph_hash
+from .xml_editor import DocxXMLEditor, ParagraphRef, build_text_map, compute_paragraph_hash
+
+
+class EditResult(int):
+    """Edit result that acts as a change ID (int) and carries the new paragraph ref.
+
+    Backwards-compatible: behaves as int (change_id) for accept/reject operations.
+    New code can use .ref to get the updated paragraph reference.
+    """
+
+    def __new__(cls, change_id: int, ref: str):
+        instance = super().__new__(cls, change_id)
+        instance.ref = ref
+        return instance
+
+    def __repr__(self):
+        return f"EditResult(change_id={int(self)}, ref={self.ref!r})"
+
+    def __str__(self):
+        return str(int(self))
 
 
 class Document:
@@ -145,6 +164,13 @@ class Document:
         self._ensure_open()
         return self._revision_manager.count_matches(text)
 
+    def _compute_new_ref(self, old_ref: str) -> str:
+        """Compute a fresh paragraph reference after mutation."""
+        ref = ParagraphRef.parse(old_ref)
+        p = self._document_editor.dom.getElementsByTagName("w:p")[ref.index - 1]
+        new_hash = compute_paragraph_hash(p)
+        return f"P{ref.index}#{new_hash}"
+
     def list_paragraphs(self, max_chars: int = 80) -> list[str]:
         """List all paragraphs with hash-anchored references.
 
@@ -187,7 +213,7 @@ class Document:
             parts.append(tm.text)
         return "\n".join(parts)
 
-    def replace(self, find: str, replace_with: str, *, paragraph: str, occurrence: int = 0) -> int:
+    def replace(self, find: str, replace_with: str, *, paragraph: str, occurrence: int = 0) -> EditResult:
         """Replace text with tracked changes.
 
         Creates a tracked deletion of the old text and insertion of the new text.
@@ -199,16 +225,17 @@ class Document:
             occurrence: Which occurrence within the paragraph (0 = first, 1 = second, etc.)
 
         Returns:
-            The change ID of the insertion
+            EditResult with .ref (new paragraph reference) and int value (change ID)
 
         Example:
-            refs = doc.list_paragraphs()
-            doc.replace("30 days", "60 days", paragraph="P2#f3c1")
+            result = doc.replace("30 days", "60 days", paragraph="P2#f3c1")
+            result.ref  # "P2#c3d4" — fresh ref for follow-up edits
         """
         self._ensure_open()
-        return self._revision_manager.replace_text(find, replace_with, occurrence=occurrence, paragraph=paragraph)
+        change_id = self._revision_manager.replace_text(find, replace_with, occurrence=occurrence, paragraph=paragraph)
+        return EditResult(change_id, self._compute_new_ref(paragraph))
 
-    def delete(self, text: str, *, paragraph: str, occurrence: int = 0) -> int:
+    def delete(self, text: str, *, paragraph: str, occurrence: int = 0) -> EditResult:
         """Mark text as deleted with tracked changes.
 
         Args:
@@ -217,15 +244,17 @@ class Document:
             occurrence: Which occurrence within the paragraph (0 = first, 1 = second, etc.)
 
         Returns:
-            The change ID of the deletion
+            EditResult with .ref (new paragraph reference) and int value (change ID)
 
         Example:
-            doc.delete("obsolete clause", paragraph="P2#f3c1")
+            result = doc.delete("obsolete clause", paragraph="P2#f3c1")
+            result.ref  # fresh ref for follow-up edits
         """
         self._ensure_open()
-        return self._revision_manager.suggest_deletion(text, occurrence=occurrence, paragraph=paragraph)
+        change_id = self._revision_manager.suggest_deletion(text, occurrence=occurrence, paragraph=paragraph)
+        return EditResult(change_id, self._compute_new_ref(paragraph))
 
-    def insert_after(self, anchor: str, text: str, *, paragraph: str, occurrence: int = 0) -> int:
+    def insert_after(self, anchor: str, text: str, *, paragraph: str, occurrence: int = 0) -> EditResult:
         """Insert text after anchor with tracked changes.
 
         Args:
@@ -235,15 +264,17 @@ class Document:
             occurrence: Which occurrence of anchor within the paragraph (0 = first)
 
         Returns:
-            The change ID of the insertion
+            EditResult with .ref (new paragraph reference) and int value (change ID)
 
         Example:
-            doc.insert_after("Section 5", " (as amended)", paragraph="P2#f3c1")
+            result = doc.insert_after("Section 5", " (as amended)", paragraph="P2#f3c1")
+            result.ref  # fresh ref for follow-up edits
         """
         self._ensure_open()
-        return self._revision_manager.insert_text_after(anchor, text, occurrence=occurrence, paragraph=paragraph)
+        change_id = self._revision_manager.insert_text_after(anchor, text, occurrence=occurrence, paragraph=paragraph)
+        return EditResult(change_id, self._compute_new_ref(paragraph))
 
-    def insert_before(self, anchor: str, text: str, *, paragraph: str, occurrence: int = 0) -> int:
+    def insert_before(self, anchor: str, text: str, *, paragraph: str, occurrence: int = 0) -> EditResult:
         """Insert text before anchor with tracked changes.
 
         Args:
@@ -253,15 +284,17 @@ class Document:
             occurrence: Which occurrence of anchor within the paragraph (0 = first)
 
         Returns:
-            The change ID of the insertion
+            EditResult with .ref (new paragraph reference) and int value (change ID)
 
         Example:
-            doc.insert_before("Section 6", "New clause: ", paragraph="P2#f3c1")
+            result = doc.insert_before("Section 6", "New clause: ", paragraph="P2#f3c1")
+            result.ref  # fresh ref for follow-up edits
         """
         self._ensure_open()
-        return self._revision_manager.insert_text_before(anchor, text, occurrence=occurrence, paragraph=paragraph)
+        change_id = self._revision_manager.insert_text_before(anchor, text, occurrence=occurrence, paragraph=paragraph)
+        return EditResult(change_id, self._compute_new_ref(paragraph))
 
-    def batch_edit(self, operations: list[EditOperation]) -> list[int]:
+    def batch_edit(self, operations: list[EditOperation]) -> list[EditResult]:
         """Apply multiple edits atomically with upfront hash validation.
 
         All paragraph hashes are validated before any edits are applied.
@@ -273,20 +306,24 @@ class Document:
             operations: List of EditOperation objects
 
         Returns:
-            List of change IDs (one per operation, in input order)
+            List of EditResult objects (in input order), each with .ref (new
+            paragraph reference) and int value (change ID).
 
         Example:
-            refs = doc.list_paragraphs()
-            doc.batch_edit([
+            results = doc.batch_edit([
                 EditOperation(action="replace", find="old", replace_with="new", paragraph="P20#a7b2"),
                 EditOperation(action="delete", text="remove", paragraph="P15#f3c1"),
-                EditOperation(action="insert_after", anchor="here", text=" added", paragraph="P3#b2c4"),
             ])
+            results[0].ref  # "P20#c3d4" — fresh ref
         """
         self._ensure_open()
-        return self._revision_manager.batch_edit(operations)
+        change_ids = self._revision_manager.batch_edit(operations)
+        return [
+            EditResult(cid, self._compute_new_ref(op.paragraph))
+            for cid, op in zip(change_ids, operations)
+        ]
 
-    def rewrite_paragraph(self, ref: str, new_text: str) -> None:
+    def rewrite_paragraph(self, ref: str, new_text: str) -> str:
         """Rewrite a paragraph's text with automatic fine-grained tracked changes.
 
         Diffs the current paragraph text against new_text at word level and
@@ -296,18 +333,18 @@ class Document:
             ref: Paragraph reference from list_paragraphs() (e.g., "P2#f3c1")
             new_text: Desired new text for the paragraph
 
-        Raises:
-            HashMismatchError: If the paragraph hash doesn't match
-            IndexError: If paragraph index is out of range
+        Returns:
+            The new paragraph reference with updated hash (e.g., "P2#c3d4").
+            Use this ref for follow-up edits without calling list_paragraphs().
 
         Example:
-            refs = doc.list_paragraphs()
-            doc.rewrite_paragraph("P2#f3c1", "The board shall approve the proposal.")
+            new_ref = doc.rewrite_paragraph("P2#f3c1", "The board shall approve the proposal.")
         """
         self._ensure_open()
         self._revision_manager.rewrite_paragraph(ref, new_text)
+        return self._compute_new_ref(ref)
 
-    def batch_rewrite(self, rewrites: list[tuple[str, str]]) -> None:
+    def batch_rewrite(self, rewrites: list[tuple[str, str]]) -> list[str]:
         """Rewrite multiple paragraphs atomically with upfront hash validation.
 
         All paragraph hashes are validated before any rewrites are applied.
@@ -316,15 +353,19 @@ class Document:
         Args:
             rewrites: List of (ref, new_text) tuples
 
+        Returns:
+            List of new paragraph references with updated hashes, in input order
+
         Example:
             refs = doc.list_paragraphs()
-            doc.batch_rewrite([
+            new_refs = doc.batch_rewrite([
                 ("P1#a7b2", "Updated first paragraph."),
                 ("P3#c3d4", "Updated third paragraph."),
             ])
         """
         self._ensure_open()
         self._revision_manager.batch_rewrite(rewrites)
+        return [self._compute_new_ref(ref) for ref, _ in rewrites]
 
     # ==================== Comments API ====================
 

--- a/docx_editor/document.py
+++ b/docx_editor/document.py
@@ -285,6 +285,27 @@ class Document:
         self._ensure_open()
         return self._revision_manager.batch_edit(operations)
 
+    def rewrite_paragraph(self, ref: str, new_text: str) -> None:
+        """Rewrite a paragraph's text with automatic fine-grained tracked changes.
+
+        Diffs the current paragraph text against new_text at word level and
+        generates minimal tracked insertions, deletions, and replacements.
+
+        Args:
+            ref: Paragraph reference from list_paragraphs() (e.g., "P2#f3c1")
+            new_text: Desired new text for the paragraph
+
+        Raises:
+            HashMismatchError: If the paragraph hash doesn't match
+            IndexError: If paragraph index is out of range
+
+        Example:
+            refs = doc.list_paragraphs()
+            doc.rewrite_paragraph("P2#f3c1", "The board shall approve the proposal.")
+        """
+        self._ensure_open()
+        self._revision_manager.rewrite_paragraph(ref, new_text)
+
     # ==================== Comments API ====================
 
     def add_comment(self, anchor_text: str, comment: str) -> int:

--- a/docx_editor/document.py
+++ b/docx_editor/document.py
@@ -152,15 +152,13 @@ class Document:
         for use as stable paragraph references in editing operations.
 
         Args:
-            max_chars: Maximum characters for the preview text (default 80,
-                minimum 10). Use a smaller value like 20 when refreshing
-                hashes after edits.
+            max_chars: Maximum characters for the preview text (default 80).
+                Use 0 to get only hash refs without preview text.
 
         Returns:
             List of hash-tagged paragraph preview strings
         """
         self._ensure_open()
-        max_chars = max(max_chars, 10)
         paragraphs = self._document_editor.dom.getElementsByTagName("w:p")
         result = []
         for i, p in enumerate(paragraphs, start=1):

--- a/docx_editor/document.py
+++ b/docx_editor/document.py
@@ -152,12 +152,15 @@ class Document:
         for use as stable paragraph references in editing operations.
 
         Args:
-            max_chars: Maximum characters for the preview text (default 80)
+            max_chars: Maximum characters for the preview text (default 80,
+                minimum 10). Use a smaller value like 20 when refreshing
+                hashes after edits.
 
         Returns:
             List of hash-tagged paragraph preview strings
         """
         self._ensure_open()
+        max_chars = max(max_chars, 10)
         paragraphs = self._document_editor.dom.getElementsByTagName("w:p")
         result = []
         for i, p in enumerate(paragraphs, start=1):

--- a/docx_editor/document.py
+++ b/docx_editor/document.py
@@ -306,6 +306,25 @@ class Document:
         self._ensure_open()
         self._revision_manager.rewrite_paragraph(ref, new_text)
 
+    def batch_rewrite(self, rewrites: list[tuple[str, str]]) -> None:
+        """Rewrite multiple paragraphs atomically with upfront hash validation.
+
+        All paragraph hashes are validated before any rewrites are applied.
+        If any hash is stale, the entire batch is rejected.
+
+        Args:
+            rewrites: List of (ref, new_text) tuples
+
+        Example:
+            refs = doc.list_paragraphs()
+            doc.batch_rewrite([
+                ("P1#a7b2", "Updated first paragraph."),
+                ("P3#c3d4", "Updated third paragraph."),
+            ])
+        """
+        self._ensure_open()
+        self._revision_manager.batch_rewrite(rewrites)
+
     # ==================== Comments API ====================
 
     def add_comment(self, anchor_text: str, comment: str) -> int:

--- a/docx_editor/document.py
+++ b/docx_editor/document.py
@@ -15,7 +15,6 @@ from .workspace import Workspace
 from .xml_editor import DocxXMLEditor, ParagraphRef, build_text_map, compute_paragraph_hash
 
 
-
 class Document:
     """Word document with track changes and comment support.
 

--- a/docx_editor/document.py
+++ b/docx_editor/document.py
@@ -15,24 +15,6 @@ from .workspace import Workspace
 from .xml_editor import DocxXMLEditor, ParagraphRef, build_text_map, compute_paragraph_hash
 
 
-class EditResult(int):
-    """Edit result that acts as a change ID (int) and carries the new paragraph ref.
-
-    Backwards-compatible: behaves as int (change_id) for accept/reject operations.
-    New code can use .ref to get the updated paragraph reference.
-    """
-
-    def __new__(cls, change_id: int, ref: str):
-        instance = super().__new__(cls, change_id)
-        instance.ref = ref
-        return instance
-
-    def __repr__(self):
-        return f"EditResult(change_id={int(self)}, ref={self.ref!r})"
-
-    def __str__(self):
-        return str(int(self))
-
 
 class Document:
     """Word document with track changes and comment support.
@@ -213,7 +195,7 @@ class Document:
             parts.append(tm.text)
         return "\n".join(parts)
 
-    def replace(self, find: str, replace_with: str, *, paragraph: str, occurrence: int = 0) -> EditResult:
+    def replace(self, find: str, replace_with: str, *, paragraph: str, occurrence: int = 0) -> str:
         """Replace text with tracked changes.
 
         Creates a tracked deletion of the old text and insertion of the new text.
@@ -225,17 +207,18 @@ class Document:
             occurrence: Which occurrence within the paragraph (0 = first, 1 = second, etc.)
 
         Returns:
-            EditResult with .ref (new paragraph reference) and int value (change ID)
+            New paragraph reference with updated hash (e.g., "P2#c3d4").
+            Use this for follow-up edits without calling list_paragraphs().
 
         Example:
-            result = doc.replace("30 days", "60 days", paragraph="P2#f3c1")
-            result.ref  # "P2#c3d4" — fresh ref for follow-up edits
+            new_ref = doc.replace("30 days", "60 days", paragraph="P2#f3c1")
+            doc.replace("other text", "new text", paragraph=new_ref)
         """
         self._ensure_open()
-        change_id = self._revision_manager.replace_text(find, replace_with, occurrence=occurrence, paragraph=paragraph)
-        return EditResult(change_id, self._compute_new_ref(paragraph))
+        self._revision_manager.replace_text(find, replace_with, occurrence=occurrence, paragraph=paragraph)
+        return self._compute_new_ref(paragraph)
 
-    def delete(self, text: str, *, paragraph: str, occurrence: int = 0) -> EditResult:
+    def delete(self, text: str, *, paragraph: str, occurrence: int = 0) -> str:
         """Mark text as deleted with tracked changes.
 
         Args:
@@ -244,17 +227,16 @@ class Document:
             occurrence: Which occurrence within the paragraph (0 = first, 1 = second, etc.)
 
         Returns:
-            EditResult with .ref (new paragraph reference) and int value (change ID)
+            New paragraph reference with updated hash (e.g., "P2#c3d4").
 
         Example:
-            result = doc.delete("obsolete clause", paragraph="P2#f3c1")
-            result.ref  # fresh ref for follow-up edits
+            new_ref = doc.delete("obsolete clause", paragraph="P2#f3c1")
         """
         self._ensure_open()
-        change_id = self._revision_manager.suggest_deletion(text, occurrence=occurrence, paragraph=paragraph)
-        return EditResult(change_id, self._compute_new_ref(paragraph))
+        self._revision_manager.suggest_deletion(text, occurrence=occurrence, paragraph=paragraph)
+        return self._compute_new_ref(paragraph)
 
-    def insert_after(self, anchor: str, text: str, *, paragraph: str, occurrence: int = 0) -> EditResult:
+    def insert_after(self, anchor: str, text: str, *, paragraph: str, occurrence: int = 0) -> str:
         """Insert text after anchor with tracked changes.
 
         Args:
@@ -264,17 +246,16 @@ class Document:
             occurrence: Which occurrence of anchor within the paragraph (0 = first)
 
         Returns:
-            EditResult with .ref (new paragraph reference) and int value (change ID)
+            New paragraph reference with updated hash (e.g., "P2#c3d4").
 
         Example:
-            result = doc.insert_after("Section 5", " (as amended)", paragraph="P2#f3c1")
-            result.ref  # fresh ref for follow-up edits
+            new_ref = doc.insert_after("Section 5", " (as amended)", paragraph="P2#f3c1")
         """
         self._ensure_open()
-        change_id = self._revision_manager.insert_text_after(anchor, text, occurrence=occurrence, paragraph=paragraph)
-        return EditResult(change_id, self._compute_new_ref(paragraph))
+        self._revision_manager.insert_text_after(anchor, text, occurrence=occurrence, paragraph=paragraph)
+        return self._compute_new_ref(paragraph)
 
-    def insert_before(self, anchor: str, text: str, *, paragraph: str, occurrence: int = 0) -> EditResult:
+    def insert_before(self, anchor: str, text: str, *, paragraph: str, occurrence: int = 0) -> str:
         """Insert text before anchor with tracked changes.
 
         Args:
@@ -284,17 +265,16 @@ class Document:
             occurrence: Which occurrence of anchor within the paragraph (0 = first)
 
         Returns:
-            EditResult with .ref (new paragraph reference) and int value (change ID)
+            New paragraph reference with updated hash (e.g., "P2#c3d4").
 
         Example:
-            result = doc.insert_before("Section 6", "New clause: ", paragraph="P2#f3c1")
-            result.ref  # fresh ref for follow-up edits
+            new_ref = doc.insert_before("Section 6", "New clause: ", paragraph="P2#f3c1")
         """
         self._ensure_open()
-        change_id = self._revision_manager.insert_text_before(anchor, text, occurrence=occurrence, paragraph=paragraph)
-        return EditResult(change_id, self._compute_new_ref(paragraph))
+        self._revision_manager.insert_text_before(anchor, text, occurrence=occurrence, paragraph=paragraph)
+        return self._compute_new_ref(paragraph)
 
-    def batch_edit(self, operations: list[EditOperation]) -> list[EditResult]:
+    def batch_edit(self, operations: list[EditOperation]) -> list[str]:
         """Apply multiple edits atomically with upfront hash validation.
 
         All paragraph hashes are validated before any edits are applied.
@@ -306,22 +286,17 @@ class Document:
             operations: List of EditOperation objects
 
         Returns:
-            List of EditResult objects (in input order), each with .ref (new
-            paragraph reference) and int value (change ID).
+            List of new paragraph references with updated hashes, in input order.
 
         Example:
-            results = doc.batch_edit([
+            new_refs = doc.batch_edit([
                 EditOperation(action="replace", find="old", replace_with="new", paragraph="P20#a7b2"),
                 EditOperation(action="delete", text="remove", paragraph="P15#f3c1"),
             ])
-            results[0].ref  # "P20#c3d4" — fresh ref
         """
         self._ensure_open()
-        change_ids = self._revision_manager.batch_edit(operations)
-        return [
-            EditResult(cid, self._compute_new_ref(op.paragraph))
-            for cid, op in zip(change_ids, operations)
-        ]
+        self._revision_manager.batch_edit(operations)
+        return [self._compute_new_ref(op.paragraph) for op in operations]
 
     def rewrite_paragraph(self, ref: str, new_text: str) -> str:
         """Rewrite a paragraph's text with automatic fine-grained tracked changes.

--- a/docx_editor/document.py
+++ b/docx_editor/document.py
@@ -320,10 +320,11 @@ class Document:
         return self._compute_new_ref(ref)
 
     def batch_rewrite(self, rewrites: list[tuple[str, str]]) -> list[str]:
-        """Rewrite multiple paragraphs atomically with upfront hash validation.
+        """Rewrite multiple paragraphs with upfront hash validation.
 
         All paragraph hashes are validated before any rewrites are applied.
-        If any hash is stale, the entire batch is rejected.
+        If any hash is stale, the entire batch is rejected before any changes
+        are made. Once validation passes, rewrites are applied sequentially.
 
         Args:
             rewrites: List of (ref, new_text) tuples

--- a/docx_editor/track_changes.py
+++ b/docx_editor/track_changes.py
@@ -264,24 +264,18 @@ class RevisionManager:
 
             if tag == "replace":
                 match_text = old_text[old_char_start:old_char_end]
-                match = self._find_match_at_position(
-                    text_map, match_text, old_char_start
-                )
+                match = self._find_match_at_position(text_map, match_text, old_char_start)
                 self._replace_across_nodes(match, new_fragment)
 
             elif tag == "delete":
                 match_text = old_text[old_char_start:old_char_end]
-                match = self._find_match_at_position(
-                    text_map, match_text, old_char_start
-                )
+                match = self._find_match_at_position(text_map, match_text, old_char_start)
                 self._delete_across_nodes(match)
 
             elif tag == "insert":
                 self._rewrite_insert_at(p, text_map, old_char_start, new_fragment)
 
-    def _find_match_at_position(
-        self, text_map: TextMap, search: str, expected_pos: int
-    ) -> TextMapMatch:
+    def _find_match_at_position(self, text_map: TextMap, search: str, expected_pos: int) -> TextMapMatch:
         """Find text at an expected character position in the text map.
 
         Unlike find_in_text_map which finds the first occurrence, this
@@ -293,9 +287,7 @@ class RevisionManager:
         """
         idx = text_map.find(search, expected_pos)
         if idx == -1 or idx != expected_pos:
-            raise RevisionError(
-                f"Rewrite failed: could not locate '{search}' at position {expected_pos}"
-            )
+            raise RevisionError(f"Rewrite failed: could not locate '{search}' at position {expected_pos}")
         end = idx + len(search)
         positions = text_map.get_nodes_for_range(idx, end)
         if positions:
@@ -304,8 +296,11 @@ class RevisionManager:
         else:
             spans = False
         return TextMapMatch(
-            start=idx, end=end, text=search,
-            positions=positions, spans_boundary=spans,
+            start=idx,
+            end=end,
+            text=search,
+            positions=positions,
+            spans_boundary=spans,
         )
 
     def _rewrite_insert_at(self, paragraph, text_map: TextMap, char_pos: int, text: str) -> None:

--- a/docx_editor/track_changes.py
+++ b/docx_editor/track_changes.py
@@ -354,9 +354,7 @@ class RevisionManager:
                 return
 
             ins_xml = f"<w:ins><w:r>{rPr_xml}<w:t>{_escape_xml(text)}</w:t></w:r></w:ins>"
-            ins_ancestor_ref = self._find_ancestor(run, "w:ins")
-            insert_ref = ins_ancestor_ref if ins_ancestor_ref else run
-            self.editor.insert_after(insert_ref, ins_xml)
+            self.editor.insert_after(run, ins_xml)
             return
 
         # Insert at a position within the text

--- a/docx_editor/track_changes.py
+++ b/docx_editor/track_changes.py
@@ -175,7 +175,7 @@ class RevisionManager:
             raise ValueError(f"Unknown action: {op.action}")
 
     def batch_rewrite(self, rewrites: list[tuple[str, str]]) -> None:
-        """Rewrite multiple paragraphs atomically with upfront hash validation."""
+        """Rewrite multiple paragraphs with upfront hash validation."""
         if not rewrites:
             return
 

--- a/docx_editor/track_changes.py
+++ b/docx_editor/track_changes.py
@@ -3,6 +3,8 @@
 Provides RevisionManager for creating and managing tracked changes (insertions/deletions).
 """
 
+import difflib
+import re
 from collections import OrderedDict
 from dataclasses import dataclass
 from datetime import datetime
@@ -13,6 +15,7 @@ from .exceptions import HashMismatchError, RevisionError, TextNotFoundError
 from .xml_editor import (
     DocxXMLEditor,
     ParagraphRef,
+    TextMap,
     TextMapMatch,
     TextPosition,
     build_text_map,
@@ -170,6 +173,165 @@ class RevisionManager:
 
         else:
             raise ValueError(f"Unknown action: {op.action}")
+
+    def rewrite_paragraph(self, ref_str: str, new_text: str) -> None:
+        """Rewrite a paragraph's text, generating fine-grained tracked changes.
+
+        Diffs old vs new text at word level and applies minimal tracked changes
+        (insertions, deletions, replacements) to transform the paragraph.
+
+        Args:
+            ref_str: Paragraph reference string (e.g., "P3#a7b2")
+            new_text: Desired new text for the paragraph
+
+        Raises:
+            HashMismatchError: If the paragraph hash doesn't match
+            IndexError: If paragraph index is out of range
+        """
+        ref = ParagraphRef.parse(ref_str)
+        p = self._resolve_paragraph(ref)
+        text_map = build_text_map(p)
+        old_text = text_map.text
+
+        if old_text == new_text:
+            return
+
+        old_tokens = _tokenize_words(old_text)
+        new_tokens = _tokenize_words(new_text)
+
+        sm = difflib.SequenceMatcher(None, old_tokens, new_tokens)
+        opcodes = sm.get_opcodes()
+
+        # Convert token indices to character offsets in old_text
+        old_token_offsets = []
+        pos = 0
+        for tok in old_tokens:
+            old_token_offsets.append(pos)
+            pos += len(tok)
+
+        # Build hunks: list of (tag, old_char_start, old_char_end, new_fragment)
+        hunks = []
+        for tag, i1, i2, j1, j2 in opcodes:
+            if tag == "equal":
+                continue
+
+            # Character range in old_text
+            if i1 < len(old_tokens):
+                old_char_start = old_token_offsets[i1]
+            else:
+                old_char_start = len(old_text)
+
+            if i2 > 0:
+                last_tok = old_tokens[i2 - 1]
+                old_char_end = old_token_offsets[i2 - 1] + len(last_tok)
+            else:
+                old_char_end = old_char_start
+
+            new_fragment = "".join(new_tokens[j1:j2])
+
+            hunks.append((tag, old_char_start, old_char_end, new_fragment))
+
+        # Process hunks in reverse order for position stability
+        for tag, old_char_start, old_char_end, new_fragment in reversed(hunks):
+            # Rebuild text_map each iteration since DOM changes
+            text_map = build_text_map(p)
+
+            if tag == "replace":
+                match_text = old_text[old_char_start:old_char_end]
+                match = find_in_text_map(text_map, match_text)
+                if match is not None:
+                    self._replace_across_nodes(match, new_fragment)
+
+            elif tag == "delete":
+                match_text = old_text[old_char_start:old_char_end]
+                match = find_in_text_map(text_map, match_text)
+                if match is not None:
+                    self._delete_across_nodes(match)
+
+            elif tag == "insert":
+                self._rewrite_insert_at(p, text_map, old_char_start, new_fragment)
+
+    def _rewrite_insert_at(self, paragraph, text_map: TextMap, char_pos: int, text: str) -> None:
+        """Insert text at a character position within a paragraph.
+
+        Used by rewrite_paragraph() for 'insert' opcodes.
+
+        Args:
+            paragraph: The <w:p> DOM element
+            text_map: Current text map for the paragraph
+            char_pos: Character position in visible text to insert at
+            text: Text to insert
+        """
+        if not text_map.positions:
+            # Empty paragraph — append insertion
+            # Get rPr from any existing run, or use empty
+            rPr_xml = ""
+            runs = paragraph.getElementsByTagName("w:r")
+            if runs:
+                rPr_elems = runs[0].getElementsByTagName("w:rPr")
+                if rPr_elems:
+                    rPr_xml = rPr_elems[0].toxml()
+
+            ins_xml = f"<w:ins><w:r>{rPr_xml}<w:t>{_escape_xml(text)}</w:t></w:r></w:ins>"
+            # Insert before w:sectPr if present, else append
+            sect_prs = paragraph.getElementsByTagName("w:sectPr")
+            if sect_prs:
+                self.editor.insert_before(sect_prs[0], ins_xml)
+            else:
+                self.editor.append_to(paragraph, ins_xml)
+            return
+
+        if char_pos >= len(text_map.positions):
+            # Insert at end — after last character's run
+            last_pos = text_map.positions[-1]
+            run, rPr_xml = self._get_run_info(last_pos.node)
+            if not run:
+                return
+
+            # If inside <w:ins>, splice text directly
+            ins_ancestor = self._find_ancestor(run, "w:ins")
+            if ins_ancestor:
+                node_text = self._get_node_text(last_pos.node)
+                last_pos.node.firstChild.data = node_text + text
+                _set_xml_space_preserve(last_pos.node)
+                return
+
+            ins_xml = f"<w:ins><w:r>{rPr_xml}<w:t>{_escape_xml(text)}</w:t></w:r></w:ins>"
+            ins_ancestor_ref = self._find_ancestor(run, "w:ins")
+            insert_ref = ins_ancestor_ref if ins_ancestor_ref else run
+            self.editor.insert_after(insert_ref, ins_xml)
+            return
+
+        # Insert at a position within the text
+        pos = text_map.positions[char_pos]
+        run, rPr_xml = self._get_run_info(pos.node)
+        if not run:
+            return
+
+        # If inside <w:ins>, splice text directly
+        ins_ancestor = self._find_ancestor(run, "w:ins")
+        if ins_ancestor:
+            node_text = self._get_node_text(pos.node)
+            offset = pos.offset_in_node
+            pos.node.firstChild.data = node_text[:offset] + text + node_text[offset:]
+            _set_xml_space_preserve(pos.node)
+            return
+
+        # Split the run at the offset and insert <w:ins> between
+        node_text = self._get_node_text(pos.node)
+        offset = pos.offset_in_node
+        before_text = node_text[:offset]
+        after_text = node_text[offset:]
+
+        xml_parts = []
+        if before_text:
+            xml_parts.append(f"<w:r>{rPr_xml}<w:t>{_escape_xml(before_text)}</w:t></w:r>")
+        xml_parts.append(f"<w:ins><w:r>{rPr_xml}<w:t>{_escape_xml(text)}</w:t></w:r></w:ins>")
+        if after_text:
+            xml_parts.append(f"<w:r>{rPr_xml}<w:t>{_escape_xml(after_text)}</w:t></w:r>")
+
+        new_xml = "".join(xml_parts)
+        self.editor.replace_node(run, new_xml)
 
     def count_matches(self, text: str) -> int:
         """Count how many times a text string appears in the document.
@@ -1410,6 +1572,11 @@ class RevisionManager:
 
         # Unwrap the w:del element
         self._unwrap_element(del_elem)
+
+
+def _tokenize_words(text: str) -> list[str]:
+    """Split text into alternating word and whitespace tokens."""
+    return re.findall(r"\S+|\s+", text)
 
 
 def _set_xml_space_preserve(wt_elem) -> None:

--- a/docx_editor/track_changes.py
+++ b/docx_editor/track_changes.py
@@ -264,18 +264,49 @@ class RevisionManager:
 
             if tag == "replace":
                 match_text = old_text[old_char_start:old_char_end]
-                match = find_in_text_map(text_map, match_text)
-                if match is not None:
-                    self._replace_across_nodes(match, new_fragment)
+                match = self._find_match_at_position(
+                    text_map, match_text, old_char_start
+                )
+                self._replace_across_nodes(match, new_fragment)
 
             elif tag == "delete":
                 match_text = old_text[old_char_start:old_char_end]
-                match = find_in_text_map(text_map, match_text)
-                if match is not None:
-                    self._delete_across_nodes(match)
+                match = self._find_match_at_position(
+                    text_map, match_text, old_char_start
+                )
+                self._delete_across_nodes(match)
 
             elif tag == "insert":
                 self._rewrite_insert_at(p, text_map, old_char_start, new_fragment)
+
+    def _find_match_at_position(
+        self, text_map: TextMap, search: str, expected_pos: int
+    ) -> TextMapMatch:
+        """Find text at an expected character position in the text map.
+
+        Unlike find_in_text_map which finds the first occurrence, this
+        verifies the match is at the expected position. Used by
+        rewrite_paragraph() to avoid matching the wrong occurrence when
+        the same text appears multiple times in a paragraph.
+
+        Raises RevisionError if the text is not found at the expected position.
+        """
+        idx = text_map.find(search, expected_pos)
+        if idx == -1 or idx != expected_pos:
+            raise RevisionError(
+                f"Rewrite failed: could not locate '{search}' at position {expected_pos}"
+            )
+        end = idx + len(search)
+        positions = text_map.get_nodes_for_range(idx, end)
+        if positions:
+            first_ins = positions[0].is_inside_ins
+            spans = any(p.is_inside_ins != first_ins for p in positions)
+        else:
+            spans = False
+        return TextMapMatch(
+            start=idx, end=end, text=search,
+            positions=positions, spans_boundary=spans,
+        )
 
     def _rewrite_insert_at(self, paragraph, text_map: TextMap, char_pos: int, text: str) -> None:
         """Insert text at a character position within a paragraph.

--- a/docx_editor/track_changes.py
+++ b/docx_editor/track_changes.py
@@ -174,6 +174,32 @@ class RevisionManager:
         else:
             raise ValueError(f"Unknown action: {op.action}")
 
+    def batch_rewrite(self, rewrites: list[tuple[str, str]]) -> None:
+        """Rewrite multiple paragraphs atomically with upfront hash validation."""
+        if not rewrites:
+            return
+
+        # Parse and validate all refs upfront
+        parsed: list[tuple[ParagraphRef, str]] = []
+        seen_indices: set[int] = set()
+        for ref_str, new_text in rewrites:
+            ref = ParagraphRef.parse(ref_str)
+            if ref.index in seen_indices:
+                raise ValueError(
+                    f"Batch contains duplicate paragraph P{ref.index}. "
+                    f"Each paragraph can appear at most once in a batch rewrite."
+                )
+            seen_indices.add(ref.index)
+            self._resolve_paragraph(ref)  # Raises HashMismatchError if stale
+            parsed.append((ref, new_text))
+
+        # Sort by paragraph index descending
+        parsed.sort(key=lambda x: x[0].index, reverse=True)
+
+        # Apply rewrites in reverse paragraph order
+        for ref, new_text in parsed:
+            self.rewrite_paragraph(f"P{ref.index}#{ref.hash}", new_text)
+
     def rewrite_paragraph(self, ref_str: str, new_text: str) -> None:
         """Rewrite a paragraph's text, generating fine-grained tracked changes.
 

--- a/openspec/changes/add-rewrite-paragraph/design.md
+++ b/openspec/changes/add-rewrite-paragraph/design.md
@@ -1,0 +1,87 @@
+## Context
+
+The docx-editor library currently requires LLMs to specify exact search text when editing paragraphs. This is brittle: ambiguous matches, occurrence counting, and multi-step search-replace sequences are common failure modes. LLMs are better at producing desired output than crafting search queries. We need a method that accepts the desired paragraph text and automatically generates tracked changes.
+
+This builds on the hash-anchored paragraph references (`add-paragraph-hash-anchors`) and batch edit infrastructure (`add-batch-edit`).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Let the LLM specify what a paragraph should say, not how to transform it
+- Generate fine-grained `<w:del>` + `<w:ins>` tracked changes (not paragraph-level replace)
+- Preserve existing formatting where text is unchanged
+- Support batch rewriting of multiple paragraphs from one snapshot
+
+**Non-Goals:**
+- Formatting changes (bold, italic, etc.) — only text content changes
+- Structural changes (splitting/merging paragraphs, adding/removing paragraphs)
+- Sub-paragraph targeting — the method always rewrites the entire paragraph text
+- Smart formatting inference for newly inserted text beyond inheriting adjacent run properties
+
+## Decisions
+
+### Diff Algorithm: `difflib.SequenceMatcher` with Word-Level Tokens
+
+- **Decision**: Tokenize both old and new text into words and whitespace, then use `difflib.SequenceMatcher` to compute the minimal diff.
+- **Why**: `difflib` is Python stdlib, well-tested, and `SequenceMatcher` produces human-readable diffs. Word-level diffing produces natural tracked changes (whole words are inserted/deleted, not individual characters).
+- **Tokenization**: Split on word boundaries using `re.findall(r'\S+|\s+', text)` to preserve whitespace tokens. This ensures whitespace changes are tracked accurately.
+- **Alternative considered**: Character-level diffing — produces noisy tracked changes where partial words are marked as changed. Word-level is more natural for document review.
+- **Alternative considered**: `google-diff-match-patch` — external dependency, character-level by default. Not worth the dependency for this use case.
+- **Alternative considered**: Line-level diffing — too coarse for paragraph editing where sentences may be reworded.
+
+### Mapping Diff Hunks to XML Positions
+
+- **Decision**: Use `build_text_map()` to get the paragraph's visible text with character-to-XML mappings. For each diff hunk that removes old text, locate the corresponding character range in the text map and apply `<w:del>` operations. For each hunk that adds new text, insert `<w:ins>` at the appropriate XML position.
+- **How it works**:
+  1. Call `build_text_map(paragraph)` to get `TextMap` with visible text and character positions
+  2. Run `SequenceMatcher` on word-tokenized old text vs new text
+  3. For `'equal'` opcodes: skip (text unchanged, XML untouched)
+  4. For `'delete'` opcodes: find the character range in the text map, apply deletion (same as existing `delete_text` path)
+  5. For `'insert'` opcodes: find the insertion point in the text map, insert new `<w:ins>` element
+  6. For `'replace'` opcodes: combine delete + insert at the same position
+- **Why**: This reuses the existing `build_text_map()` infrastructure. The text map already handles cross-boundary spans, tracked changes, and element splitting.
+- **Application order**: Process hunks in reverse document order (right-to-left) so that earlier positions remain valid as modifications are applied.
+
+### Formatting Preservation
+
+- **Decision**: When inserting new text via `<w:ins>`, copy the `<w:rPr>` (run properties) from the nearest adjacent run at the insertion point.
+- **Why**: If the user changes "Hello world" to "Hello beautiful world", the word "beautiful" should inherit the formatting of the surrounding text. This is the same behavior Word uses when typing new text.
+- **Edge case**: If the paragraph has no runs (empty paragraph being filled), no `<w:rPr>` is applied (default formatting).
+
+### Edge Cases
+
+#### Empty Paragraphs
+- Rewriting an empty paragraph inserts all new text as a single `<w:ins>` run.
+- The text map for an empty paragraph is empty string `""`, so the diff is a single insert hunk.
+
+#### Rewrite to Empty
+- Rewriting a paragraph to empty text (`new_text=""`) deletes all visible text via `<w:del>` elements.
+- The paragraph element itself is preserved (it's still a `<w:p>`, just with no visible text).
+
+#### Paragraphs with Existing Tracked Changes
+- `build_text_map()` already handles paragraphs with `<w:ins>` and `<w:del>` elements.
+- Deletions of text that is inside an existing `<w:ins>` will undo the insertion (remove from `<w:ins>`) rather than creating nested `<w:del>` inside `<w:ins>`.
+- This follows the same logic as the existing `replace_text` path for mixed-state editing.
+
+#### No-Op Rewrite
+- If `new_text` equals the current visible text, `SequenceMatcher` produces all `'equal'` opcodes.
+- The method returns without modifying the XML. No tracked changes are generated.
+
+### `batch_rewrite()` Design
+
+- **Decision**: Follow the same pattern as `batch_edit()` from `add-batch-edit`:
+  1. Accept a list of `(ref, new_text)` pairs
+  2. Validate all paragraph hashes upfront — reject entire batch if any mismatch
+  3. Apply rewrites in reverse paragraph order (highest index first)
+- **Why**: Consistent with existing batch semantics. All refs are validated against the pre-edit state.
+- **Multiple rewrites to same paragraph**: Not supported in a single batch (each paragraph can appear at most once). Unlike `batch_edit()` where multiple find-replace operations within a paragraph are meaningful, a rewrite specifies the complete final text — a second rewrite would overwrite the first.
+
+## Risks / Trade-offs
+
+- **Risk**: Word-level diffing may produce suboptimal hunks for heavily rewritten text (e.g., entire sentence reworded) -> **Mitigation**: `SequenceMatcher` uses a heuristic for "junk" detection that handles this reasonably. For extreme rewrites, the result is equivalent to delete-all + insert-all, which is correct if not minimal.
+- **Risk**: Formatting inheritance from adjacent runs may not always match user expectations -> **Mitigation**: This is the same behavior as typing in Word. For formatting-aware edits, users should use `replace()` with explicit formatting parameters (future work).
+- **Risk**: Large paragraphs may produce many small hunks -> **Mitigation**: `SequenceMatcher` naturally coalesces equal regions. The number of hunks is proportional to the number of changes, not the paragraph length.
+
+## Open Questions
+
+- Should `rewrite_paragraph()` return a summary of changes made (e.g., number of insertions/deletions)? This could help LLMs verify their edits were applied as expected.

--- a/openspec/changes/add-rewrite-paragraph/proposal.md
+++ b/openspec/changes/add-rewrite-paragraph/proposal.md
@@ -1,0 +1,47 @@
+# Change: Add Paragraph Rewrite via Automatic Diffing
+
+## Why
+
+Current edit methods (`replace`, `delete`) require the LLM to specify exact search text and handle occurrence disambiguation. This is error-prone: the LLM must craft precise `find` strings, deal with occurrence counts, and hope the search text is unambiguous. LLMs are much better at producing desired output text than constructing search-and-replace queries. A `rewrite_paragraph()` method lets the LLM simply state what the paragraph should say, and the system automatically diffs old vs new text to generate fine-grained tracked changes.
+
+### Track Changes Quality is the Priority
+
+The ultimate goal of this project is producing **high-quality tracked changes** that look natural when reviewed in Microsoft Word. This is not just about convenience — tracked changes are the core value proposition. Any new editing method must produce track changes that are at least as clean as the surgical methods.
+
+`rewrite_paragraph()` uses word-level diffing (`difflib.SequenceMatcher`), which produces natural tracked changes for most edits — whole words are inserted/deleted, matching how a human reviewer would see changes in Word. For simple single-word swaps, the diff output is identical to what `replace()` produces (one `<w:del>` + one `<w:ins>`). For heavily rewritten text, the diff may produce more hunks than a hand-crafted sequence of surgical edits would, but each hunk is still a valid, reviewable tracked change.
+
+### When to Use Rewrite vs Surgical Methods
+
+Both methods produce proper tracked changes. The choice depends on the edit:
+
+**Use `replace()` / `delete()` / `insert_after()` / `insert_before()` when:**
+- Making a single, precise change (e.g., "30" → "60", delete one phrase)
+- The change is simple and unambiguous — no occurrence confusion
+- Token efficiency matters (only the changed word is sent, not the whole paragraph)
+- You want guaranteed minimal track changes (exactly one `<w:del>` + `<w:ins>`)
+
+**Use `rewrite_paragraph()` when:**
+- Restructuring a sentence or rewriting multiple parts of a paragraph at once
+- The search text would be ambiguous or hard to specify precisely
+- You'd otherwise need to chain 3+ surgical edits on the same paragraph
+- The paragraph is short enough that outputting the full text is not wasteful
+
+A single-word change via `rewrite_paragraph()` produces identical track changes to `replace()` — it's a degenerate case. The difference is only in token cost (rewrite sends the full paragraph text).
+
+## What Changes
+
+- New `rewrite_paragraph(ref, new_text)` method on `Document` that accepts a hash-anchored paragraph reference and the complete desired paragraph text
+- Internal word-level diffing using `difflib.SequenceMatcher` to compare old visible text vs new text
+- Automatic mapping of diff hunks back to XML positions using existing `build_text_map()` / `find_in_text_map()`
+- Fine-grained `<w:del>` + `<w:ins>` generation for each changed segment (unchanged text is preserved as-is)
+- New `batch_rewrite()` method on `Document` for rewriting multiple paragraphs from a single snapshot
+- Formatting preservation: new text inserted adjacent to a changed segment inherits the run properties of that segment
+
+## Impact
+
+- Affected specs: `specs/text-operations`
+- Affected code: `docx_editor/document.py`, `docx_editor/track_changes.py`, `docx_editor/xml_editor.py`
+- Affected docs: `skills/docx/SKILL.md`, `README.md`
+- **Non-breaking**: New methods only. Existing `replace()`, `delete()`, `insert_after()`, `insert_before()` are unchanged.
+- **Depends on**: `add-paragraph-hash-anchors` (uses ParagraphRef, HashMismatchError, `_resolve_paragraph`, `compute_paragraph_hash`)
+- **Depends on**: `add-batch-edit` (batch_rewrite follows the same upfront-validation, reverse-order pattern)

--- a/openspec/changes/add-rewrite-paragraph/proposal.md
+++ b/openspec/changes/add-rewrite-paragraph/proposal.md
@@ -12,21 +12,16 @@ The ultimate goal of this project is producing **high-quality tracked changes** 
 
 ### When to Use Rewrite vs Surgical Methods
 
-Both methods produce proper tracked changes. The choice depends on the edit:
+**Default: always use surgical methods** (`replace`, `delete`, `insert_after`, `insert_before`, `batch_edit`).
 
-**Use `replace()` / `delete()` / `insert_after()` / `insert_before()` when:**
-- Making a single, precise change (e.g., "30" → "60", delete one phrase)
-- The change is simple and unambiguous — no occurrence confusion
-- Token efficiency matters (only the changed word is sent, not the whole paragraph)
-- You want guaranteed minimal track changes (exactly one `<w:del>` + `<w:ins>`)
+**Use `rewrite_paragraph()` only when the edit cannot be decomposed into independent find→replace pairs:**
+- **Sentence restructuring** — the grammar or clause order changes, not just word swaps
+- **Reordering** — words, items, or clauses move to different positions
+- **Intertwined changes** — edits overlap or depend on each other so they can't be applied independently
 
-**Use `rewrite_paragraph()` when:**
-- Restructuring a sentence or rewriting multiple parts of a paragraph at once
-- The search text would be ambiguous or hard to specify precisely
-- You'd otherwise need to chain 3+ surgical edits on the same paragraph
-- The paragraph is short enough that outputting the full text is not wasteful
+**Use surgical methods when** each change is an independent substitution — even if there are many. Five independent word swaps → `batch_edit`, not `rewrite_paragraph`.
 
-A single-word change via `rewrite_paragraph()` produces identical track changes to `replace()` — it's a degenerate case. The difference is only in token cost (rewrite sends the full paragraph text).
+This criterion is designed to be mechanical, not judgmental: "Can each change be expressed as an independent find→replace?" If yes → surgical. If no → rewrite.
 
 ## What Changes
 

--- a/openspec/changes/add-rewrite-paragraph/specs/text-operations/spec.md
+++ b/openspec/changes/add-rewrite-paragraph/specs/text-operations/spec.md
@@ -1,0 +1,122 @@
+## ADDED Requirements
+
+### Requirement: Paragraph Rewrite via Automatic Diffing
+
+The system SHALL provide a `rewrite_paragraph(ref, new_text)` method on `Document` that accepts a hash-anchored paragraph reference and the complete desired text for that paragraph.
+
+The method SHALL:
+- Validate the paragraph hash using the same mechanism as other hash-anchored methods
+- Retrieve the paragraph's current visible text via `build_text_map()`
+- Compute a word-level diff between old and new text using `difflib.SequenceMatcher`
+- Generate fine-grained `<w:del>` and `<w:ins>` tracked changes for each changed segment
+- Preserve unchanged text and its formatting without modification
+- Inherit run properties (`<w:rPr>`) from the nearest adjacent run for newly inserted text
+
+#### Scenario: Rewrite paragraph with word-level changes
+
+- **GIVEN** a document where paragraph 2 has visible text "The committee has decided to proceed with the plan"
+- **WHEN** `rewrite_paragraph("P2#f3c1", "The board has decided to approve the plan")` is called
+- **THEN** the operation succeeds
+- **AND** "committee" is wrapped in `<w:del>` and "board" is wrapped in `<w:ins>`
+- **AND** "proceed with" is wrapped in `<w:del>` and "approve" is wrapped in `<w:ins>`
+- **AND** "The ", "has decided to ", and " the plan" remain unchanged in the XML
+
+#### Scenario: Rewrite paragraph with additions only
+
+- **GIVEN** a document where paragraph 1 has visible text "Hello world"
+- **WHEN** `rewrite_paragraph("P1#ab12", "Hello beautiful world")` is called
+- **THEN** the operation succeeds
+- **AND** "beautiful " is wrapped in `<w:ins>`
+- **AND** "Hello " and "world" remain unchanged in the XML
+
+#### Scenario: Rewrite paragraph with deletions only
+
+- **GIVEN** a document where paragraph 1 has visible text "Hello beautiful world"
+- **WHEN** `rewrite_paragraph("P1#cd34", "Hello world")` is called
+- **THEN** the operation succeeds
+- **AND** "beautiful " is wrapped in `<w:del>`
+- **AND** "Hello " and "world" remain unchanged in the XML
+
+#### Scenario: Rewrite rejected with stale hash
+
+- **GIVEN** a document where paragraph 3 has been modified since the last `list_paragraphs()` call
+- **WHEN** `rewrite_paragraph("P3#old1", "New text")` is called with a stale hash
+- **THEN** `HashMismatchError` is raised
+- **AND** no changes are applied to the document
+
+#### Scenario: Rewrite empty paragraph
+
+- **GIVEN** a document where paragraph 4 is an empty paragraph
+- **WHEN** `rewrite_paragraph("P4#e000", "New content for this paragraph")` is called
+- **THEN** the operation succeeds
+- **AND** the entire new text is wrapped in a single `<w:ins>` element
+
+#### Scenario: Rewrite paragraph to empty text
+
+- **GIVEN** a document where paragraph 2 has visible text "Remove this entirely"
+- **WHEN** `rewrite_paragraph("P2#ff12", "")` is called
+- **THEN** the operation succeeds
+- **AND** all visible text is wrapped in `<w:del>` elements
+- **AND** the `<w:p>` paragraph element is preserved
+
+#### Scenario: No-op rewrite produces no changes
+
+- **GIVEN** a document where paragraph 1 has visible text "Unchanged text"
+- **WHEN** `rewrite_paragraph("P1#ab00", "Unchanged text")` is called
+- **THEN** the operation succeeds
+- **AND** no tracked changes are generated in the XML
+
+#### Scenario: Rewrite paragraph with existing tracked changes
+
+- **GIVEN** a paragraph containing "Hello " as regular text and "beautiful " inside `<w:ins>` and "world" as regular text
+- **WHEN** `rewrite_paragraph(ref, "Hello wonderful world")` is called
+- **THEN** "beautiful " is removed from the `<w:ins>` element (undoing partial insertion)
+- **AND** "wonderful " is inserted as a new `<w:ins>` element
+- **AND** "Hello " and "world" remain unchanged
+
+#### Scenario: Formatting preserved on insertion
+
+- **GIVEN** a paragraph where "Hello world" is formatted in bold
+- **WHEN** `rewrite_paragraph(ref, "Hello beautiful world")` is called
+- **THEN** the inserted "beautiful " inherits the bold formatting from the adjacent run
+
+### Requirement: Batch Paragraph Rewrite
+
+The system SHALL provide a `batch_rewrite(rewrites)` method on `Document` that accepts a list of paragraph rewrites and applies them atomically.
+
+Each rewrite SHALL specify:
+- `ref`: a hash-anchored paragraph reference
+- `new_text`: the complete desired text for that paragraph
+
+The method SHALL:
+- Validate ALL paragraph hashes upfront before applying any rewrites
+- Reject the entire batch with `HashMismatchError` if any hash is stale (no rewrites applied)
+- Apply rewrites in reverse paragraph order (highest index first)
+- Reject batches that contain duplicate paragraph references
+
+#### Scenario: Batch rewrite of multiple paragraphs
+
+- **GIVEN** a document with paragraphs P1 through P5
+- **WHEN** `batch_rewrite()` is called with rewrites for P2, P4, and P5
+- **THEN** all 3 rewrites succeed
+- **AND** rewrites are applied in order P5, P4, P2 (reverse)
+
+#### Scenario: Batch rejected on stale hash
+
+- **GIVEN** a document where paragraph P3 has been modified since the last `list_paragraphs()` call
+- **WHEN** `batch_rewrite()` is called with rewrites including a stale ref for P3
+- **THEN** `HashMismatchError` is raised
+- **AND** no rewrites from the batch are applied to the document
+
+#### Scenario: Batch rejected on duplicate paragraph
+
+- **GIVEN** a batch with two rewrites targeting the same paragraph P2
+- **WHEN** `batch_rewrite()` is called
+- **THEN** a `ValueError` is raised
+- **AND** no rewrites are applied
+
+#### Scenario: Single snapshot suffices for entire batch
+
+- **GIVEN** a document with 10 paragraphs
+- **WHEN** `list_paragraphs()` is called once, and refs are used in a single `batch_rewrite()` call
+- **THEN** all rewrites succeed without needing to re-read paragraph hashes between rewrites

--- a/openspec/changes/add-rewrite-paragraph/tasks.md
+++ b/openspec/changes/add-rewrite-paragraph/tasks.md
@@ -1,0 +1,42 @@
+## 1. Core Diffing Infrastructure
+
+- [x] 1.1 Implement word-level tokenizer that splits visible text into words and whitespace tokens
+- [x] 1.2 Implement diff engine using `difflib.SequenceMatcher` on word tokens
+- [x] 1.3 Implement hunk-to-XML mapper that converts diff hunks to text-map positions using `build_text_map()` and `find_in_text_map()`
+
+## 2. Rewrite Method
+
+- [x] 2.1 Add `rewrite_paragraph(ref, new_text)` to `RevisionManager`
+- [x] 2.2 Integrate hash validation via `_resolve_paragraph()`
+- [x] 2.3 For each diff hunk: generate `<w:del>` for removed text and `<w:ins>` for added text
+- [x] 2.4 Preserve formatting by inheriting `<w:rPr>` from adjacent runs
+- [x] 2.5 Expose `rewrite_paragraph()` on `Document` facade
+
+## 3. Batch Rewrite
+
+- [x] 3.1 Add `batch_rewrite(rewrites)` to `Document` that accepts a list of `(ref, new_text)` pairs
+- [x] 3.2 Validate all paragraph hashes upfront (reject entire batch on any mismatch)
+- [x] 3.3 Apply rewrites in reverse paragraph order
+
+## 4. Edge Cases
+
+- [x] 4.1 Handle empty paragraph rewrite (insert all new text)
+- [x] 4.2 Handle rewrite to empty text (delete all paragraph text)
+- [x] 4.3 Handle paragraphs with existing tracked changes
+- [x] 4.4 Handle no-op rewrite (new_text equals old text)
+
+## 5. Tests
+
+- [x] 5.1 Unit tests for word-level tokenizer
+- [x] 5.2 Unit tests for diff-to-hunk mapping
+- [x] 5.3 Integration tests for `rewrite_paragraph()` with simple text changes
+- [x] 5.4 Integration tests for `rewrite_paragraph()` with formatting preservation
+- [x] 5.5 Integration tests for `rewrite_paragraph()` with existing tracked changes
+- [x] 5.6 Integration tests for `batch_rewrite()` with multiple paragraphs
+- [x] 5.7 Test hash mismatch rejection for rewrite operations
+- [x] 5.8 Test no-op rewrite raises no error and produces no changes
+
+## 6. Documentation
+
+- [x] 6.1 Update `skills/docx/SKILL.md` with `rewrite_paragraph()` API and usage guidance (when to use rewrite vs surgical methods)
+- [x] 6.2 Update `README.md` with `rewrite_paragraph()` in features list and quick start examples

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "docx-editor"
-version = "0.2.0"
+version = "0.2.1"
 description = "Edit docx with python"
 authors = [{ name = "Pablo Speciale", email = "pablospe@users.noreply.github.com" }]
 readme = "README.md"

--- a/skills/docx/SKILL.md
+++ b/skills/docx/SKILL.md
@@ -382,42 +382,45 @@ with Document.open("file.docx", author=author) as doc:
     #         P2#f3c1| The committee shall review all...
     #         P3#b2c4| The meeting was productive...
 
-    # Step 2: Use the paragraph reference to target exactly the right paragraph
-    doc.replace("the meeting was productive",
-                "the conference was productive",
-                paragraph="P3#b2c4")
-
+    # Step 2: Edit returns the new ref — use it for follow-up edits
+    result = doc.replace("the meeting was productive",
+                         "the conference was productive",
+                         paragraph="P3#b2c4")
+    # result.ref = "P3#d5e6" — fresh hash, ready for the next edit
     doc.save()
 ```
 
-The `paragraph` argument is **required** for all edit methods (`replace`, `delete`, `insert_after`, `insert_before`). If the paragraph content has changed since you called `list_paragraphs()`, a `HashMismatchError` is raised — preventing edits to the wrong location.
+The `paragraph` argument is **required** for all edit methods. If the paragraph content has changed since you called `list_paragraphs()`, a `HashMismatchError` is raised — preventing edits to the wrong location.
+
+**Every edit method returns the new paragraph ref.** Use `.ref` to chain edits without calling `list_paragraphs()` again:
+
+```python
+# Chain 3 edits on the same paragraph — no list_paragraphs() between them:
+r1 = doc.replace("30 days", "60 days", paragraph="P2#f3c1")
+r2 = doc.replace("Manager", "Director", paragraph=r1.ref)
+r3 = doc.delete("draft ", paragraph=r2.ref)
+# r3.ref is the final hash for paragraph 2
+```
 
 ### Batch Editing
 
-For multiple edits, use `batch_edit()` to validate all paragraph hashes upfront before applying any changes:
+For multiple independent edits, use `batch_edit()`:
 
 ```python
 from docx_editor import Document, EditOperation
 
 with Document.open("file.docx", author=author) as doc:
     refs = doc.list_paragraphs()
-    doc.batch_edit([
+    results = doc.batch_edit([
         EditOperation(action="replace", find="old term", replace_with="new term", paragraph="P2#f3c1"),
         EditOperation(action="delete", text="remove this", paragraph="P5#d4e5"),
         EditOperation(action="insert_after", anchor="Section 5", text=" (amended)", paragraph="P3#b2c4"),
     ])
+    # results[0].ref = "P2#c3d4" — fresh ref for paragraph 2
     doc.save()
 ```
 
 If any hash is stale, the entire batch is rejected before any edits are applied.
-
-**Tip: `max_chars=0` for hash-only refresh.** After a batch edit, you already know which paragraphs changed — you just need fresh hashes, not previews:
-
-```python
-# Refresh hashes with no preview text after editing:
-refs = doc.list_paragraphs(max_chars=0)
-# Returns: ["P1#a7b2| ", "P2#f3c1| ", ...]
-```
 
 ### Paragraph Rewrite (Fallback for Structural Edits)
 
@@ -451,13 +454,14 @@ doc.batch_edit([
 # Rephrasing (sentence structure changes completely):
 # "The committee recommends that the timeline be extended by three months"
 # → "The board has approved a three-month extension"
-doc.rewrite_paragraph("P5#a7b2",
+new_ref = doc.rewrite_paragraph("P5#a7b2",
     "The board has approved a three-month extension for further stakeholder review.")
+# new_ref = "P5#d6e7" — fresh ref for follow-up edits
 
 # Reordering items in a list:
 # "final report, executive summary, and presentation slides"
 # → "presentation slides, final report, and executive summary"
-doc.rewrite_paragraph("P3#c4d5",
+new_ref = doc.rewrite_paragraph("P3#c4d5",
     "Deliverables include the presentation slides, final report, and executive summary.")
 ```
 

--- a/skills/docx/SKILL.md
+++ b/skills/docx/SKILL.md
@@ -411,11 +411,12 @@ with Document.open("file.docx", author=author) as doc:
 
 If any hash is stale, the entire batch is rejected before any edits are applied.
 
-**Tip: `max_chars` for faster hash refresh.** `list_paragraphs(max_chars=N)` controls the preview length (default 80). After a batch edit, you already know which paragraphs changed — you just need fresh hashes, not full previews:
+**Tip: `max_chars=0` for hash-only refresh.** After a batch edit, you already know which paragraphs changed — you just need fresh hashes, not previews:
 
 ```python
-# Refresh hashes with minimal output after editing:
-refs = doc.list_paragraphs(max_chars=20)
+# Refresh hashes with no preview text after editing:
+refs = doc.list_paragraphs(max_chars=0)
+# Returns: ["P1#a7b2| ", "P2#f3c1| ", ...]
 ```
 
 ### Paragraph Rewrite (Fallback for Structural Edits)

--- a/skills/docx/SKILL.md
+++ b/skills/docx/SKILL.md
@@ -477,6 +477,8 @@ new_ref = doc.rewrite_paragraph("P3#c4d5",
 **Batch rewrite** for multiple paragraphs at once:
 
 ```python
+import os
+author = os.environ.get("USER") or "Reviewer"
 with Document.open("contract.docx", author=author) as doc:
     refs = doc.list_paragraphs()
     doc.batch_rewrite([

--- a/skills/docx/SKILL.md
+++ b/skills/docx/SKILL.md
@@ -411,6 +411,13 @@ with Document.open("file.docx", author=author) as doc:
 
 If any hash is stale, the entire batch is rejected before any edits are applied.
 
+**Tip: `max_chars` for faster hash refresh.** `list_paragraphs(max_chars=N)` controls the preview length (default 80). After a batch edit, you already know which paragraphs changed — you just need fresh hashes, not full previews:
+
+```python
+# Refresh hashes with minimal output after editing:
+refs = doc.list_paragraphs(max_chars=20)
+```
+
 ### Paragraph Rewrite (Fallback for Structural Edits)
 
 **Default: always use surgical methods** (`replace`, `delete`, `insert_after`, `insert_before`, `batch_edit`).

--- a/skills/docx/SKILL.md
+++ b/skills/docx/SKILL.md
@@ -411,6 +411,55 @@ with Document.open("file.docx", author=author) as doc:
 
 If any hash is stale, the entire batch is rejected before any edits are applied.
 
+### Paragraph Rewrite (Alternative to Surgical Edits)
+
+Use `rewrite_paragraph()` when you need to restructure a sentence, reword multiple parts, or the search text would be ambiguous. Instead of chaining multiple `replace()` / `delete()` / `insert_after()` calls, just specify what the paragraph should say — the system diffs old vs new text at word level and generates fine-grained tracked changes automatically.
+
+**When to use `rewrite_paragraph()` vs surgical methods:**
+
+| Situation | Use | Why |
+|-----------|-----|-----|
+| Change one word ("30" → "60") | `replace()` | Token-efficient, guaranteed minimal track changes |
+| Delete a phrase | `delete()` | Direct, one `<w:del>` |
+| Reword a sentence | `rewrite_paragraph()` | One call vs chaining 3+ edits |
+| Multiple changes in same paragraph | `rewrite_paragraph()` | No occurrence counting needed |
+| Ambiguous search text | `rewrite_paragraph()` | Zero ambiguity — hash-anchored, full paragraph |
+
+**Example: rewrite is clearly better** — restructuring a sentence with multiple changes:
+
+```python
+# BEFORE (chaining 3 surgical edits — error-prone):
+doc.replace("committee", "board", paragraph="P5#a7b2")
+# Oops — need fresh hash now since paragraph changed:
+refs = doc.list_paragraphs()
+doc.replace("shall review and proceed with", "must evaluate", paragraph=refs[4].split("|")[0])
+refs = doc.list_paragraphs()
+doc.replace("the committee", "the board", paragraph=refs[4].split("|")[0])
+
+# AFTER (one rewrite call — zero ambiguity):
+doc.rewrite_paragraph("P5#a7b2",
+    "The board must evaluate item 5. The report includes conclusions from the board.")
+```
+
+**Example: surgical is better** — simple single-word change:
+
+```python
+# Simple, token-efficient, guaranteed minimal track changes:
+doc.replace("30", "60", paragraph="P2#f3c1")
+```
+
+**Batch rewrite** for multiple paragraphs at once:
+
+```python
+with Document.open("contract.docx", author=author) as doc:
+    refs = doc.list_paragraphs()
+    doc.batch_rewrite([
+        (refs[1].split("|")[0], "Updated paragraph 2 text here."),
+        (refs[4].split("|")[0], "Updated paragraph 5 text here."),
+    ])
+    doc.save()
+```
+
 ### Workflow for Large Documents
 
 1. **List paragraphs** with hash-anchored references:

--- a/skills/docx/SKILL.md
+++ b/skills/docx/SKILL.md
@@ -179,7 +179,8 @@ with Document.open("contract.docx", author=author) as doc:
     #         P2#f3c1| The committee shall review...
 
     # Step 2: Edit using paragraph references (safe, unambiguous)
-    doc.replace("old text", "new text", paragraph="P2#f3c1")
+    # Each method returns the new paragraph ref for chaining
+    new_ref = doc.replace("old text", "new text", paragraph="P2#f3c1")
     doc.delete("text to delete", paragraph="P5#d4e5")
     doc.insert_after("anchor", "new text", paragraph="P3#b2c4")
     doc.insert_before("anchor", "prefix", paragraph="P3#b2c4")
@@ -222,8 +223,10 @@ match = doc.find_text("30 days")
 # Get all visible text (inserted text included, deleted text excluded)
 visible = doc.get_visible_text()
 
-# Replace text (creates tracked deletion + insertion)
-doc.replace("30 days", "60 days", paragraph="P2#f3c1")
+# All edit methods return the new paragraph ref as a plain string.
+# Use it for follow-up edits on the same paragraph:
+new_ref = doc.replace("30 days", "60 days", paragraph="P2#f3c1")
+doc.replace("net", "gross", paragraph=new_ref)  # chain without list_paragraphs()
 
 # Delete text (creates tracked deletion)
 doc.delete("unnecessary clause", paragraph="P5#d4e5")
@@ -232,11 +235,15 @@ doc.delete("unnecessary clause", paragraph="P5#d4e5")
 doc.insert_after("Section 3.", " Additional terms apply.", paragraph="P3#b2c4")
 doc.insert_before("Section 3.", "See also: ", paragraph="P3#b2c4")
 
+# To accept/reject a specific edit, use list_revisions() to get the change ID:
+revisions = doc.list_revisions()
+doc.accept_revision(revisions[-1].id)
+
 doc.save("edited.docx")
 doc.close()
 ```
 
-**Return values:** All track changes methods return an `int` change ID. Returns `-1` when the target text is already inside a tracked insertion (`<w:ins>`), because the edit is done in-place without creating new revision markup.
+**Return values:** All edit methods return the new paragraph reference as a plain `str` (e.g., `"P2#c3d4"`). Use this for follow-up edits on the same paragraph without calling `list_paragraphs()` again. To get change IDs for accept/reject, use `doc.list_revisions()`.
 
 **Raises:** `TextNotFoundError` if the text is not found.
 
@@ -341,7 +348,9 @@ for p in doc.list_paragraphs():
     print(p)
 
 # Section 2 changes (using paragraph references from list_paragraphs)
-doc.replace("30 days", "60 days", paragraph="P4#a1b2")
+# Each edit returns the new ref — chain edits on the same paragraph
+r = doc.replace("30 days", "60 days", paragraph="P4#a1b2")
+doc.replace("net", "gross", paragraph=r)  # second edit on same paragraph
 doc.replace("January 1, 2024", "March 1, 2024", paragraph="P5#c3d4")
 
 # Section 5 changes

--- a/skills/docx/SKILL.md
+++ b/skills/docx/SKILL.md
@@ -431,9 +431,9 @@ doc.replace("30", "60", paragraph="P2#f3c1")
 # Multiple independent swaps — use batch_edit():
 # "CFO" → "Finance Director", "audit committee" → "board", "December 31st" → "January 15th"
 doc.batch_edit([
-    {"paragraph": "P5#a7b2", "find": "CFO", "replace": "Finance Director"},
-    {"paragraph": "P5#a7b2", "find": "audit committee", "replace": "board"},
-    {"paragraph": "P5#a7b2", "find": "December 31st", "replace": "January 15th"},
+    EditOperation(action="replace", find="CFO", replace_with="Finance Director", paragraph="P5#a7b2"),
+    EditOperation(action="replace", find="audit committee", replace_with="board", paragraph="P5#a7b2"),
+    EditOperation(action="replace", find="December 31st", replace_with="January 15th", paragraph="P5#a7b2"),
 ])
 ```
 

--- a/skills/docx/SKILL.md
+++ b/skills/docx/SKILL.md
@@ -386,20 +386,20 @@ with Document.open("file.docx", author=author) as doc:
     result = doc.replace("the meeting was productive",
                          "the conference was productive",
                          paragraph="P3#b2c4")
-    # result.ref = "P3#d5e6" — fresh hash, ready for the next edit
+    # returns "P3#d5e6" — fresh hash, ready for the next edit
     doc.save()
 ```
 
 The `paragraph` argument is **required** for all edit methods. If the paragraph content has changed since you called `list_paragraphs()`, a `HashMismatchError` is raised — preventing edits to the wrong location.
 
-**Every edit method returns the new paragraph ref.** Use `.ref` to chain edits without calling `list_paragraphs()` again:
+**Every edit method returns the new paragraph ref as a plain string.** Chain edits without calling `list_paragraphs()` again:
 
 ```python
 # Chain 3 edits on the same paragraph — no list_paragraphs() between them:
 r1 = doc.replace("30 days", "60 days", paragraph="P2#f3c1")
-r2 = doc.replace("Manager", "Director", paragraph=r1.ref)
-r3 = doc.delete("draft ", paragraph=r2.ref)
-# r3.ref is the final hash for paragraph 2
+r2 = doc.replace("Manager", "Director", paragraph=r1)
+r3 = doc.delete("draft ", paragraph=r2)
+# r3 is "P2#xxxx" — the final hash for paragraph 2
 ```
 
 ### Batch Editing
@@ -411,12 +411,12 @@ from docx_editor import Document, EditOperation
 
 with Document.open("file.docx", author=author) as doc:
     refs = doc.list_paragraphs()
-    results = doc.batch_edit([
+    new_refs = doc.batch_edit([
         EditOperation(action="replace", find="old term", replace_with="new term", paragraph="P2#f3c1"),
         EditOperation(action="delete", text="remove this", paragraph="P5#d4e5"),
         EditOperation(action="insert_after", anchor="Section 5", text=" (amended)", paragraph="P3#b2c4"),
     ])
-    # results[0].ref = "P2#c3d4" — fresh ref for paragraph 2
+    # new_refs[0] = "P2#c3d4" — fresh ref for paragraph 2
     doc.save()
 ```
 

--- a/skills/docx/SKILL.md
+++ b/skills/docx/SKILL.md
@@ -411,41 +411,46 @@ with Document.open("file.docx", author=author) as doc:
 
 If any hash is stale, the entire batch is rejected before any edits are applied.
 
-### Paragraph Rewrite (Alternative to Surgical Edits)
+### Paragraph Rewrite (Fallback for Structural Edits)
 
-Use `rewrite_paragraph()` when you need to restructure a sentence, reword multiple parts, or the search text would be ambiguous. Instead of chaining multiple `replace()` / `delete()` / `insert_after()` calls, just specify what the paragraph should say — the system diffs old vs new text at word level and generates fine-grained tracked changes automatically.
+**Default: always use surgical methods** (`replace`, `delete`, `insert_after`, `insert_before`, `batch_edit`).
 
-**When to use `rewrite_paragraph()` vs surgical methods:**
+**Use `rewrite_paragraph()` only when the edit cannot be decomposed into independent find→replace pairs.** This happens when:
+- **Sentence restructuring** — the grammar or clause order changes, not just word swaps
+- **Reordering** — words, items, or clauses move to different positions
+- **Intertwined changes** — edits overlap or depend on each other so they can't be applied independently
 
-| Situation | Use | Why |
-|-----------|-----|-----|
-| Change one word ("30" → "60") | `replace()` | Token-efficient, guaranteed minimal track changes |
-| Delete a phrase | `delete()` | Direct, one `<w:del>` |
-| Reword a sentence | `rewrite_paragraph()` | One call vs chaining 3+ edits |
-| Multiple changes in same paragraph | `rewrite_paragraph()` | No occurrence counting needed |
-| Ambiguous search text | `rewrite_paragraph()` | Zero ambiguity — hash-anchored, full paragraph |
+**Use surgical methods when** each change is an independent substitution, even if there are many of them. Five independent word swaps → `batch_edit`, not `rewrite_paragraph`.
 
-**Example: rewrite is clearly better** — restructuring a sentence with multiple changes:
+**Examples — surgical is correct:**
 
 ```python
-# BEFORE (chaining 3 surgical edits — error-prone):
-doc.replace("committee", "board", paragraph="P5#a7b2")
-# Oops — need fresh hash now since paragraph changed:
-refs = doc.list_paragraphs()
-doc.replace("shall review and proceed with", "must evaluate", paragraph=refs[4].split("|")[0])
-refs = doc.list_paragraphs()
-doc.replace("the committee", "the board", paragraph=refs[4].split("|")[0])
+# Single word swap — use replace():
+doc.replace("30", "60", paragraph="P2#f3c1")
 
-# AFTER (one rewrite call — zero ambiguity):
-doc.rewrite_paragraph("P5#a7b2",
-    "The board must evaluate item 5. The report includes conclusions from the board.")
+# Multiple independent swaps — use batch_edit():
+# "CFO" → "Finance Director", "audit committee" → "board", "December 31st" → "January 15th"
+doc.batch_edit([
+    {"paragraph": "P5#a7b2", "find": "CFO", "replace": "Finance Director"},
+    {"paragraph": "P5#a7b2", "find": "audit committee", "replace": "board"},
+    {"paragraph": "P5#a7b2", "find": "December 31st", "replace": "January 15th"},
+])
 ```
 
-**Example: surgical is better** — simple single-word change:
+**Examples — rewrite is correct:**
 
 ```python
-# Simple, token-efficient, guaranteed minimal track changes:
-doc.replace("30", "60", paragraph="P2#f3c1")
+# Rephrasing (sentence structure changes completely):
+# "The committee recommends that the timeline be extended by three months"
+# → "The board has approved a three-month extension"
+doc.rewrite_paragraph("P5#a7b2",
+    "The board has approved a three-month extension for further stakeholder review.")
+
+# Reordering items in a list:
+# "final report, executive summary, and presentation slides"
+# → "presentation slides, final report, and executive summary"
+doc.rewrite_paragraph("P3#c4d5",
+    "Deliverables include the presentation slides, final report, and executive summary.")
 ```
 
 **Batch rewrite** for multiple paragraphs at once:
@@ -454,8 +459,8 @@ doc.replace("30", "60", paragraph="P2#f3c1")
 with Document.open("contract.docx", author=author) as doc:
     refs = doc.list_paragraphs()
     doc.batch_rewrite([
-        (refs[1].split("|")[0], "Updated paragraph 2 text here."),
-        (refs[4].split("|")[0], "Updated paragraph 5 text here."),
+        (refs[1].split("|")[0], "Rephrased paragraph 2 text here."),
+        (refs[4].split("|")[0], "Restructured paragraph 5 text here."),
     ])
     doc.save()
 ```

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -194,8 +194,8 @@ class TestMixedStateDeletion:
             pytest.skip("Expected boundary not created")
 
         ref = find_ref(doc, "fox")
-        change_id = doc.delete("fox ADDED", paragraph=ref)
-        assert change_id >= 0
+        new_ref = doc.delete("fox ADDED", paragraph=ref)
+        assert isinstance(new_ref, str)
 
         text = doc.get_visible_text()
         assert "fox" not in text
@@ -469,8 +469,8 @@ class TestInsertWithCrossBoundaryAnchor:
             pytest.skip("Boundary not created")
 
         ref = find_ref(doc, "fox RED")
-        change_id = doc.insert_after("fox RED", " NEW", paragraph=ref)
-        assert change_id >= 0
+        new_ref = doc.insert_after("fox RED", " NEW", paragraph=ref)
+        assert isinstance(new_ref, str)
         text = doc.get_visible_text()
         assert "fox RED NEW" in text
         doc.close()
@@ -487,8 +487,8 @@ class TestInsertWithCrossBoundaryAnchor:
             pytest.skip("Boundary not created")
 
         ref = find_ref(doc, "fox RED")
-        change_id = doc.insert_before("fox RED", "NEW ", paragraph=ref)
-        assert change_id >= 0
+        new_ref = doc.insert_before("fox RED", "NEW ", paragraph=ref)
+        assert isinstance(new_ref, str)
         text = doc.get_visible_text()
         assert "NEW fox RED" in text
         doc.close()

--- a/tests/test_cross_boundary_replace.py
+++ b/tests/test_cross_boundary_replace.py
@@ -41,8 +41,8 @@ class TestCrossBoundaryReplaceRegression:
         """Replace text contained in a single w:t element."""
         doc = Document.open(clean_workspace)
         ref = find_ref(doc, "fox")
-        change_id = doc.replace("fox", "cat", paragraph=ref)
-        assert change_id >= 0
+        new_ref = doc.replace("fox", "cat", paragraph=ref)
+        assert isinstance(new_ref, str)
         assert "cat" in doc.get_visible_text()
         assert "fox" not in doc.get_visible_text()
         doc.close()
@@ -203,8 +203,8 @@ class TestCrossBoundaryReplaceRoundtrip:
 
         # Now "fox" spans two runs: "...fo" and "x jumps..."
         ref = find_ref(doc, "fo")
-        change_id = doc.replace("fox", "cat", paragraph=ref)
-        assert change_id >= 0
+        new_ref = doc.replace("fox", "cat", paragraph=ref)
+        assert isinstance(new_ref, str)
 
         output = temp_dir / "output.docx"
         doc.save(output)

--- a/tests/test_mixed_state.py
+++ b/tests/test_mixed_state.py
@@ -64,8 +64,8 @@ class TestMixedStateReplace:
             pytest.skip("Expected boundary not created")
 
         ref = find_ref(doc, "dog.")
-        change_id = doc.replace("dog. ADDED", "cat. CHANGED", paragraph=ref)
-        assert change_id >= 0
+        new_ref = doc.replace("dog. ADDED", "cat. CHANGED", paragraph=ref)
+        assert isinstance(new_ref, str)
 
         text = doc.get_visible_text()
         assert "cat. CHANGED" in text
@@ -96,9 +96,8 @@ class TestMixedStateReplace:
             pytest.skip("Text not entirely within insertion")
 
         ref = find_ref(doc, "beautiful")
-        change_id = doc.replace("beautiful", "wonderful", paragraph=ref)
-        # change_id is -1 when editing in-place inside an existing insertion
-        assert isinstance(change_id, int)
+        new_ref = doc.replace("beautiful", "wonderful", paragraph=ref)
+        assert isinstance(new_ref, str)
         text = doc.get_visible_text()
         assert "wonderful" in text
         assert "beautiful" not in text

--- a/tests/test_rewrite_paragraph.py
+++ b/tests/test_rewrite_paragraph.py
@@ -267,3 +267,54 @@ class TestRewriteParagraph:
             if rPr_elems:
                 b_elems = rPr_elems[0].getElementsByTagName("w:b")
                 assert len(b_elems) > 0, "Inserted text should inherit bold formatting"
+
+
+class TestBatchRewrite:
+    def test_batch_multiple_paragraphs(self, rewrite_doc):
+        """Batch rewrite of multiple paragraphs succeeds."""
+        doc, _ = rewrite_doc
+        refs = doc.list_paragraphs()
+
+        doc.batch_rewrite([
+            (refs[0].split("|")[0], "The board shall review and approve."),
+            (refs[2].split("|")[0], "The report is complete."),
+            (refs[4].split("|")[0], "Final decision pending."),
+        ])
+
+        vis = doc.get_visible_text()
+        assert "The board shall review and approve." in vis
+        assert "The report is complete." in vis
+        assert "Final decision pending." in vis
+
+    def test_batch_rejected_on_stale_hash(self, rewrite_doc):
+        """Stale hash in batch rejects entire batch (no changes applied)."""
+        doc, _ = rewrite_doc
+        refs = doc.list_paragraphs()
+
+        with pytest.raises(HashMismatchError):
+            doc.batch_rewrite([
+                (refs[0].split("|")[0], "Good text"),
+                ("P3#0000", "Bad hash"),
+            ])
+
+        # Verify no changes were applied (P1 unchanged)
+        vis = doc.get_visible_text()
+        assert "The committee shall review" in vis
+
+    def test_batch_rejected_on_duplicate(self, rewrite_doc):
+        """Duplicate paragraph in batch raises ValueError."""
+        doc, _ = rewrite_doc
+        refs = doc.list_paragraphs()
+        ref = refs[0].split("|")[0]
+
+        with pytest.raises(ValueError, match="duplicate"):
+            doc.batch_rewrite([
+                (ref, "First"),
+                (ref, "Second"),
+            ])
+
+    def test_batch_empty(self, rewrite_doc):
+        """Empty batch succeeds with no changes."""
+        doc, _ = rewrite_doc
+        doc.batch_rewrite([])
+        assert len(doc.list_revisions()) == 0

--- a/tests/test_rewrite_paragraph.py
+++ b/tests/test_rewrite_paragraph.py
@@ -591,58 +591,61 @@ class TestRewriteStructuralEdits:
             shutil.rmtree(tmp, ignore_errors=True)
 
 
-class TestEditResultRef:
+class TestEditReturnsRef:
     """Tests for edit methods returning new paragraph refs."""
 
     def test_replace_returns_ref(self, rewrite_doc):
-        """replace() returns EditResult with .ref for follow-up edits."""
+        """replace() returns new paragraph ref string."""
         doc, _ = rewrite_doc
         refs = doc.list_paragraphs()
         ref = refs[0].split("|")[0]
 
-        result = doc.replace("committee", "board", paragraph=ref)
+        new_ref = doc.replace("committee", "board", paragraph=ref)
 
-        # .ref is a fresh paragraph reference
-        assert result.ref.startswith("P1#")
-        assert result.ref != ref  # hash changed
+        assert isinstance(new_ref, str)
+        assert new_ref.startswith("P1#")
+        assert new_ref != ref  # hash changed
 
-        # Can use .ref for a follow-up edit without list_paragraphs()
-        result2 = doc.replace("board", "council", paragraph=result.ref)
-        assert result2.ref.startswith("P1#")
-        assert result2.ref != result.ref  # hash changed again
+        # Can use returned ref for a follow-up edit without list_paragraphs()
+        new_ref2 = doc.replace("board", "council", paragraph=new_ref)
+        assert new_ref2.startswith("P1#")
+        assert new_ref2 != new_ref  # hash changed again
 
         vis = doc.get_visible_text()
         assert "council" in vis
 
     def test_delete_returns_ref(self, rewrite_doc):
-        """delete() returns EditResult with .ref."""
+        """delete() returns new paragraph ref."""
         doc, _ = rewrite_doc
         refs = doc.list_paragraphs()
         ref = refs[0].split("|")[0]
 
-        result = doc.delete("committee", paragraph=ref)
-        assert result.ref.startswith("P1#")
-        assert result.ref != ref
+        new_ref = doc.delete("committee", paragraph=ref)
+        assert isinstance(new_ref, str)
+        assert new_ref.startswith("P1#")
+        assert new_ref != ref
 
     def test_insert_after_returns_ref(self, rewrite_doc):
-        """insert_after() returns EditResult with .ref."""
+        """insert_after() returns new paragraph ref."""
         doc, _ = rewrite_doc
         refs = doc.list_paragraphs()
         ref = refs[0].split("|")[0]
 
-        result = doc.insert_after("committee", " meeting", paragraph=ref)
-        assert result.ref.startswith("P1#")
-        assert result.ref != ref
+        new_ref = doc.insert_after("committee", " meeting", paragraph=ref)
+        assert isinstance(new_ref, str)
+        assert new_ref.startswith("P1#")
+        assert new_ref != ref
 
     def test_insert_before_returns_ref(self, rewrite_doc):
-        """insert_before() returns EditResult with .ref."""
+        """insert_before() returns new paragraph ref."""
         doc, _ = rewrite_doc
         refs = doc.list_paragraphs()
         ref = refs[0].split("|")[0]
 
-        result = doc.insert_before("committee", "special ", paragraph=ref)
-        assert result.ref.startswith("P1#")
-        assert result.ref != ref
+        new_ref = doc.insert_before("committee", "special ", paragraph=ref)
+        assert isinstance(new_ref, str)
+        assert new_ref.startswith("P1#")
+        assert new_ref != ref
 
     def test_rewrite_returns_ref(self, rewrite_doc):
         """rewrite_paragraph() returns new ref string."""
@@ -677,7 +680,7 @@ class TestEditResultRef:
         assert new_refs[1].startswith("P3#")
 
     def test_batch_edit_returns_refs(self, rewrite_doc):
-        """batch_edit() returns list of EditResults with .ref."""
+        """batch_edit() returns list of new paragraph refs."""
         from docx_editor import EditOperation
 
         doc, _ = rewrite_doc
@@ -689,35 +692,34 @@ class TestEditResultRef:
         ])
 
         assert len(results) == 2
-        assert results[0].ref.startswith("P1#")
-        assert results[1].ref.startswith("P2#")
+        assert isinstance(results[0], str)
+        assert results[0].startswith("P1#")
+        assert results[1].startswith("P2#")
 
-    def test_edit_result_backwards_compatible(self, rewrite_doc):
-        """EditResult works as int for accept/reject operations."""
+    def test_accept_revision_via_list_revisions(self, rewrite_doc):
+        """Change IDs are available via list_revisions() for accept/reject."""
         doc, _ = rewrite_doc
         refs = doc.list_paragraphs()
         ref = refs[0].split("|")[0]
 
-        result = doc.insert_after("committee", " NEW", paragraph=ref)
+        doc.insert_after("committee", " NEW", paragraph=ref)
 
-        # Acts as int
-        assert isinstance(result, int)
-        assert int(result) >= 0
-
-        # Can be used for accept/reject
-        accepted = doc.accept_revision(result)
+        # Get change ID from list_revisions
+        revisions = doc.list_revisions()
+        assert len(revisions) > 0
+        accepted = doc.accept_revision(revisions[-1].id)
         assert accepted is True
 
     def test_sequential_edits_without_list_paragraphs(self, rewrite_doc):
-        """Chain multiple edits using .ref without ever calling list_paragraphs() again."""
+        """Chain multiple edits using returned ref without ever calling list_paragraphs() again."""
         doc, _ = rewrite_doc
         refs = doc.list_paragraphs()
         ref = refs[0].split("|")[0]
 
-        # Chain 3 edits on the same paragraph, using .ref each time
+        # Chain 3 edits on the same paragraph, using returned ref each time
         r1 = doc.replace("committee", "board", paragraph=ref)
-        r2 = doc.replace("shall", "must", paragraph=r1.ref)
-        r3 = doc.replace("annual", "quarterly", paragraph=r2.ref)
+        r2 = doc.replace("shall", "must", paragraph=r1)
+        r3 = doc.replace("annual", "quarterly", paragraph=r2)
 
         vis = doc.get_visible_text()
         assert "board" in vis

--- a/tests/test_rewrite_paragraph.py
+++ b/tests/test_rewrite_paragraph.py
@@ -351,7 +351,7 @@ class TestRewriteDuplicateText:
         del_texts = [r.text for r in revisions if r.type == "deletion"]
         ins_texts = [r.text for r in revisions if r.type == "insertion"]
         assert any("the" in t.lower() for t in del_texts)
-        assert any("a" == t.strip() for t in ins_texts)
+        assert any(t.strip() == "a" for t in ins_texts)
 
 
 def _make_doc_with_paragraphs(paragraphs: list[str]):

--- a/tests/test_rewrite_paragraph.py
+++ b/tests/test_rewrite_paragraph.py
@@ -269,6 +269,91 @@ class TestRewriteParagraph:
                 assert len(b_elems) > 0, "Inserted text should inherit bold formatting"
 
 
+class TestRewriteDuplicateText:
+    """Tests for paragraphs containing duplicate text (Bug #1 fix)."""
+
+    @pytest.fixture
+    def dup_doc(self):
+        """Build a document with a paragraph containing repeated words."""
+        test_data = Path(__file__).parent / "test_data" / "simple.docx"
+        tmp = tempfile.mkdtemp(prefix="rewrite_dup_test_")
+        dest = Path(tmp) / "test.docx"
+        shutil.copy(test_data, dest)
+
+        doc = Document.open(dest)
+        doc.accept_all()
+        doc.save()
+        doc.close()
+
+        doc = Document.open(dest, force_recreate=True)
+        editor = doc._document_editor
+        body = editor.dom.getElementsByTagName("w:body")[0]
+
+        for p in list(editor.dom.getElementsByTagName("w:p")):
+            if p.parentNode == body:
+                body.removeChild(p)
+
+        sect_pr = editor.dom.getElementsByTagName("w:sectPr")
+        insert_before = sect_pr[0] if sect_pr else None
+
+        # Paragraph with "the" appearing 3 times
+        text = "The cat and the dog and the bird"
+        p_xml = f'<w:p><w:r><w:t xml:space="preserve">{text}</w:t></w:r></w:p>'
+        nodes = editor._parse_fragment(p_xml)
+        for node in nodes:
+            if insert_before:
+                body.insertBefore(node, insert_before)
+            else:
+                body.appendChild(node)
+
+        editor.save()
+        save_path = doc.save()
+        doc.close()
+
+        doc = Document.open(save_path, force_recreate=True)
+        yield doc, Path(tmp)
+        doc.close()
+        shutil.rmtree(tmp, ignore_errors=True)
+
+    def test_replace_second_occurrence(self, dup_doc):
+        """Replacing only the second 'the' should not touch the first or third."""
+        doc, _ = dup_doc
+        refs = doc.list_paragraphs()
+        ref = refs[0].split("|")[0]
+
+        # Change "the dog" to "the hound" — second "the" stays, "dog" becomes "hound"
+        doc.rewrite_paragraph(ref, "The cat and the hound and the bird")
+
+        vis = doc.get_visible_text()
+        assert "The cat and the hound and the bird" in vis
+
+        revisions = doc.list_revisions()
+        del_texts = [r.text for r in revisions if r.type == "deletion"]
+        ins_texts = [r.text for r in revisions if r.type == "insertion"]
+        assert any("dog" in t for t in del_texts)
+        assert any("hound" in t for t in ins_texts)
+        # "the" should NOT appear in deletions or insertions
+        assert not any(t.strip() == "the" for t in del_texts)
+        assert not any(t.strip() == "the" for t in ins_texts)
+
+    def test_replace_last_occurrence(self, dup_doc):
+        """Replacing only the last 'the' should not touch earlier occurrences."""
+        doc, _ = dup_doc
+        refs = doc.list_paragraphs()
+        ref = refs[0].split("|")[0]
+
+        doc.rewrite_paragraph(ref, "The cat and the dog and a bird")
+
+        vis = doc.get_visible_text()
+        assert "The cat and the dog and a bird" in vis
+
+        revisions = doc.list_revisions()
+        del_texts = [r.text for r in revisions if r.type == "deletion"]
+        ins_texts = [r.text for r in revisions if r.type == "insertion"]
+        assert any("the" in t.lower() for t in del_texts)
+        assert any("a" == t.strip() for t in ins_texts)
+
+
 class TestRewriteWithTrackedChanges:
     def test_rewrite_after_prior_edit(self, rewrite_doc):
         """Rewriting a paragraph that already has tracked changes works."""

--- a/tests/test_rewrite_paragraph.py
+++ b/tests/test_rewrite_paragraph.py
@@ -1,0 +1,269 @@
+"""Tests for rewrite_paragraph() — word-level diff with tracked changes."""
+
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from docx_editor import Document, HashMismatchError
+from docx_editor.track_changes import _tokenize_words
+
+
+@pytest.fixture
+def rewrite_doc():
+    """Build a document with 5 known paragraphs for rewrite testing."""
+    test_data = Path(__file__).parent / "test_data" / "simple.docx"
+    tmp = tempfile.mkdtemp(prefix="rewrite_test_")
+    dest = Path(tmp) / "test.docx"
+    shutil.copy(test_data, dest)
+
+    doc = Document.open(dest)
+    doc.accept_all()
+    doc.save()
+    doc.close()
+
+    # Inject paragraphs directly
+    doc = Document.open(dest, force_recreate=True)
+    editor = doc._document_editor
+    body = editor.dom.getElementsByTagName("w:body")[0]
+
+    # Remove existing paragraphs
+    for p in list(editor.dom.getElementsByTagName("w:p")):
+        if p.parentNode == body:
+            body.removeChild(p)
+
+    sect_pr = editor.dom.getElementsByTagName("w:sectPr")
+    insert_before = sect_pr[0] if sect_pr else None
+
+    paragraphs = [
+        "The committee shall review and proceed with the annual budget proposal.",
+        "All members must attend the quarterly meeting without exception.",
+        "The report includes findings from the committee investigation.",
+        "",  # empty paragraph
+        "Final approval requires a majority vote by the board.",
+    ]
+
+    for text in paragraphs:
+        if text:
+            p_xml = f'<w:p><w:r><w:t xml:space="preserve">{text}</w:t></w:r></w:p>'
+        else:
+            p_xml = "<w:p/>"
+        nodes = editor._parse_fragment(p_xml)
+        for node in nodes:
+            if insert_before:
+                body.insertBefore(node, insert_before)
+            else:
+                body.appendChild(node)
+
+    editor.save()
+    save_path = doc.save()
+    doc.close()
+
+    doc = Document.open(save_path, force_recreate=True)
+    yield doc, Path(tmp)
+    doc.close()
+    shutil.rmtree(tmp, ignore_errors=True)
+
+
+@pytest.fixture
+def bold_doc():
+    """Build a document with a bold-formatted paragraph for formatting tests."""
+    test_data = Path(__file__).parent / "test_data" / "simple.docx"
+    tmp = tempfile.mkdtemp(prefix="rewrite_bold_test_")
+    dest = Path(tmp) / "test.docx"
+    shutil.copy(test_data, dest)
+
+    doc = Document.open(dest)
+    doc.accept_all()
+    doc.save()
+    doc.close()
+
+    doc = Document.open(dest, force_recreate=True)
+    editor = doc._document_editor
+    body = editor.dom.getElementsByTagName("w:body")[0]
+
+    for p in list(editor.dom.getElementsByTagName("w:p")):
+        if p.parentNode == body:
+            body.removeChild(p)
+
+    sect_pr = editor.dom.getElementsByTagName("w:sectPr")
+    insert_before = sect_pr[0] if sect_pr else None
+
+    # Bold paragraph
+    p_xml = '<w:p><w:r><w:rPr><w:b/></w:rPr><w:t xml:space="preserve">The bold committee meets today.</w:t></w:r></w:p>'
+    nodes = editor._parse_fragment(p_xml)
+    for node in nodes:
+        if insert_before:
+            body.insertBefore(node, insert_before)
+        else:
+            body.appendChild(node)
+
+    editor.save()
+    save_path = doc.save()
+    doc.close()
+
+    doc = Document.open(save_path, force_recreate=True)
+    yield doc, Path(tmp)
+    doc.close()
+    shutil.rmtree(tmp, ignore_errors=True)
+
+
+class TestTokenizeWords:
+    def test_basic(self):
+        tokens = _tokenize_words("hello world")
+        assert tokens == ["hello", " ", "world"]
+
+    def test_multiple_spaces(self):
+        tokens = _tokenize_words("a  b")
+        assert tokens == ["a", "  ", "b"]
+
+    def test_empty(self):
+        tokens = _tokenize_words("")
+        assert tokens == []
+
+
+class TestRewriteParagraph:
+    def test_word_replacement(self, rewrite_doc):
+        """Replace 'committee' with 'board' and 'proceed with' with 'approve'."""
+        doc, _ = rewrite_doc
+        refs = doc.list_paragraphs()
+        ref = refs[0].split("|")[0]
+
+        doc.rewrite_paragraph(
+            ref,
+            "The board shall review and approve the annual budget proposal.",
+        )
+
+        vis = doc.get_visible_text()
+        assert "board" in vis
+        assert "approve" in vis
+
+        # Verify tracked changes were created
+        revisions = doc.list_revisions()
+        assert len(revisions) > 0
+
+        # Check for deletions and insertions
+        del_texts = [r.text for r in revisions if r.type == "deletion"]
+        ins_texts = [r.text for r in revisions if r.type == "insertion"]
+        assert any("committee" in t for t in del_texts)
+        assert any("board" in t for t in ins_texts)
+
+    def test_addition_only(self, rewrite_doc):
+        """Add a word — should produce insertions only."""
+        doc, _ = rewrite_doc
+        refs = doc.list_paragraphs()
+        ref = refs[1].split("|")[0]
+
+        doc.rewrite_paragraph(
+            ref,
+            "All members must always attend the quarterly meeting without exception.",
+        )
+
+        vis = doc.get_visible_text()
+        assert "always" in vis
+
+        revisions = doc.list_revisions()
+        # Should have insertion(s) but no deletions
+        ins_revs = [r for r in revisions if r.type == "insertion"]
+        del_revs = [r for r in revisions if r.type == "deletion"]
+        assert len(ins_revs) > 0
+        assert len(del_revs) == 0
+
+    def test_deletion_only(self, rewrite_doc):
+        """Remove a word — should produce deletions only."""
+        doc, _ = rewrite_doc
+        refs = doc.list_paragraphs()
+        ref = refs[1].split("|")[0]
+
+        doc.rewrite_paragraph(
+            ref,
+            "All members must attend the meeting without exception.",
+        )
+
+        vis = doc.get_visible_text()
+        assert "quarterly" not in vis
+
+        revisions = doc.list_revisions()
+        del_revs = [r for r in revisions if r.type == "deletion"]
+        ins_revs = [r for r in revisions if r.type == "insertion"]
+        assert len(del_revs) > 0
+        assert len(ins_revs) == 0
+
+    def test_noop_rewrite(self, rewrite_doc):
+        """Same text produces no revisions."""
+        doc, _ = rewrite_doc
+        refs = doc.list_paragraphs()
+        ref = refs[0].split("|")[0]
+
+        original_text = "The committee shall review and proceed with the annual budget proposal."
+        doc.rewrite_paragraph(ref, original_text)
+
+        revisions = doc.list_revisions()
+        assert len(revisions) == 0
+
+    def test_hash_mismatch(self, rewrite_doc):
+        """Stale hash raises HashMismatchError."""
+        doc, _ = rewrite_doc
+        refs = doc.list_paragraphs()
+        ref = refs[0].split("|")[0]
+
+        # Mutate the paragraph
+        doc.rewrite_paragraph(ref, "Changed text here.")
+
+        # Now use old ref (stale hash)
+        with pytest.raises(HashMismatchError):
+            doc.rewrite_paragraph(ref, "Another change.")
+
+    def test_rewrite_empty_paragraph(self, rewrite_doc):
+        """Empty paragraph to text — all inserted."""
+        doc, _ = rewrite_doc
+        refs = doc.list_paragraphs()
+        # P4 is the empty paragraph (index 3)
+        ref = refs[3].split("|")[0]
+
+        doc.rewrite_paragraph(ref, "Brand new text.")
+
+        vis = doc.get_visible_text()
+        assert "Brand new text." in vis
+
+        revisions = doc.list_revisions()
+        ins_revs = [r for r in revisions if r.type == "insertion"]
+        assert len(ins_revs) > 0
+
+    def test_rewrite_to_empty(self, rewrite_doc):
+        """Text to empty string — all deleted."""
+        doc, _ = rewrite_doc
+        refs = doc.list_paragraphs()
+        ref = refs[2].split("|")[0]
+
+        original = "The report includes findings from the committee investigation."
+        doc.rewrite_paragraph(ref, "")
+
+        vis = doc.get_visible_text()
+        assert original not in vis
+
+        revisions = doc.list_revisions()
+        del_revs = [r for r in revisions if r.type == "deletion"]
+        assert len(del_revs) > 0
+
+    def test_formatting_preserved(self, bold_doc):
+        """Bold formatting is inherited by inserted text."""
+        doc, _ = bold_doc
+        refs = doc.list_paragraphs()
+        ref = refs[0].split("|")[0]
+
+        doc.rewrite_paragraph(ref, "The bold board meets today.")
+
+        # Check that inserted text has bold rPr
+        revisions = doc.list_revisions()
+        ins_revs = [r for r in revisions if r.type == "insertion"]
+        assert len(ins_revs) > 0
+
+        # Verify the w:ins element contains w:b in rPr
+        editor = doc._document_editor
+        for ins_elem in editor.dom.getElementsByTagName("w:ins"):
+            rPr_elems = ins_elem.getElementsByTagName("w:rPr")
+            if rPr_elems:
+                b_elems = rPr_elems[0].getElementsByTagName("w:b")
+                assert len(b_elems) > 0, "Inserted text should inherit bold formatting"

--- a/tests/test_rewrite_paragraph.py
+++ b/tests/test_rewrite_paragraph.py
@@ -354,6 +354,243 @@ class TestRewriteDuplicateText:
         assert any("a" == t.strip() for t in ins_texts)
 
 
+def _make_doc_with_paragraphs(paragraphs: list[str]):
+    """Helper: build a document with specific paragraph texts. Returns (doc, tmp_dir)."""
+    test_data = Path(__file__).parent / "test_data" / "simple.docx"
+    tmp = tempfile.mkdtemp(prefix="rewrite_stress_")
+    dest = Path(tmp) / "test.docx"
+    shutil.copy(test_data, dest)
+
+    doc = Document.open(dest)
+    doc.accept_all()
+    doc.save()
+    doc.close()
+
+    doc = Document.open(dest, force_recreate=True)
+    editor = doc._document_editor
+    body = editor.dom.getElementsByTagName("w:body")[0]
+
+    for p in list(editor.dom.getElementsByTagName("w:p")):
+        if p.parentNode == body:
+            body.removeChild(p)
+
+    sect_pr = editor.dom.getElementsByTagName("w:sectPr")
+    insert_before = sect_pr[0] if sect_pr else None
+
+    for text in paragraphs:
+        if text:
+            p_xml = f'<w:p><w:r><w:t xml:space="preserve">{text}</w:t></w:r></w:p>'
+        else:
+            p_xml = "<w:p/>"
+        nodes = editor._parse_fragment(p_xml)
+        for node in nodes:
+            if insert_before:
+                body.insertBefore(node, insert_before)
+            else:
+                body.appendChild(node)
+
+    editor.save()
+    save_path = doc.save()
+    doc.close()
+
+    doc = Document.open(save_path, force_recreate=True)
+    return doc, Path(tmp)
+
+
+class TestRewriteStructuralEdits:
+    """Stress tests for structural edits where rewrite_paragraph is the right tool."""
+
+    def test_passive_to_active_voice(self):
+        """Passive→active voice conversion restructures clauses."""
+        doc, tmp = _make_doc_with_paragraphs(
+            ["The proposal was reviewed by the committee and was approved by the board."]
+        )
+        try:
+            refs = doc.list_paragraphs()
+            ref = refs[0].split("|")[0]
+
+            doc.rewrite_paragraph(
+                ref, "The committee reviewed the proposal and the board approved it."
+            )
+
+            vis = doc.get_visible_text()
+            assert "The committee reviewed the proposal and the board approved it." in vis
+
+            revisions = doc.list_revisions()
+            assert len(revisions) > 0
+            del_texts = [r.text for r in revisions if r.type == "deletion"]
+            ins_texts = [r.text for r in revisions if r.type == "insertion"]
+            assert len(del_texts) > 0
+            assert len(ins_texts) > 0
+        finally:
+            doc.close()
+            shutil.rmtree(tmp, ignore_errors=True)
+
+    def test_reorder_list_items(self):
+        """Reordering items in a list produces correct tracked changes."""
+        doc, tmp = _make_doc_with_paragraphs(
+            ["Deliverables include the final report, executive summary, and presentation slides."]
+        )
+        try:
+            refs = doc.list_paragraphs()
+            ref = refs[0].split("|")[0]
+
+            doc.rewrite_paragraph(
+                ref,
+                "Deliverables include the presentation slides, final report, and executive summary.",
+            )
+
+            vis = doc.get_visible_text()
+            assert "presentation slides, final report, and executive summary" in vis
+
+            revisions = doc.list_revisions()
+            assert len(revisions) > 0
+        finally:
+            doc.close()
+            shutil.rmtree(tmp, ignore_errors=True)
+
+    def test_full_sentence_rephrasing(self):
+        """Complete rephrasing produces tracked changes for restructured sentence."""
+        doc, tmp = _make_doc_with_paragraphs(
+            ["The committee recommends that the project timeline be extended by three months to allow for additional stakeholder consultation and review."]
+        )
+        try:
+            refs = doc.list_paragraphs()
+            ref = refs[0].split("|")[0]
+
+            doc.rewrite_paragraph(
+                ref,
+                "The board has approved a three-month extension for further stakeholder review.",
+            )
+
+            vis = doc.get_visible_text()
+            assert "The board has approved a three-month extension" in vis
+
+            revisions = doc.list_revisions()
+            del_texts = [r.text for r in revisions if r.type == "deletion"]
+            ins_texts = [r.text for r in revisions if r.type == "insertion"]
+            assert len(del_texts) > 0
+            assert len(ins_texts) > 0
+        finally:
+            doc.close()
+            shutil.rmtree(tmp, ignore_errors=True)
+
+    def test_prose_tightening(self):
+        """Removing filler words (multiple independent deletions)."""
+        doc, tmp = _make_doc_with_paragraphs(
+            ["We need to ensure that all stakeholders are informed and that all risks are mitigated."]
+        )
+        try:
+            refs = doc.list_paragraphs()
+            ref = refs[0].split("|")[0]
+
+            doc.rewrite_paragraph(
+                ref,
+                "We need to ensure all stakeholders are informed and all risks mitigated.",
+            )
+
+            vis = doc.get_visible_text()
+            assert "ensure all stakeholders" in vis
+            assert "and all risks mitigated" in vis
+
+            revisions = doc.list_revisions()
+            del_texts = [r.text for r in revisions if r.type == "deletion"]
+            # "that" should be deleted (twice) and "are " before "mitigated"
+            assert len(del_texts) >= 2
+        finally:
+            doc.close()
+            shutil.rmtree(tmp, ignore_errors=True)
+
+    def test_duplicate_phrase_different_changes(self):
+        """Different changes to different occurrences of the same phrase."""
+        doc, tmp = _make_doc_with_paragraphs(
+            ["The team will meet on Monday, the team will present on Wednesday, and the team will review on Friday."]
+        )
+        try:
+            refs = doc.list_paragraphs()
+            ref = refs[0].split("|")[0]
+
+            doc.rewrite_paragraph(
+                ref,
+                "The team will meet on Monday, management will present on Wednesday, and everyone will review on Friday.",
+            )
+
+            vis = doc.get_visible_text()
+            assert "management will present" in vis
+            assert "everyone will review" in vis
+            # First "The team will meet" unchanged
+            assert "The team will meet on Monday" in vis
+
+            revisions = doc.list_revisions()
+            del_texts = [r.text for r in revisions if r.type == "deletion"]
+            ins_texts = [r.text for r in revisions if r.type == "insertion"]
+            assert any("the team" in t.lower() for t in del_texts)
+            assert any("management" in t for t in ins_texts)
+            assert any("everyone" in t for t in ins_texts)
+        finally:
+            doc.close()
+            shutil.rmtree(tmp, ignore_errors=True)
+
+    def test_add_clause_and_change_value(self):
+        """Insert a clause in the middle while also changing a value elsewhere."""
+        doc, tmp = _make_doc_with_paragraphs(
+            ["The contract expires on December 31st."]
+        )
+        try:
+            refs = doc.list_paragraphs()
+            ref = refs[0].split("|")[0]
+
+            doc.rewrite_paragraph(
+                ref,
+                "The contract, unless renewed by either party, expires on January 15th.",
+            )
+
+            vis = doc.get_visible_text()
+            assert "unless renewed by either party" in vis
+            assert "January 15th" in vis
+
+            revisions = doc.list_revisions()
+            del_texts = [r.text for r in revisions if r.type == "deletion"]
+            ins_texts = [r.text for r in revisions if r.type == "insertion"]
+            assert any("December" in t for t in del_texts)
+            assert any("January" in t for t in ins_texts)
+            assert any("unless renewed" in t for t in ins_texts)
+        finally:
+            doc.close()
+            shutil.rmtree(tmp, ignore_errors=True)
+
+    def test_duplicate_manager_different_replacements(self):
+        """Two occurrences of 'manager' replaced with different words."""
+        doc, tmp = _make_doc_with_paragraphs(
+            ["The manager will review the report and the manager will approve the budget."]
+        )
+        try:
+            refs = doc.list_paragraphs()
+            ref = refs[0].split("|")[0]
+
+            doc.rewrite_paragraph(
+                ref,
+                "The director will review the findings and the supervisor will approve the budget.",
+            )
+
+            vis = doc.get_visible_text()
+            assert "director will review" in vis
+            assert "supervisor will approve" in vis
+            assert "findings" in vis
+
+            revisions = doc.list_revisions()
+            del_texts = [r.text for r in revisions if r.type == "deletion"]
+            ins_texts = [r.text for r in revisions if r.type == "insertion"]
+            assert any("manager" in t for t in del_texts)
+            assert any("director" in t for t in ins_texts)
+            assert any("supervisor" in t for t in ins_texts)
+            assert any("report" in t for t in del_texts)
+            assert any("findings" in t for t in ins_texts)
+        finally:
+            doc.close()
+            shutil.rmtree(tmp, ignore_errors=True)
+
+
 class TestRewriteWithTrackedChanges:
     def test_rewrite_after_prior_edit(self, rewrite_doc):
         """Rewriting a paragraph that already has tracked changes works."""

--- a/tests/test_rewrite_paragraph.py
+++ b/tests/test_rewrite_paragraph.py
@@ -264,9 +264,9 @@ class TestRewriteParagraph:
         editor = doc._document_editor
         for ins_elem in editor.dom.getElementsByTagName("w:ins"):
             rPr_elems = ins_elem.getElementsByTagName("w:rPr")
-            if rPr_elems:
-                b_elems = rPr_elems[0].getElementsByTagName("w:b")
-                assert len(b_elems) > 0, "Inserted text should inherit bold formatting"
+            assert len(rPr_elems) > 0, "Inserted run should have rPr"
+            b_elems = rPr_elems[0].getElementsByTagName("w:b")
+            assert len(b_elems) > 0, "Inserted text should inherit bold formatting"
 
 
 class TestRewriteDuplicateText:

--- a/tests/test_rewrite_paragraph.py
+++ b/tests/test_rewrite_paragraph.py
@@ -834,3 +834,269 @@ class TestBatchRewrite:
         doc, _ = rewrite_doc
         doc.batch_rewrite([])
         assert len(doc.list_revisions()) == 0
+
+
+class TestRewriteInsertEdgeCases:
+    """Coverage tests for _rewrite_insert_at edge cases."""
+
+    def test_rewrite_empty_paragraph(self):
+        """Rewriting an empty paragraph inserts all text as tracked insertion."""
+        doc, tmp = _make_doc_with_paragraphs([""])
+        try:
+            refs = doc.list_paragraphs()
+            ref = refs[0].split("|")[0]
+
+            doc.rewrite_paragraph(ref, "Brand new content.")
+
+            vis = doc.get_visible_text()
+            assert "Brand new content." in vis
+
+            revisions = doc.list_revisions()
+            ins_texts = [r.text for r in revisions if r.type == "insertion"]
+            assert any("Brand new content." in t for t in ins_texts)
+        finally:
+            doc.close()
+            shutil.rmtree(tmp, ignore_errors=True)
+
+    def test_rewrite_append_text_at_end(self):
+        """Rewriting to append text at end of paragraph covers insert-at-end path."""
+        doc, tmp = _make_doc_with_paragraphs(["Hello world."])
+        try:
+            refs = doc.list_paragraphs()
+            ref = refs[0].split("|")[0]
+
+            # Add text at the end — triggers insert opcode at end position
+            doc.rewrite_paragraph(ref, "Hello world. Goodbye world.")
+
+            vis = doc.get_visible_text()
+            assert "Hello world." in vis
+            assert "Goodbye world." in vis
+
+            revisions = doc.list_revisions()
+            ins_texts = [r.text for r in revisions if r.type == "insertion"]
+            assert any("Goodbye" in t for t in ins_texts)
+        finally:
+            doc.close()
+            shutil.rmtree(tmp, ignore_errors=True)
+
+    def test_rewrite_prepend_text_at_start(self):
+        """Rewriting to prepend text at start covers insert-at-position path."""
+        doc, tmp = _make_doc_with_paragraphs(["The contract is valid."])
+        try:
+            refs = doc.list_paragraphs()
+            ref = refs[0].split("|")[0]
+
+            doc.rewrite_paragraph(ref, "IMPORTANT: The contract is valid.")
+
+            vis = doc.get_visible_text()
+            assert "IMPORTANT:" in vis
+            assert "The contract is valid." in vis
+        finally:
+            doc.close()
+            shutil.rmtree(tmp, ignore_errors=True)
+
+    def test_rewrite_insert_into_tracked_insertion(self):
+        """Inserting text into a paragraph with prior tracked insertion covers w:ins splice path."""
+        doc, tmp = _make_doc_with_paragraphs(["The quick fox."])
+        try:
+            refs = doc.list_paragraphs()
+            ref = refs[0].split("|")[0]
+
+            # First: surgical insert creates a <w:ins> node
+            new_ref = doc.insert_after("quick", " brown", paragraph=ref)
+
+            # Now rewrite to add more text inside the same area
+            # The word "brown" is inside <w:ins>, so rewriting to change it
+            # will exercise the w:ins splice path
+            doc.rewrite_paragraph(new_ref, "The quick brown and spotted fox.")
+
+            vis = doc.get_visible_text()
+            assert "spotted" in vis
+        finally:
+            doc.close()
+            shutil.rmtree(tmp, ignore_errors=True)
+
+    def test_rewrite_append_after_tracked_insertion(self):
+        """Appending after tracked insertion at paragraph end covers end-of-ins path."""
+        doc, tmp = _make_doc_with_paragraphs(["Start."])
+        try:
+            refs = doc.list_paragraphs()
+            ref = refs[0].split("|")[0]
+
+            # Insert at end creates <w:ins> at paragraph end
+            new_ref = doc.insert_after("Start.", " Middle.", paragraph=ref)
+
+            # Rewrite to append more — last char is inside <w:ins>
+            doc.rewrite_paragraph(new_ref, "Start. Middle. End.")
+
+            vis = doc.get_visible_text()
+            assert "End." in vis
+        finally:
+            doc.close()
+            shutil.rmtree(tmp, ignore_errors=True)
+
+    def test_rewrite_insert_mid_word(self):
+        """Insert text in the middle of a word to cover run-splitting path."""
+        doc, tmp = _make_doc_with_paragraphs(["The contract expires soon."])
+        try:
+            refs = doc.list_paragraphs()
+            ref = refs[0].split("|")[0]
+
+            # "expires" → "will expire" — changes the word at a non-boundary position
+            doc.rewrite_paragraph(ref, "The contract will expire soon.")
+
+            vis = doc.get_visible_text()
+            assert "will expire" in vis
+        finally:
+            doc.close()
+            shutil.rmtree(tmp, ignore_errors=True)
+
+    def test_rewrite_append_after_ins_at_end(self):
+        """Append text when the paragraph ends with a <w:ins> node.
+
+        Covers _rewrite_insert_at lines 344-349: insert at end inside w:ins.
+        """
+        doc, tmp = _make_doc_with_paragraphs(["Hello"])
+        try:
+            refs = doc.list_paragraphs()
+            ref = refs[0].split("|")[0]
+
+            # Insert " world" at end — creates <w:ins> at paragraph end
+            new_ref = doc.insert_after("Hello", " world", paragraph=ref)
+
+            # Rewrite keeping existing text and appending " today"
+            # " world" is inside <w:ins>, so appending triggers the
+            # ins_ancestor splice at line 344
+            doc.rewrite_paragraph(new_ref, "Hello world today")
+
+            vis = doc.get_visible_text()
+            assert "today" in vis
+        finally:
+            doc.close()
+            shutil.rmtree(tmp, ignore_errors=True)
+
+    def test_rewrite_modify_within_ins_node(self):
+        """Modify text inside a <w:ins> node mid-paragraph.
+
+        Covers _rewrite_insert_at lines 362-368: insert at mid-position inside w:ins.
+        """
+        doc, tmp = _make_doc_with_paragraphs(["start end"])
+        try:
+            refs = doc.list_paragraphs()
+            ref = refs[0].split("|")[0]
+
+            # Insert " alpha beta" after "start" — creates <w:ins> mid-paragraph
+            new_ref = doc.insert_after("start", " alpha beta", paragraph=ref)
+            # Visible text: "start alpha beta end"
+            # "alpha beta" is inside <w:ins>
+
+            # Rewrite to add a word between "alpha" and "beta"
+            # The insert opcode for "gamma " should land inside <w:ins>
+            doc.rewrite_paragraph(new_ref, "start alpha gamma beta end")
+
+            vis = doc.get_visible_text()
+            assert "gamma" in vis
+        finally:
+            doc.close()
+            shutil.rmtree(tmp, ignore_errors=True)
+
+    def test_rewrite_empty_paragraph_with_formatting(self):
+        """Rewriting empty paragraph with formatted run inherits rPr.
+
+        Covers _rewrite_insert_at lines 322-325: empty paragraph with w:rPr.
+        """
+        test_data = Path(__file__).parent / "test_data" / "simple.docx"
+        tmp = tempfile.mkdtemp(prefix="rewrite_fmt_")
+        dest = Path(tmp) / "test.docx"
+        shutil.copy(test_data, dest)
+
+        doc = Document.open(dest)
+        doc.accept_all()
+        doc.save()
+        doc.close()
+
+        doc = Document.open(dest, force_recreate=True)
+        editor = doc._document_editor
+        body = editor.dom.getElementsByTagName("w:body")[0]
+
+        for p in list(editor.dom.getElementsByTagName("w:p")):
+            if p.parentNode == body:
+                body.removeChild(p)
+
+        # Create a paragraph with a run that has rPr but empty text
+        p_xml = "<w:p><w:r><w:rPr><w:b/></w:rPr><w:t></w:t></w:r></w:p>"
+        sect_prs = editor.dom.getElementsByTagName("w:sectPr")
+        insert_before = sect_prs[0] if sect_prs else None
+        nodes = editor._parse_fragment(p_xml)
+        for node in nodes:
+            if insert_before:
+                body.insertBefore(node, insert_before)
+            else:
+                body.appendChild(node)
+
+        editor.save()
+        save_path = doc.save()
+        doc.close()
+
+        doc = Document.open(save_path, force_recreate=True)
+        try:
+            refs = doc.list_paragraphs()
+            ref = refs[0].split("|")[0]
+            doc.rewrite_paragraph(ref, "Bold text here.")
+            vis = doc.get_visible_text()
+            assert "Bold text here." in vis
+        finally:
+            doc.close()
+            shutil.rmtree(tmp, ignore_errors=True)
+
+    def test_rewrite_empty_paragraph_with_sectpr(self):
+        """Rewriting an empty paragraph that has w:sectPr covers insert-before-sectPr path.
+
+        Covers _rewrite_insert_at line 331.
+        """
+        test_data = Path(__file__).parent / "test_data" / "simple.docx"
+        tmp = tempfile.mkdtemp(prefix="rewrite_sectpr_")
+        dest = Path(tmp) / "test.docx"
+        shutil.copy(test_data, dest)
+
+        doc = Document.open(dest)
+        doc.accept_all()
+        doc.save()
+        doc.close()
+
+        doc = Document.open(dest, force_recreate=True)
+        editor = doc._document_editor
+        body = editor.dom.getElementsByTagName("w:body")[0]
+
+        # Remove all paragraphs but keep sectPr
+        for p in list(editor.dom.getElementsByTagName("w:p")):
+            if p.parentNode == body:
+                body.removeChild(p)
+
+        # Add an empty paragraph that contains a w:sectPr child
+        sect_prs = editor.dom.getElementsByTagName("w:sectPr")
+        if sect_prs:
+            sect_pr = sect_prs[0]
+            # Move sectPr inside a new empty paragraph
+            sect_pr.parentNode.removeChild(sect_pr)
+            p_xml = "<w:p/>"
+            nodes = editor._parse_fragment(p_xml)
+            for node in nodes:
+                body.appendChild(node)
+            p_elem = editor.dom.getElementsByTagName("w:p")[0]
+            p_elem.appendChild(sect_pr)
+
+        editor.save()
+        save_path = doc.save()
+        doc.close()
+
+        doc = Document.open(save_path, force_recreate=True)
+        try:
+            refs = doc.list_paragraphs()
+            ref = refs[0].split("|")[0]
+            doc.rewrite_paragraph(ref, "New content.")
+            vis = doc.get_visible_text()
+            assert "New content." in vis
+        finally:
+            doc.close()
+            shutil.rmtree(tmp, ignore_errors=True)

--- a/tests/test_rewrite_paragraph.py
+++ b/tests/test_rewrite_paragraph.py
@@ -402,16 +402,14 @@ class TestRewriteStructuralEdits:
 
     def test_passive_to_active_voice(self):
         """Passive→active voice conversion restructures clauses."""
-        doc, tmp = _make_doc_with_paragraphs(
-            ["The proposal was reviewed by the committee and was approved by the board."]
-        )
+        doc, tmp = _make_doc_with_paragraphs([
+            "The proposal was reviewed by the committee and was approved by the board."
+        ])
         try:
             refs = doc.list_paragraphs()
             ref = refs[0].split("|")[0]
 
-            doc.rewrite_paragraph(
-                ref, "The committee reviewed the proposal and the board approved it."
-            )
+            doc.rewrite_paragraph(ref, "The committee reviewed the proposal and the board approved it.")
 
             vis = doc.get_visible_text()
             assert "The committee reviewed the proposal and the board approved it." in vis
@@ -428,9 +426,9 @@ class TestRewriteStructuralEdits:
 
     def test_reorder_list_items(self):
         """Reordering items in a list produces correct tracked changes."""
-        doc, tmp = _make_doc_with_paragraphs(
-            ["Deliverables include the final report, executive summary, and presentation slides."]
-        )
+        doc, tmp = _make_doc_with_paragraphs([
+            "Deliverables include the final report, executive summary, and presentation slides."
+        ])
         try:
             refs = doc.list_paragraphs()
             ref = refs[0].split("|")[0]
@@ -451,9 +449,10 @@ class TestRewriteStructuralEdits:
 
     def test_full_sentence_rephrasing(self):
         """Complete rephrasing produces tracked changes for restructured sentence."""
-        doc, tmp = _make_doc_with_paragraphs(
-            ["The committee recommends that the project timeline be extended by three months to allow for additional stakeholder consultation and review."]
-        )
+        doc, tmp = _make_doc_with_paragraphs([
+            "The committee recommends that the project timeline be extended by three months"
+            " to allow for additional stakeholder consultation and review."
+        ])
         try:
             refs = doc.list_paragraphs()
             ref = refs[0].split("|")[0]
@@ -477,9 +476,9 @@ class TestRewriteStructuralEdits:
 
     def test_prose_tightening(self):
         """Removing filler words (multiple independent deletions)."""
-        doc, tmp = _make_doc_with_paragraphs(
-            ["We need to ensure that all stakeholders are informed and that all risks are mitigated."]
-        )
+        doc, tmp = _make_doc_with_paragraphs([
+            "We need to ensure that all stakeholders are informed and that all risks are mitigated."
+        ])
         try:
             refs = doc.list_paragraphs()
             ref = refs[0].split("|")[0]
@@ -503,16 +502,17 @@ class TestRewriteStructuralEdits:
 
     def test_duplicate_phrase_different_changes(self):
         """Different changes to different occurrences of the same phrase."""
-        doc, tmp = _make_doc_with_paragraphs(
-            ["The team will meet on Monday, the team will present on Wednesday, and the team will review on Friday."]
-        )
+        doc, tmp = _make_doc_with_paragraphs([
+            "The team will meet on Monday, the team will present on Wednesday, and the team will review on Friday."
+        ])
         try:
             refs = doc.list_paragraphs()
             ref = refs[0].split("|")[0]
 
             doc.rewrite_paragraph(
                 ref,
-                "The team will meet on Monday, management will present on Wednesday, and everyone will review on Friday.",
+                "The team will meet on Monday, management will present on Wednesday,"
+                " and everyone will review on Friday.",
             )
 
             vis = doc.get_visible_text()
@@ -533,9 +533,7 @@ class TestRewriteStructuralEdits:
 
     def test_add_clause_and_change_value(self):
         """Insert a clause in the middle while also changing a value elsewhere."""
-        doc, tmp = _make_doc_with_paragraphs(
-            ["The contract expires on December 31st."]
-        )
+        doc, tmp = _make_doc_with_paragraphs(["The contract expires on December 31st."])
         try:
             refs = doc.list_paragraphs()
             ref = refs[0].split("|")[0]
@@ -561,9 +559,9 @@ class TestRewriteStructuralEdits:
 
     def test_duplicate_manager_different_replacements(self):
         """Two occurrences of 'manager' replaced with different words."""
-        doc, tmp = _make_doc_with_paragraphs(
-            ["The manager will review the report and the manager will approve the budget."]
-        )
+        doc, tmp = _make_doc_with_paragraphs([
+            "The manager will review the report and the manager will approve the budget."
+        ])
         try:
             refs = doc.list_paragraphs()
             ref = refs[0].split("|")[0]
@@ -719,7 +717,7 @@ class TestEditReturnsRef:
         # Chain 3 edits on the same paragraph, using returned ref each time
         r1 = doc.replace("committee", "board", paragraph=ref)
         r2 = doc.replace("shall", "must", paragraph=r1)
-        r3 = doc.replace("annual", "quarterly", paragraph=r2)
+        doc.replace("annual", "quarterly", paragraph=r2)
 
         vis = doc.get_visible_text()
         assert "board" in vis

--- a/tests/test_rewrite_paragraph.py
+++ b/tests/test_rewrite_paragraph.py
@@ -269,6 +269,66 @@ class TestRewriteParagraph:
                 assert len(b_elems) > 0, "Inserted text should inherit bold formatting"
 
 
+class TestRewriteWithTrackedChanges:
+    def test_rewrite_after_prior_edit(self, rewrite_doc):
+        """Rewriting a paragraph that already has tracked changes works."""
+        doc, _ = rewrite_doc
+        refs = doc.list_paragraphs()
+        ref1 = refs[0].split("|")[0]
+
+        # Make a surgical edit first (creates tracked insertion/deletion)
+        doc.replace("committee", "board", paragraph=ref1)
+
+        # Now rewrite the paragraph using fresh hash
+        refs2 = doc.list_paragraphs()
+        ref2 = refs2[0].split("|")[0]
+        doc.rewrite_paragraph(ref2, "The board shall review and approve the annual budget proposal.")
+
+        vis = doc.get_visible_text()
+        assert "approve" in vis
+        assert "proceed with" not in vis
+
+    def test_save_and_reopen(self, rewrite_doc):
+        """Document can be saved and reopened after rewrite."""
+        doc, tmp = rewrite_doc
+        refs = doc.list_paragraphs()
+        ref = refs[0].split("|")[0]
+
+        doc.rewrite_paragraph(ref, "Completely rewritten paragraph text.")
+        save_path = doc.save()
+        doc.close()
+
+        # Reopen and verify
+        doc2 = Document.open(save_path, force_recreate=True)
+        vis = doc2.get_visible_text()
+        assert "Completely rewritten paragraph text." in vis
+
+        # Verify revisions are preserved
+        revisions = doc2.list_revisions()
+        assert len(revisions) > 0
+        doc2.close()
+
+    def test_rewrite_after_batch(self, rewrite_doc):
+        """Individual rewrite works after batch rewrite."""
+        doc, _ = rewrite_doc
+        refs = doc.list_paragraphs()
+
+        doc.batch_rewrite([
+            (refs[0].split("|")[0], "First changed."),
+            (refs[2].split("|")[0], "Third changed."),
+        ])
+
+        # Now do another rewrite on a different paragraph
+        refs2 = doc.list_paragraphs()
+        ref = refs2[4].split("|")[0]
+        doc.rewrite_paragraph(ref, "Fifth also changed.")
+
+        vis = doc.get_visible_text()
+        assert "First changed." in vis
+        assert "Third changed." in vis
+        assert "Fifth also changed." in vis
+
+
 class TestBatchRewrite:
     def test_batch_multiple_paragraphs(self, rewrite_doc):
         """Batch rewrite of multiple paragraphs succeeds."""

--- a/tests/test_rewrite_paragraph.py
+++ b/tests/test_rewrite_paragraph.py
@@ -591,6 +591,140 @@ class TestRewriteStructuralEdits:
             shutil.rmtree(tmp, ignore_errors=True)
 
 
+class TestEditResultRef:
+    """Tests for edit methods returning new paragraph refs."""
+
+    def test_replace_returns_ref(self, rewrite_doc):
+        """replace() returns EditResult with .ref for follow-up edits."""
+        doc, _ = rewrite_doc
+        refs = doc.list_paragraphs()
+        ref = refs[0].split("|")[0]
+
+        result = doc.replace("committee", "board", paragraph=ref)
+
+        # .ref is a fresh paragraph reference
+        assert result.ref.startswith("P1#")
+        assert result.ref != ref  # hash changed
+
+        # Can use .ref for a follow-up edit without list_paragraphs()
+        result2 = doc.replace("board", "council", paragraph=result.ref)
+        assert result2.ref.startswith("P1#")
+        assert result2.ref != result.ref  # hash changed again
+
+        vis = doc.get_visible_text()
+        assert "council" in vis
+
+    def test_delete_returns_ref(self, rewrite_doc):
+        """delete() returns EditResult with .ref."""
+        doc, _ = rewrite_doc
+        refs = doc.list_paragraphs()
+        ref = refs[0].split("|")[0]
+
+        result = doc.delete("committee", paragraph=ref)
+        assert result.ref.startswith("P1#")
+        assert result.ref != ref
+
+    def test_insert_after_returns_ref(self, rewrite_doc):
+        """insert_after() returns EditResult with .ref."""
+        doc, _ = rewrite_doc
+        refs = doc.list_paragraphs()
+        ref = refs[0].split("|")[0]
+
+        result = doc.insert_after("committee", " meeting", paragraph=ref)
+        assert result.ref.startswith("P1#")
+        assert result.ref != ref
+
+    def test_insert_before_returns_ref(self, rewrite_doc):
+        """insert_before() returns EditResult with .ref."""
+        doc, _ = rewrite_doc
+        refs = doc.list_paragraphs()
+        ref = refs[0].split("|")[0]
+
+        result = doc.insert_before("committee", "special ", paragraph=ref)
+        assert result.ref.startswith("P1#")
+        assert result.ref != ref
+
+    def test_rewrite_returns_ref(self, rewrite_doc):
+        """rewrite_paragraph() returns new ref string."""
+        doc, _ = rewrite_doc
+        refs = doc.list_paragraphs()
+        ref = refs[0].split("|")[0]
+
+        new_ref = doc.rewrite_paragraph(ref, "Completely new text.")
+        assert new_ref.startswith("P1#")
+        assert new_ref != ref
+
+        # Can chain with another rewrite
+        new_ref2 = doc.rewrite_paragraph(new_ref, "Even newer text.")
+        assert new_ref2.startswith("P1#")
+        assert new_ref2 != new_ref
+
+        vis = doc.get_visible_text()
+        assert "Even newer text." in vis
+
+    def test_batch_rewrite_returns_refs(self, rewrite_doc):
+        """batch_rewrite() returns list of new refs in input order."""
+        doc, _ = rewrite_doc
+        refs = doc.list_paragraphs()
+
+        new_refs = doc.batch_rewrite([
+            (refs[0].split("|")[0], "First changed."),
+            (refs[2].split("|")[0], "Third changed."),
+        ])
+
+        assert len(new_refs) == 2
+        assert new_refs[0].startswith("P1#")
+        assert new_refs[1].startswith("P3#")
+
+    def test_batch_edit_returns_refs(self, rewrite_doc):
+        """batch_edit() returns list of EditResults with .ref."""
+        from docx_editor import EditOperation
+
+        doc, _ = rewrite_doc
+        refs = doc.list_paragraphs()
+
+        results = doc.batch_edit([
+            EditOperation(action="replace", find="committee", replace_with="board", paragraph=refs[0].split("|")[0]),
+            EditOperation(action="replace", find="quarterly", replace_with="monthly", paragraph=refs[1].split("|")[0]),
+        ])
+
+        assert len(results) == 2
+        assert results[0].ref.startswith("P1#")
+        assert results[1].ref.startswith("P2#")
+
+    def test_edit_result_backwards_compatible(self, rewrite_doc):
+        """EditResult works as int for accept/reject operations."""
+        doc, _ = rewrite_doc
+        refs = doc.list_paragraphs()
+        ref = refs[0].split("|")[0]
+
+        result = doc.insert_after("committee", " NEW", paragraph=ref)
+
+        # Acts as int
+        assert isinstance(result, int)
+        assert int(result) >= 0
+
+        # Can be used for accept/reject
+        accepted = doc.accept_revision(result)
+        assert accepted is True
+
+    def test_sequential_edits_without_list_paragraphs(self, rewrite_doc):
+        """Chain multiple edits using .ref without ever calling list_paragraphs() again."""
+        doc, _ = rewrite_doc
+        refs = doc.list_paragraphs()
+        ref = refs[0].split("|")[0]
+
+        # Chain 3 edits on the same paragraph, using .ref each time
+        r1 = doc.replace("committee", "board", paragraph=ref)
+        r2 = doc.replace("shall", "must", paragraph=r1.ref)
+        r3 = doc.replace("annual", "quarterly", paragraph=r2.ref)
+
+        vis = doc.get_visible_text()
+        assert "board" in vis
+        assert "must" in vis
+        assert "quarterly" in vis
+
+
 class TestRewriteWithTrackedChanges:
     def test_rewrite_after_prior_edit(self, rewrite_doc):
         """Rewriting a paragraph that already has tracked changes works."""

--- a/tests/test_track_changes.py
+++ b/tests/test_track_changes.py
@@ -29,15 +29,16 @@ class TestTrackedReplace:
 
         doc.close()
 
-    def test_replace_returns_change_id(self, clean_workspace):
-        """Test that replace returns a valid change ID."""
+    def test_replace_returns_new_ref(self, clean_workspace):
+        """Test that replace returns a new paragraph reference."""
         doc = Document.open(clean_workspace)
 
         try:
             ref = find_ref(doc, "the")
-            change_id = doc.replace("the", "THE", paragraph=ref)
-            assert isinstance(change_id, int)
-            assert change_id >= 0
+            new_ref = doc.replace("the", "THE", paragraph=ref)
+            assert isinstance(new_ref, str)
+            assert new_ref.startswith("P")
+            assert "#" in new_ref
         except TextNotFoundError:
             pytest.skip("Test text not found in document")
 
@@ -63,9 +64,9 @@ class TestTrackedDeletion:
 
         try:
             ref = find_ref(doc, "the")
-            change_id = doc.delete("the", paragraph=ref)
-            assert isinstance(change_id, int)
-            assert change_id >= 0
+            new_ref = doc.delete("the", paragraph=ref)
+            assert isinstance(new_ref, str)
+            assert new_ref.startswith("P")
         except TextNotFoundError:
             pytest.skip("Test text not found in document")
 
@@ -91,9 +92,9 @@ class TestTrackedInsertion:
 
         try:
             ref = find_ref(doc, "the")
-            change_id = doc.insert_after("the", " NEW TEXT", paragraph=ref)
-            assert isinstance(change_id, int)
-            assert change_id >= 0
+            new_ref = doc.insert_after("the", " NEW TEXT", paragraph=ref)
+            assert isinstance(new_ref, str)
+            assert new_ref.startswith("P")
         except TextNotFoundError:
             pytest.skip("Anchor text not found in document")
 
@@ -105,9 +106,9 @@ class TestTrackedInsertion:
 
         try:
             ref = find_ref(doc, "the")
-            change_id = doc.insert_before("the", "BEFORE ", paragraph=ref)
-            assert isinstance(change_id, int)
-            assert change_id >= 0
+            new_ref = doc.insert_before("the", "BEFORE ", paragraph=ref)
+            assert isinstance(new_ref, str)
+            assert new_ref.startswith("P")
         except TextNotFoundError:
             pytest.skip("Anchor text not found in document")
 
@@ -180,9 +181,12 @@ class TestRevisionAcceptReject:
 
         try:
             ref = find_ref(doc, "the")
-            change_id = doc.delete("the", paragraph=ref)
+            doc.delete("the", paragraph=ref)
         except TextNotFoundError:
             pytest.skip("Test text not found in document")
+
+        revisions = doc.list_revisions()
+        change_id = revisions[-1].id
 
         result = doc.accept_revision(change_id)
         assert result is True
@@ -200,9 +204,12 @@ class TestRevisionAcceptReject:
 
         try:
             ref = find_ref(doc, "the")
-            change_id = doc.delete("the", paragraph=ref)
+            doc.delete("the", paragraph=ref)
         except TextNotFoundError:
             pytest.skip("Test text not found in document")
+
+        revisions = doc.list_revisions()
+        change_id = revisions[-1].id
 
         result = doc.reject_revision(change_id)
         assert result is True
@@ -293,9 +300,8 @@ class TestOccurrenceParameter:
         # 'over' appears once. Use occurrence=0 on the right paragraph
         # to verify occurrence param is accepted.
         ref = find_ref(doc, "lazy dog")
-        change_id = doc.replace("the", "THE", paragraph=ref, occurrence=0)
-        assert isinstance(change_id, int)
-        assert change_id >= 0
+        new_ref = doc.replace("the", "THE", paragraph=ref, occurrence=0)
+        assert isinstance(new_ref, str)
 
         doc.close()
 
@@ -315,9 +321,8 @@ class TestOccurrenceParameter:
         doc = Document.open(clean_workspace)
 
         ref = find_ref(doc, "lazy dog")
-        change_id = doc.delete("the", paragraph=ref, occurrence=0)
-        assert isinstance(change_id, int)
-        assert change_id >= 0
+        new_ref = doc.delete("the", paragraph=ref, occurrence=0)
+        assert isinstance(new_ref, str)
 
         doc.close()
 
@@ -326,8 +331,8 @@ class TestOccurrenceParameter:
         doc = Document.open(clean_workspace)
 
         ref = find_ref(doc, "lazy dog")
-        change_id = doc.insert_after("the", " INSERTED", paragraph=ref, occurrence=0)
-        assert isinstance(change_id, int)
+        new_ref = doc.insert_after("the", " INSERTED", paragraph=ref, occurrence=0)
+        assert isinstance(new_ref, str)
 
         doc.close()
 
@@ -336,8 +341,8 @@ class TestOccurrenceParameter:
         doc = Document.open(clean_workspace)
 
         ref = find_ref(doc, "lazy dog")
-        change_id = doc.insert_before("the", "INSERTED ", paragraph=ref, occurrence=0)
-        assert isinstance(change_id, int)
+        new_ref = doc.insert_before("the", "INSERTED ", paragraph=ref, occurrence=0)
+        assert isinstance(new_ref, str)
 
         doc.close()
 
@@ -398,9 +403,8 @@ class TestRevisionManagerDirectAccess:
 
         # "quick" is in the middle of "The quick brown fox..."
         ref = find_ref(doc, "quick")
-        change_id = doc.replace("quick", "QUICK", paragraph=ref)
-        assert isinstance(change_id, int)
-        assert change_id >= 0
+        new_ref = doc.replace("quick", "QUICK", paragraph=ref)
+        assert isinstance(new_ref, str)
 
         doc.close()
 
@@ -410,8 +414,8 @@ class TestRevisionManagerDirectAccess:
 
         # Replace text - the document structure should be preserved
         ref = find_ref(doc, "Sample")
-        change_id = doc.replace("Sample", "SAMPLE", paragraph=ref)
-        assert change_id >= 0
+        new_ref = doc.replace("Sample", "SAMPLE", paragraph=ref)
+        assert isinstance(new_ref, str)
 
         doc.close()
 
@@ -421,9 +425,8 @@ class TestRevisionManagerDirectAccess:
 
         # "brown" is in the middle of "The quick brown fox..."
         ref = find_ref(doc, "brown")
-        change_id = doc.delete("brown", paragraph=ref)
-        assert isinstance(change_id, int)
-        assert change_id >= 0
+        new_ref = doc.delete("brown", paragraph=ref)
+        assert isinstance(new_ref, str)
 
         doc.close()
 
@@ -511,7 +514,10 @@ class TestAcceptRejectExtended:
         doc = Document.open(clean_workspace)
 
         ref = find_ref(doc, "fox")
-        change_id = doc.insert_after("fox", " NEW", paragraph=ref)
+        doc.insert_after("fox", " NEW", paragraph=ref)
+
+        revisions = doc.list_revisions()
+        change_id = revisions[-1].id
 
         result = doc.accept_revision(change_id)
         assert result is True
@@ -528,7 +534,10 @@ class TestAcceptRejectExtended:
         doc = Document.open(clean_workspace)
 
         ref = find_ref(doc, "quick")
-        change_id = doc.delete("quick", paragraph=ref)
+        doc.delete("quick", paragraph=ref)
+
+        revisions = doc.list_revisions()
+        change_id = revisions[-1].id
 
         result = doc.accept_revision(change_id)
         assert result is True
@@ -545,7 +554,10 @@ class TestAcceptRejectExtended:
         doc = Document.open(clean_workspace)
 
         ref = find_ref(doc, "fox")
-        change_id = doc.insert_after("fox", " REJECT_ME", paragraph=ref)
+        doc.insert_after("fox", " REJECT_ME", paragraph=ref)
+
+        revisions = doc.list_revisions()
+        change_id = revisions[-1].id
 
         result = doc.reject_revision(change_id)
         assert result is True
@@ -562,7 +574,10 @@ class TestAcceptRejectExtended:
         doc = Document.open(clean_workspace)
 
         ref = find_ref(doc, "brown")
-        change_id = doc.delete("brown", paragraph=ref)
+        doc.delete("brown", paragraph=ref)
+
+        revisions = doc.list_revisions()
+        change_id = revisions[-1].id
 
         result = doc.reject_revision(change_id)
         assert result is True
@@ -831,7 +846,10 @@ class TestRestoreDeletionEdgeCases:
 
         # Create a deletion
         ref = find_ref(doc, "lazy")
-        change_id = doc.delete("lazy", paragraph=ref)
+        doc.delete("lazy", paragraph=ref)
+
+        revisions = doc.list_revisions()
+        change_id = revisions[-1].id
 
         # Reject it to trigger _restore_deletion
         result = doc.reject_revision(change_id)
@@ -845,7 +863,10 @@ class TestRestoreDeletionEdgeCases:
 
         # Create a deletion
         ref = find_ref(doc, "dog")
-        change_id = doc.delete("dog", paragraph=ref)
+        doc.delete("dog", paragraph=ref)
+
+        revisions = doc.list_revisions()
+        change_id = revisions[-1].id
 
         # Reject it
         result = doc.reject_revision(change_id)

--- a/uv.lock
+++ b/uv.lock
@@ -295,7 +295,7 @@ wheels = [
 
 [[package]]
 name = "docx-editor"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "defusedxml" },


### PR DESCRIPTION
## Summary

- Add `rewrite_paragraph(ref, new_text)` — specify desired paragraph text, auto-generates fine-grained tracked changes via word-level diffing
- Add `batch_rewrite(rewrites)` — multi-paragraph rewrite with upfront hash validation
- **All edit methods now return the new paragraph ref as a plain `str`** — enables chaining edits without calling `list_paragraphs()` between them
- Position-aware matching to correctly handle paragraphs with duplicate text
- Formatting preservation: inserted text inherits run properties from adjacent runs

### Return value change

All edit methods (`replace`, `delete`, `insert_after`, `insert_before`, `batch_edit`) now return the new paragraph reference (`str`) instead of a change ID (`int`). This enables:

```python
r1 = doc.replace("30 days", "60 days", paragraph="P2#f3c1")
r2 = doc.replace("net", "gross", paragraph=r1)  # no list_paragraphs() needed
```

Change IDs for accept/reject are available via `doc.list_revisions()`.

### When to use rewrite vs surgical methods

**Default: always use surgical methods** (replace, delete, insert_after, insert_before, batch_edit).

**Use rewrite_paragraph() only when the edit cannot be decomposed into independent find-replace pairs:**
- Sentence restructuring (e.g., passive to active voice)
- Reordering words, items, or clauses
- Intertwined changes that overlap or depend on each other

## Test plan

- 463 tests pass (36 new in test_rewrite_paragraph.py)
- Stress tests: passive-to-active voice, list reordering, full rephrasing, prose tightening, duplicate phrases
- LLM workflow validation: 10/10 subagent scenarios for str return API
- LLM decision criteria: 10/10 subagent scenarios for rewrite vs surgical classification