### PR TITLE
fix: batch_edit rolls back on partial failure to honor atomic contract

### DIFF
--- a/docx_editor/track_changes.py
+++ b/docx_editor/track_changes.py
@@ -147,16 +147,27 @@ class RevisionManager:
         # Stable sort preserves original order for same-paragraph edits
         parsed.sort(key=lambda x: x[1].index, reverse=True)
 
-        # Apply edits in reverse paragraph order
-        results = [0] * len(operations)
-        for original_idx, _ref, op in parsed:
-            try:
-                change_id = self._apply_single_edit(op)
-            except ValueError as e:
-                raise BatchOperationError(original_idx, str(e)) from e
-            results[original_idx] = change_id
+        # Snapshot DOM before any mutation so we can roll back on partial failure.
+        snapshot = self.editor.dom.toxml(encoding=self.editor.encoding)
 
-        return results
+        try:
+            results = [0] * len(operations)
+            for original_idx, _ref, op in parsed:
+                try:
+                    change_id = self._apply_single_edit(op)
+                except ValueError as e:
+                    raise BatchOperationError(original_idx, str(e)) from e
+                results[original_idx] = change_id
+            return results
+        except Exception:
+            # Restore via the line-tracking parser so parse_position is preserved.
+            # If rollback itself fails, surface the original edit error — it is
+            # the actionable one; a rollback failure is a secondary symptom.
+            try:
+                self.editor._reload_dom_from_bytes(snapshot)
+            except Exception:
+                pass
+            raise
 
     def _apply_single_edit(self, op: EditOperation) -> int:
         """Apply a single edit operation. Paragraph hash was already validated."""

--- a/docx_editor/xml_editor.py
+++ b/docx_editor/xml_editor.py
@@ -5,6 +5,7 @@ line-number-based node finding and DOM manipulation.
 """
 
 import html
+import io
 import random
 import re
 import zlib
@@ -212,6 +213,18 @@ class XMLEditor:
 
         parser = _create_line_tracking_parser()
         self.dom = defusedxml.minidom.parse(str(self.xml_path), parser)
+
+    def _reload_dom_from_bytes(self, xml_bytes: bytes) -> None:
+        """Replace ``self.dom`` by re-parsing ``xml_bytes`` with line tracking.
+
+        Used to restore a snapshot (e.g., rollback after a failed batch edit)
+        while preserving the ``parse_position`` invariant that ``get_node``
+        with ``line_number`` relies on. Parses via ``BytesIO`` because
+        ``defusedxml.minidom.parseString`` does not accept bytes when a
+        custom parser is supplied.
+        """
+        parser = _create_line_tracking_parser()
+        self.dom = defusedxml.minidom.parse(io.BytesIO(xml_bytes), parser)
 
     def get_node(
         self,

--- a/docx_editor/xml_editor.py
+++ b/docx_editor/xml_editor.py
@@ -215,13 +215,16 @@ class XMLEditor:
         self.dom = defusedxml.minidom.parse(str(self.xml_path), parser)
 
     def _reload_dom_from_bytes(self, xml_bytes: bytes) -> None:
-        """Replace ``self.dom`` by re-parsing ``xml_bytes`` with line tracking.
+        """Replace self.dom by re-parsing xml_bytes with line tracking.
 
-        Used to restore a snapshot (e.g., rollback after a failed batch edit)
-        while preserving the ``parse_position`` invariant that ``get_node``
-        with ``line_number`` relies on. Parses via ``BytesIO`` because
-        ``defusedxml.minidom.parseString`` does not accept bytes when a
-        custom parser is supplied.
+        Used to restore a snapshot (e.g., rollback after a failed batch
+        edit) while preserving the parse_position invariant that get_node
+        with line_number relies on. Parses via BytesIO because
+        defusedxml.minidom.parseString does not accept bytes when a custom
+        parser is supplied.
+
+        Args:
+            xml_bytes: Raw XML bytes to parse as the new DOM.
         """
         parser = _create_line_tracking_parser()
         self.dom = defusedxml.minidom.parse(io.BytesIO(xml_bytes), parser)

--- a/tests/test_batch_edit.py
+++ b/tests/test_batch_edit.py
@@ -531,3 +531,34 @@ class TestBatchEditRollback:
         paragraphs_after = editor.dom.getElementsByTagName("w:p")
         assert paragraphs_after
         assert all(hasattr(p, "parse_position") for p in paragraphs_after)
+
+    def test_rollback_failure_surfaces_original_error(self, multi_para_doc, monkeypatch):
+        """If the rollback re-parse itself fails, the original edit error must
+        still propagate — not the rollback failure."""
+        doc, _ = multi_para_doc
+        refs = doc.list_paragraphs()
+        editor = doc._document_editor
+
+        def boom(_xml_bytes):
+            raise RuntimeError("simulated rollback failure")
+
+        monkeypatch.setattr(editor, "_reload_dom_from_bytes", boom)
+
+        ops = [
+            EditOperation(
+                action="replace",
+                find="item 2",
+                replace_with="x",
+                paragraph=refs[1].split("|")[0],
+            ),
+            EditOperation(
+                action="replace",
+                find="MISSING",
+                replace_with="x",
+                paragraph=refs[5].split("|")[0],
+            ),
+        ]
+
+        # Original edit error wins over the rollback failure.
+        with pytest.raises(TextNotFoundError):
+            doc.batch_edit(ops)

--- a/tests/test_batch_edit.py
+++ b/tests/test_batch_edit.py
@@ -538,8 +538,9 @@ class TestBatchEditRollback:
         doc, _ = multi_para_doc
         refs = doc.list_paragraphs()
         editor = doc._document_editor
+        before_text = doc.get_visible_text()
 
-        def boom(_xml_bytes):
+        def boom(xml_bytes):
             raise RuntimeError("simulated rollback failure")
 
         monkeypatch.setattr(editor, "_reload_dom_from_bytes", boom)
@@ -562,3 +563,8 @@ class TestBatchEditRollback:
         # Original edit error wins over the rollback failure.
         with pytest.raises(TextNotFoundError):
             doc.batch_edit(ops)
+
+        # Reverse-paragraph order means the failing P6 op runs first and
+        # raises before any mutation, so visible text is still unchanged
+        # even though the rollback re-parse itself was swallowed.
+        assert doc.get_visible_text() == before_text

--- a/tests/test_batch_edit.py
+++ b/tests/test_batch_edit.py
@@ -396,3 +396,138 @@ class TestStructuredBatchOperationError:
         ops = [EditOperation(action="replace", find="a", replace_with="b", paragraph="")]
         with pytest.raises(DocxEditError):
             doc.batch_edit(ops)
+
+
+class TestBatchEditRollback:
+    """Mid-batch failure must leave the document untouched (atomic contract)."""
+
+    def test_rollback_on_text_not_found_mid_batch(self, multi_para_doc):
+        """First op applies, second op's find text doesn't exist — DOM must roll back."""
+        doc, _ = multi_para_doc
+        refs = doc.list_paragraphs()
+
+        before_text = doc.get_visible_text()
+        before_revisions = len(doc.list_revisions())
+
+        ops = [
+            EditOperation(
+                action="replace",
+                find="item 3",
+                replace_with="ITEM_THREE",
+                paragraph=refs[2].split("|")[0],
+            ),
+            EditOperation(
+                action="replace",
+                find="DOES_NOT_EXIST_IN_P7",
+                replace_with="x",
+                paragraph=refs[6].split("|")[0],
+            ),
+            EditOperation(
+                action="replace",
+                find="item 9",
+                replace_with="ITEM_NINE",
+                paragraph=refs[8].split("|")[0],
+            ),
+        ]
+
+        with pytest.raises(TextNotFoundError):
+            doc.batch_edit(ops)
+
+        # Reverse-paragraph order means P9 applied before P7 failed; full-text
+        # equality proves P9's mutation was rolled back.
+        assert doc.get_visible_text() == before_text
+        assert len(doc.list_revisions()) == before_revisions
+
+    def test_rollback_on_structural_error_mid_batch(self, multi_para_doc):
+        """First op is valid; second op has replace_with=None — DOM must roll back."""
+        doc, _ = multi_para_doc
+        refs = doc.list_paragraphs()
+
+        before_text = doc.get_visible_text()
+        before_revisions = len(doc.list_revisions())
+
+        ops = [
+            EditOperation(
+                action="replace",
+                find="item 2",
+                replace_with="SECOND",
+                paragraph=refs[1].split("|")[0],
+            ),
+            EditOperation(
+                action="replace",
+                find="item 4",
+                replace_with=None,
+                paragraph=refs[3].split("|")[0],
+            ),
+        ]
+
+        with pytest.raises(BatchOperationError) as exc:
+            doc.batch_edit(ops)
+        assert exc.value.operation_index == 1
+
+        assert doc.get_visible_text() == before_text
+        assert len(doc.list_revisions()) == before_revisions
+
+    def test_rollback_preserves_hash_anchored_refs(self, multi_para_doc):
+        """After a failed batch, pre-batch paragraph refs still resolve cleanly."""
+        doc, _ = multi_para_doc
+        refs_before = doc.list_paragraphs()
+
+        ops = [
+            EditOperation(
+                action="replace",
+                find="item 2",
+                replace_with="WILL_ROLLBACK",
+                paragraph=refs_before[1].split("|")[0],
+            ),
+            EditOperation(
+                action="replace",
+                find="MISSING",
+                replace_with="x",
+                paragraph=refs_before[5].split("|")[0],
+            ),
+        ]
+
+        with pytest.raises(TextNotFoundError):
+            doc.batch_edit(ops)
+
+        # The pre-batch P2 ref must still resolve — proves hashes did not drift.
+        doc.replace("item 2", "POST_ROLLBACK", paragraph=refs_before[1].split("|")[0])
+        assert "POST_ROLLBACK" in doc.get_visible_text()
+        assert "WILL_ROLLBACK" not in doc.get_visible_text()
+
+    def test_rollback_preserves_parse_position_metadata(self, multi_para_doc):
+        """After rollback, parse_position attributes on elements must survive,
+        so XMLEditor.get_node(line_number=...) keeps working."""
+        doc, _ = multi_para_doc
+        refs = doc.list_paragraphs()
+        editor = doc._document_editor
+
+        # Sanity: parse_position is set on every element before any batch.
+        paragraphs_before = editor.dom.getElementsByTagName("w:p")
+        assert paragraphs_before
+        assert all(hasattr(p, "parse_position") for p in paragraphs_before)
+
+        ops = [
+            EditOperation(
+                action="replace",
+                find="item 2",
+                replace_with="x",
+                paragraph=refs[1].split("|")[0],
+            ),
+            EditOperation(
+                action="replace",
+                find="MISSING",
+                replace_with="x",
+                paragraph=refs[5].split("|")[0],
+            ),
+        ]
+
+        with pytest.raises(TextNotFoundError):
+            doc.batch_edit(ops)
+
+        # After rollback, parse_position must still be present on every element
+        # — proves the line-tracking parser was used for the restore.
+        paragraphs_after = editor.dom.getElementsByTagName("w:p")
+        assert paragraphs_after
+        assert all(hasattr(p, "parse_position") for p in paragraphs_after)


### PR DESCRIPTION
## Summary
- `RevisionManager.batch_edit` claimed atomic semantics but a mid-batch failure left edits partially applied.
- Now snapshots the DOM before any mutation and restores it on exception, preserving the line-tracking `parse_position` invariant by re-parsing the snapshot through the same line-tracking parser used at load time.
- New `XMLEditor._reload_dom_from_bytes` helper backs the restore path.

## Test plan
- [ ] `uv run pytest tests/test_batch_edit.py`
- [ ] Confirm a failing edit mid-batch leaves the document unchanged
- [ ] Confirm subsequent operations on the restored DOM still resolve `line_number` via `get_node`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Batch editing operations now include atomic rollback support. If any operation within a batch fails for any reason, all changes are automatically rolled back to the pre-batch state, ensuring the document remains in a consistent state. This prevents partial failures from corrupting your data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->