### PR TITLE
fix: exclude workspace meta.json from packed .docx output (closes #8)

### DIFF
--- a/docx_editor/ooxml/pack.py
+++ b/docx_editor/ooxml/pack.py
@@ -9,6 +9,12 @@ from pathlib import Path
 
 import defusedxml.minidom
 
+# Workspace-root paths that must not be packed into the output.
+# meta.json is workspace bookkeeping (see Workspace.META_FILE); packing it makes
+# Word flag the document as "unreadable content" on open. Paths are workspace-root
+# relative — a hypothetical subpart literally named "meta.json" is unaffected.
+EXCLUDED_PATHS = {Path("meta.json")}
+
 
 def pack_document(input_dir: str | Path, output_file: str | Path, validate: bool = False) -> bool:
     """Pack a directory into an Office file (.docx/.pptx/.xlsx).
@@ -46,8 +52,12 @@ def pack_document(input_dir: str | Path, output_file: str | Path, validate: bool
         output_file.parent.mkdir(parents=True, exist_ok=True)
         with zipfile.ZipFile(output_file, "w", zipfile.ZIP_DEFLATED) as zf:
             for f in temp_content_dir.rglob("*"):
-                if f.is_file():
-                    zf.write(f, f.relative_to(temp_content_dir))
+                if not f.is_file():
+                    continue
+                rel = f.relative_to(temp_content_dir)
+                if rel in EXCLUDED_PATHS:
+                    continue
+                zf.write(f, rel)
 
         # Validate if requested
         if validate:  # pragma: no cover

--- a/docx_editor/workspace.py
+++ b/docx_editor/workspace.py
@@ -32,6 +32,9 @@ class Workspace:
     """
 
     WORKSPACE_DIR = ".docx"
+    # If you rename META_FILE, also update EXCLUDED_PATHS in ooxml/pack.py —
+    # otherwise the renamed file will be packed into the .docx and Word will
+    # flag it as "unreadable content" (issue #8).
     META_FILE = "meta.json"
 
     meta: dict[str, Any]

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -1,5 +1,7 @@
 """Tests for the main Document class."""
 
+import zipfile
+
 import pytest
 from conftest import find_ref
 
@@ -64,6 +66,24 @@ class TestDocumentSave:
         assert clean_workspace.exists()  # Original unchanged
 
         doc.close()
+
+    def test_save_does_not_include_meta_json(self, clean_workspace, temp_dir):
+        """Regression for issue #8: meta.json must not be packed into output.
+
+        Word flags any non-OOXML entry in the ZIP as "unreadable content" on open.
+        Reproduces the issue end-to-end via Document.open + save.
+        """
+        doc = Document.open(clean_workspace, author="Test")
+        output_path = temp_dir / "output.docx"
+        doc.save(output_path)
+        doc.close()
+
+        with zipfile.ZipFile(output_path, "r") as zf:
+            names = zf.namelist()
+        assert "meta.json" not in names
+        # Sanity: real OOXML parts are still present.
+        assert "word/document.xml" in names
+        assert "[Content_Types].xml" in names
 
 
 class TestDocumentClose:

--- a/tests/test_ooxml.py
+++ b/tests/test_ooxml.py
@@ -1,5 +1,7 @@
 """Tests for ooxml pack and unpack functions."""
 
+import zipfile
+
 import pytest
 
 from docx_editor.exceptions import DocumentNotFoundError, InvalidDocumentError
@@ -70,3 +72,21 @@ class TestPack:
         assert result is True
         assert output_path.exists()
         assert output_path.stat().st_size > 0
+
+    def test_pack_excludes_root_meta_json(self, simple_docx, temp_dir):
+        """Root-level meta.json must not be packed (Word flags it as corrupt).
+
+        Scope is workspace-root only: a same-named file under a subpath stays.
+        """
+        unpacked = temp_dir / "unpacked"
+        unpack_document(simple_docx, unpacked)
+        (unpacked / "meta.json").write_text('{"author": "test"}')
+        (unpacked / "word" / "meta.json").write_text('{"unrelated": true}')
+
+        output_path = temp_dir / "output.docx"
+        pack_document(unpacked, output_path)
+
+        with zipfile.ZipFile(output_path, "r") as zf:
+            names = zf.namelist()
+        assert "meta.json" not in names
+        assert "word/meta.json" in names


### PR DESCRIPTION
## Summary

- `pack_document()` was zipping every file in the workspace, including the workspace's `meta.json` written by `Workspace._save_meta()` immediately before pack. Word opens such files with the warning *"Word found unreadable content in [filename].docx"*.
- Skip workspace-root paths in `EXCLUDED_PATHS` during pack. The comparison is on the path **relative to the workspace root**, so a hypothetical subpart literally named `meta.json` is unaffected.
- Add a cross-reference comment on `Workspace.META_FILE` so any future rename also updates the exclusion set.

Fixes #8.

## Test plan

- [x] `uv run pytest` — 496 passed, 6 skipped
- [x] New unit test `test_pack_excludes_root_meta_json` pins the scoping: workspace-root `meta.json` is dropped, `word/meta.json` is preserved
- [x] New e2e test `test_save_does_not_include_meta_json` reproduces the issue via `Document.open(...).save(...)` and asserts the output archive
- [x] Verified both tests **fail** without the fix (temporarily reverted to confirm)
- [x] `uv run ruff check .` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where internal workspace metadata was being included in generated Office documents, which could cause compatibility issues. Generated documents now properly exclude this metadata.

* **Tests**
  * Added regression tests to verify workspace metadata is excluded from document packages while other content remains intact.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pablospe/docx-editor/pull/15)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->