### PR TITLE
fix: Document.open() must not silently delete workspace on sync mismatch

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -18,9 +18,13 @@ Open a Word document for editing.
 
 - `path` (str | Path): Path to the .docx file
 - `author` (str, optional): Author name for tracked changes. Defaults to system username.
-- `force_recreate` (bool): If True, delete existing workspace and create fresh. Defaults to False.
+- `force_recreate` (bool): If True, delete any existing workspace (stale or in-sync) before opening — any unsaved edits in the workspace are discarded. Use this to recover from `WorkspaceSyncError`. Defaults to False.
 
 **Returns:** Document instance ready for editing
+
+**Raises:**
+
+- `WorkspaceSyncError`: If the source `.docx` was modified since the workspace was created. Pass `force_recreate=True` to discard the stale workspace and re-unpack from the current source. The workspace is never deleted silently.
 
 **Example:**
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -23,7 +23,7 @@ with Document.open("contract.docx", author="Legal Team") as doc:
     doc.save()
 ```
 
-If you need a fresh workspace and are intentionally discarding pending workspace state, pass `force_recreate=True`:
+If the source `.docx` was modified outside this library since the workspace was created, `Document.open()` raises `WorkspaceSyncError` instead of silently discarding the workspace. Pass `force_recreate=True` to acknowledge the divergence and re-unpack from the current source:
 
 ```python
 doc = Document.open("contract.docx", force_recreate=True)

--- a/docx_editor/document.py
+++ b/docx_editor/document.py
@@ -9,7 +9,6 @@ import shutil
 from pathlib import Path
 
 from .comments import Comment, CommentManager
-from .exceptions import WorkspaceSyncError
 from .track_changes import EditOperation, Revision, RevisionManager
 from .workspace import Workspace
 from .xml_editor import DocxXMLEditor, ParagraphRef, build_text_map, compute_paragraph_hash
@@ -80,10 +79,17 @@ class Document:
         Args:
             path: Path to the .docx file
             author: Author name for tracked changes (defaults to system username)
-            force_recreate: If True, delete existing workspace and create fresh
+            force_recreate: If True, delete any existing workspace (stale or
+                in-sync) before opening. Any unsaved edits in the workspace
+                are discarded. Use this to recover from WorkspaceSyncError.
 
         Returns:
             Document instance ready for editing
+
+        Raises:
+            WorkspaceSyncError: If the source document was modified since the
+                workspace was created. Pass force_recreate=True to discard the
+                stale workspace and re-unpack from the current source.
 
         Example:
             doc = Document.open("contract.docx")
@@ -94,15 +100,7 @@ class Document:
         if force_recreate:
             Workspace.delete(path)
 
-        try:
-            workspace = Workspace(path, author=author, create=True)
-        except WorkspaceSyncError:
-            # Document changed, offer to recreate
-            if force_recreate:
-                raise
-            Workspace.delete(path)
-            workspace = Workspace(path, author=author, create=True)
-
+        workspace = Workspace(path, author=author, create=True)
         return cls(workspace)
 
     @property

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -173,20 +173,40 @@ class TestDocumentEdgeCases:
         # Second close should not raise
         doc.close()
 
-    def test_auto_recreate_on_sync_error(self, clean_workspace):
-        """Test that Document.open auto-recreates on WorkspaceSyncError."""
-        import time
+    def test_open_raises_on_sync_mismatch(self, clean_workspace):
+        """Document.open must raise WorkspaceSyncError instead of silently
+        deleting a workspace whose source .docx was modified out-of-band.
 
-        # Create workspace
+        Verifies both that the exception propagates AND that the workspace
+        survives on disk (a buggy implementation that deleted and then
+        re-raised would otherwise pass). Recovery is via the explicit
+        force_recreate=True opt-in.
+        """
+        import os
+
+        from docx_editor.exceptions import WorkspaceSyncError
+
+        # Create workspace, keep it on disk so the next open hits the sync check.
         doc1 = Document.open(clean_workspace)
         doc1.close(cleanup=False)
+        assert Workspace.exists(clean_workspace)
 
-        # Modify source to trigger sync error
-        time.sleep(0.1)
+        # Mutate source bytes and bump mtime explicitly (sleep-based mtime
+        # changes are unreliable on coarse-resolution filesystems).
+        original_mtime = clean_workspace.stat().st_mtime
         clean_workspace.write_bytes(clean_workspace.read_bytes() + b"\x00")
+        os.utime(clean_workspace, (original_mtime + 5, original_mtime + 5))
 
-        # Should auto-recreate without error
-        doc2 = Document.open(clean_workspace)
+        with pytest.raises(WorkspaceSyncError):
+            Document.open(clean_workspace)
+
+        # The whole point of this PR: workspace must survive the failed open.
+        assert Workspace.exists(clean_workspace), (
+            "workspace must remain on disk when Document.open raises WorkspaceSyncError"
+        )
+
+        # The documented escape hatch still works: discard and re-unpack.
+        doc2 = Document.open(clean_workspace, force_recreate=True)
         assert doc2.source_path == clean_workspace
         doc2.close()
 
@@ -245,10 +265,9 @@ class TestDocumentInternalMethods:
     """Tests for internal Document methods and edge cases."""
 
     def test_force_recreate_with_persistent_sync_error(self, clean_workspace):
-        """Test that force_recreate=True re-raises WorkspaceSyncError if it persists.
-
-        This tests line 102: the `raise` when force_recreate=True but WorkspaceSyncError
-        still occurs after deletion.
+        """Test that WorkspaceSyncError propagates from Workspace.__init__ even
+        when force_recreate=True (i.e. when the workspace constructor raises
+        sync errors for some reason other than a pre-existing stale workspace).
         """
         from unittest.mock import patch
 


### PR DESCRIPTION
## Summary
- `Document.open()` previously swallowed `WorkspaceSyncError` and deleted/recreated the workspace even when `force_recreate=False`, contradicting the documented contract and risking silent loss of unsaved edits.
- Constructor now surfaces `WorkspaceSyncError` by default; deletion only happens when `force_recreate=True`.
- Docstring updated to spell out the raised exception and clarify the opt-in semantics of `force_recreate`.

## Test plan
- [ ] `uv run pytest tests/test_document.py`
- [ ] Confirm `force_recreate=False` raises `WorkspaceSyncError` on a stale workspace
- [ ] Confirm `force_recreate=True` discards the workspace and re-unpacks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified workspace error handling: `WorkspaceSyncError` now propagates when a document's source file changes outside the library, requiring explicit `force_recreate=True` to recover.

* **Documentation**
  * Clarified `Document.open()` API behavior and error recovery guidance in API docs and quickstart guide.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pablospe/docx-editor/pull/18?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->