### PR TITLE
chore: bump plugin version to 0.2.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "docx-editor",
   "description": "Comprehensive document creation, editing, and analysis with support for tracked changes, comments, formatting preservation, and text extraction",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "author": {
     "name": "pablospe"
   },


### PR DESCRIPTION
## Summary

- Update `.claude-plugin/plugin.json` version from `0.1.1` to `0.2.0` to match the release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin version to 0.2.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->