### PR TITLE
security: harden ZIP unpack against path traversal; skip symlinks on pack

### DIFF
--- a/docx_editor/ooxml/pack.py
+++ b/docx_editor/ooxml/pack.py
@@ -16,6 +16,12 @@ import defusedxml.minidom
 EXCLUDED_PATHS = {Path("meta.json")}
 
 
+def _ignore_symlinks(directory: str, names: list[str]) -> list[str]:
+    """Skip symlinks so they cannot leak external host content into the archive."""
+    base = Path(directory)
+    return [n for n in names if (base / n).is_symlink()]
+
+
 def pack_document(input_dir: str | Path, output_file: str | Path, validate: bool = False) -> bool:
     """Pack a directory into an Office file (.docx/.pptx/.xlsx).
 
@@ -33,6 +39,8 @@ def pack_document(input_dir: str | Path, output_file: str | Path, validate: bool
     input_dir = Path(input_dir)
     output_file = Path(output_file)
 
+    if input_dir.is_symlink():
+        raise ValueError(f"{input_dir} is a symlink")
     if not input_dir.is_dir():
         raise ValueError(f"{input_dir} is not a directory")
     if output_file.suffix.lower() not in {".docx", ".pptx", ".xlsx"}:
@@ -41,7 +49,7 @@ def pack_document(input_dir: str | Path, output_file: str | Path, validate: bool
     # Work in temporary directory to avoid modifying original
     with tempfile.TemporaryDirectory() as temp_dir:
         temp_content_dir = Path(temp_dir) / "content"
-        shutil.copytree(input_dir, temp_content_dir)
+        shutil.copytree(input_dir, temp_content_dir, ignore=_ignore_symlinks)
 
         # Process XML files to remove pretty-printing whitespace
         for pattern in ["*.xml", "*.rels"]:

--- a/docx_editor/ooxml/pack.py
+++ b/docx_editor/ooxml/pack.py
@@ -34,7 +34,8 @@ def pack_document(input_dir: str | Path, output_file: str | Path, validate: bool
         bool: True if successful, False if validation failed
 
     Raises:
-        ValueError: If input_dir doesn't exist or output_file has wrong extension
+        ValueError: If input_dir is a symlink, doesn't exist, or output_file has
+            the wrong extension
     """
     input_dir = Path(input_dir)
     output_file = Path(output_file)

--- a/docx_editor/ooxml/unpack.py
+++ b/docx_editor/ooxml/unpack.py
@@ -11,10 +11,12 @@ from docx_editor.exceptions import DocumentNotFoundError, InvalidDocumentError
 
 
 def _is_unsafe_zip_path(name: str) -> bool:
-    """Reject absolute paths, drive letters, and '..' traversal segments."""
+    """Reject absolute paths, colons, and '..' traversal segments."""
     if not name or name.startswith(("/", "\\")):
         return True
-    if len(name) >= 2 and name[1] == ":":  # Windows drive letter, e.g. C:\
+    # Reject any colon: covers Windows drive letters (C:\) and NTFS alternate
+    # data streams (foo.xml:stream). OOXML part names never contain a colon.
+    if ":" in name:
         return True
     for seg in name.replace("\\", "/").split("/"):
         # Reject literal "..", and any segment composed only of dots/spaces:
@@ -45,7 +47,9 @@ def unpack_document(input_file: str | Path, output_dir: str | Path) -> str:
 
     Raises:
         DocumentNotFoundError: If the input file doesn't exist
-        InvalidDocumentError: If the file is not a valid zip/docx
+        InvalidDocumentError: If the file is not a valid zip/docx, contains an
+            unsafe entry path or a symlink entry, or the output directory is
+            (or contains) a symlink or is an existing non-directory.
     """
     input_path = Path(input_file)
     output_path = Path(output_dir)
@@ -57,6 +61,8 @@ def unpack_document(input_file: str | Path, output_dir: str | Path) -> str:
     if output_path.is_symlink():
         raise InvalidDocumentError(f"Output directory is a symlink: {output_dir}")
     if output_path.exists():
+        if not output_path.is_dir():
+            raise InvalidDocumentError(f"Output path is not a directory: {output_dir}")
         for entry in output_path.rglob("*"):
             if entry.is_symlink():
                 raise InvalidDocumentError(f"Symlink inside output directory: {entry}")

--- a/docx_editor/ooxml/unpack.py
+++ b/docx_editor/ooxml/unpack.py
@@ -1,12 +1,36 @@
 """Unpack and format XML contents of Office files (.docx, .pptx, .xlsx)."""
 
 import random
+import stat
 import zipfile
 from pathlib import Path
 
 import defusedxml.minidom
 
 from docx_editor.exceptions import DocumentNotFoundError, InvalidDocumentError
+
+
+def _is_unsafe_zip_path(name: str) -> bool:
+    """Reject absolute paths, drive letters, and '..' traversal segments."""
+    if not name or name.startswith(("/", "\\")):
+        return True
+    if len(name) >= 2 and name[1] == ":":  # Windows drive letter, e.g. C:\
+        return True
+    for seg in name.replace("\\", "/").split("/"):
+        # Reject literal "..", and any segment composed only of dots/spaces:
+        # NTFS strips trailing spaces and dots from path components, so ".. "
+        # and "..." can normalize to "..". OOXML never uses such segments.
+        if seg == ".." or (seg and seg.strip(" .") == ""):
+            return True
+    return False
+
+
+def _is_symlink_entry(info: zipfile.ZipInfo) -> bool:
+    """Return True if the ZIP entry is a Unix symlink."""
+    if info.create_system != 3:  # not Unix-created
+        return False
+    mode = (info.external_attr >> 16) & 0xFFFF
+    return stat.S_ISLNK(mode)
 
 
 def unpack_document(input_file: str | Path, output_dir: str | Path) -> str:
@@ -29,10 +53,25 @@ def unpack_document(input_file: str | Path, output_dir: str | Path) -> str:
     if not input_path.exists():
         raise DocumentNotFoundError(f"Document not found: {input_file}")
 
-    # Extract and format
-    output_path.mkdir(parents=True, exist_ok=True)
+    # Reject a symlinked destination so extractall cannot write through it.
+    if output_path.is_symlink():
+        raise InvalidDocumentError(f"Output directory is a symlink: {output_dir}")
+    if output_path.exists():
+        for entry in output_path.rglob("*"):
+            if entry.is_symlink():
+                raise InvalidDocumentError(f"Symlink inside output directory: {entry}")
+
+    # Validate ZIP entries before extractall (and before mkdir) so a rejection
+    # leaves the filesystem untouched.
     try:
-        zipfile.ZipFile(input_path).extractall(output_path)
+        with zipfile.ZipFile(input_path) as zf:
+            for info in zf.infolist():
+                if _is_unsafe_zip_path(info.filename):
+                    raise InvalidDocumentError(f"Unsafe ZIP entry path: {info.filename!r} in {input_file}")
+                if _is_symlink_entry(info):
+                    raise InvalidDocumentError(f"Symlink ZIP entry: {info.filename!r} in {input_file}")
+            output_path.mkdir(parents=True, exist_ok=True)
+            zf.extractall(output_path)
     except zipfile.BadZipFile as e:
         raise InvalidDocumentError(f"Not a valid .docx file: {input_file}") from e
 

--- a/tests/test_ooxml.py
+++ b/tests/test_ooxml.py
@@ -8,7 +8,7 @@ import pytest
 
 from docx_editor.exceptions import DocumentNotFoundError, InvalidDocumentError
 from docx_editor.ooxml.pack import pack_document
-from docx_editor.ooxml.unpack import unpack_document
+from docx_editor.ooxml.unpack import _is_symlink_entry, unpack_document
 
 
 def _build_zip(path, entries):
@@ -100,6 +100,35 @@ class TestUnpack:
         _build_zip(bad_zip, [("safe.txt", b"safe"), (".. /evil.txt", b"pwned")])
         with pytest.raises(InvalidDocumentError, match="Unsafe ZIP entry"):
             unpack_document(bad_zip, temp_dir / "output")
+
+    def test_unpack_rejects_drive_letter(self, temp_dir):
+        """Reject Windows drive-letter ZIP entry names like 'C:evil.txt'."""
+        bad_zip = temp_dir / "bad.docx"
+        _build_zip(bad_zip, [("safe.txt", b"safe"), ("C:evil.txt", b"pwned")])
+        with pytest.raises(InvalidDocumentError, match="Unsafe ZIP entry"):
+            unpack_document(bad_zip, temp_dir / "output")
+
+    def test_unpack_accepts_existing_empty_output_dir(self, temp_dir, simple_docx):
+        """Pre-existing empty output_dir is fine (no symlinks to reject)."""
+        output = temp_dir / "output"
+        output.mkdir()
+        rsid = unpack_document(simple_docx, output)
+        assert len(rsid) == 8
+
+    def test_unpack_accepts_existing_output_dir_without_symlinks(self, temp_dir, simple_docx):
+        """Pre-existing output_dir containing only regular files is accepted."""
+        output = temp_dir / "output"
+        output.mkdir()
+        (output / "leftover.txt").write_text("ok")
+        rsid = unpack_document(simple_docx, output)
+        assert len(rsid) == 8
+
+    def test_is_symlink_entry_skips_non_unix_creator(self):
+        """Non-Unix-created entries are not classified as symlinks even with S_IFLNK bits."""
+        info = zipfile.ZipInfo("foo")
+        info.create_system = 0  # MS-DOS / FAT
+        info.external_attr = (stat.S_IFLNK | 0o777) << 16
+        assert _is_symlink_entry(info) is False
 
     @pytest.mark.skipif(sys.platform == "win32", reason="symlinks require elevation on Windows")
     def test_unpack_rejects_symlinked_output_dir(self, temp_dir, simple_docx):

--- a/tests/test_ooxml.py
+++ b/tests/test_ooxml.py
@@ -1,5 +1,7 @@
 """Tests for ooxml pack and unpack functions."""
 
+import stat
+import sys
 import zipfile
 
 import pytest
@@ -7,6 +9,13 @@ import pytest
 from docx_editor.exceptions import DocumentNotFoundError, InvalidDocumentError
 from docx_editor.ooxml.pack import pack_document
 from docx_editor.ooxml.unpack import unpack_document
+
+
+def _build_zip(path, entries):
+    """Build a ZIP at path from a list of (name_or_zipinfo, data_bytes) tuples."""
+    with zipfile.ZipFile(path, "w") as zf:
+        for name_or_info, data in entries:
+            zf.writestr(name_or_info, data)
 
 
 class TestUnpack:
@@ -32,6 +41,88 @@ class TestUnpack:
         assert isinstance(rsid, str)
         assert len(rsid) == 8
         assert all(c in "0123456789ABCDEF" for c in rsid)
+
+    def test_unpack_rejects_path_traversal(self, temp_dir):
+        """Reject ZIP entries containing '..' segments before any extraction."""
+        bad_zip = temp_dir / "bad.docx"
+        _build_zip(
+            bad_zip,
+            [
+                ("safe.txt", b"safe"),
+                ("../evil.txt", b"pwned"),
+            ],
+        )
+        output = temp_dir / "output"
+        with pytest.raises(InvalidDocumentError, match="Unsafe ZIP entry"):
+            unpack_document(bad_zip, output)
+
+        # Nothing should have leaked outside output_dir.
+        assert not (temp_dir / "evil.txt").exists()
+
+    def test_unpack_rejects_absolute_path(self, temp_dir):
+        """Reject ZIP entries with absolute paths."""
+        bad_zip = temp_dir / "bad.docx"
+        _build_zip(
+            bad_zip,
+            [
+                ("safe.txt", b"safe"),
+                ("/tmp/evil.txt", b"pwned"),
+            ],
+        )
+        output = temp_dir / "output"
+        with pytest.raises(InvalidDocumentError, match="Unsafe ZIP entry"):
+            unpack_document(bad_zip, output)
+
+    def test_unpack_rejects_symlink_entry(self, temp_dir):
+        """Reject Unix symlink ZIP entries (create_system==3, mode S_IFLNK)."""
+        bad_zip = temp_dir / "bad.docx"
+        link_info = zipfile.ZipInfo("evil_link")
+        link_info.create_system = 3  # Unix
+        link_info.external_attr = (stat.S_IFLNK | 0o777) << 16
+        _build_zip(
+            bad_zip,
+            [
+                ("safe.txt", b"safe"),
+                (link_info, b"/etc/passwd"),
+            ],
+        )
+        output = temp_dir / "output"
+        with pytest.raises(InvalidDocumentError, match="Symlink ZIP entry"):
+            unpack_document(bad_zip, output)
+
+        # Validation must happen before extraction — no symlink left behind.
+        assert not (output / "evil_link").exists()
+        assert not (output / "evil_link").is_symlink()
+
+    def test_unpack_rejects_dotdot_with_trailing_space(self, temp_dir):
+        """Reject '.. ' (Windows strips trailing space → '..' parent traversal)."""
+        bad_zip = temp_dir / "bad.docx"
+        _build_zip(bad_zip, [("safe.txt", b"safe"), (".. /evil.txt", b"pwned")])
+        with pytest.raises(InvalidDocumentError, match="Unsafe ZIP entry"):
+            unpack_document(bad_zip, temp_dir / "output")
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="symlinks require elevation on Windows")
+    def test_unpack_rejects_symlinked_output_dir(self, temp_dir, simple_docx):
+        """Refuse to unpack into an output_dir that is itself a symlink."""
+        real = temp_dir / "real"
+        real.mkdir()
+        linked = temp_dir / "linked"
+        linked.symlink_to(real, target_is_directory=True)
+
+        with pytest.raises(InvalidDocumentError, match="Output directory is a symlink"):
+            unpack_document(simple_docx, linked)
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="symlinks require elevation on Windows")
+    def test_unpack_rejects_preexisting_symlink_inside_output_dir(self, temp_dir, simple_docx):
+        """Refuse to extract when output_dir already contains a symlink."""
+        output = temp_dir / "output"
+        output.mkdir()
+        external = temp_dir / "external"
+        external.mkdir()
+        (output / "word").symlink_to(external, target_is_directory=True)
+
+        with pytest.raises(InvalidDocumentError, match="Symlink inside output directory"):
+            unpack_document(simple_docx, output)
 
 
 class TestPack:
@@ -123,6 +214,60 @@ class TestPack:
         with zipfile.ZipFile(output_path, "r") as zf:
             for info in zf.infolist():
                 assert info.date_time == (1980, 1, 1, 0, 0, 0)
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="symlinks require elevation on Windows")
+    def test_pack_skips_symlink_files(self, simple_docx, temp_dir):
+        """File symlinks in the workspace must not be packed (would leak host content)."""
+        unpacked = temp_dir / "unpacked"
+        unpack_document(simple_docx, unpacked)
+
+        # Create an external secret and replace word/document.xml with a symlink to it.
+        # Packing the workspace must NOT include the symlink (we'd rather break the doc
+        # than leak external content).
+        secret = temp_dir / "secret.txt"
+        secret.write_text("OUTSIDE")
+
+        doc_xml = unpacked / "word" / "document.xml"
+        doc_xml.unlink()
+        doc_xml.symlink_to(secret)
+
+        output_path = temp_dir / "output.docx"
+        pack_document(unpacked, output_path)
+
+        with zipfile.ZipFile(output_path, "r") as zf:
+            names = zf.namelist()
+        assert "word/document.xml" not in names
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="symlinks require elevation on Windows")
+    def test_pack_skips_symlink_directories(self, simple_docx, temp_dir):
+        """Directory symlinks must not be followed during pack."""
+        unpacked = temp_dir / "unpacked"
+        unpack_document(simple_docx, unpacked)
+
+        # Create an external directory with a recognizable file and symlink it in.
+        external = temp_dir / "external"
+        external.mkdir()
+        (external / "leaked.txt").write_text("LEAKED")
+        (unpacked / "leak").symlink_to(external, target_is_directory=True)
+
+        output_path = temp_dir / "output.docx"
+        pack_document(unpacked, output_path)
+
+        with zipfile.ZipFile(output_path, "r") as zf:
+            names = zf.namelist()
+        assert not any(n.startswith("leak/") for n in names)
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="symlinks require elevation on Windows")
+    def test_pack_rejects_symlinked_input_dir(self, simple_docx, temp_dir):
+        """Refuse to pack when input_dir itself is a symlink to an external dir."""
+        unpacked = temp_dir / "unpacked"
+        unpack_document(simple_docx, unpacked)
+
+        link = temp_dir / "link"
+        link.symlink_to(unpacked, target_is_directory=True)
+
+        with pytest.raises(ValueError, match="symlink"):
+            pack_document(link, temp_dir / "out.docx")
 
 
 def _read_doc_xml(docx_path):

--- a/tests/test_ooxml.py
+++ b/tests/test_ooxml.py
@@ -108,6 +108,13 @@ class TestUnpack:
         with pytest.raises(InvalidDocumentError, match="Unsafe ZIP entry"):
             unpack_document(bad_zip, temp_dir / "output")
 
+    def test_unpack_rejects_colon_ads(self, temp_dir):
+        """Reject mid-path colons (NTFS alternate data stream, e.g. 'word/a.xml:s')."""
+        bad_zip = temp_dir / "bad.docx"
+        _build_zip(bad_zip, [("safe.txt", b"safe"), ("word/document.xml:stream", b"pwned")])
+        with pytest.raises(InvalidDocumentError, match="Unsafe ZIP entry"):
+            unpack_document(bad_zip, temp_dir / "output")
+
     def test_unpack_accepts_existing_empty_output_dir(self, temp_dir, simple_docx):
         """Pre-existing empty output_dir is fine (no symlinks to reject)."""
         output = temp_dir / "output"
@@ -122,6 +129,13 @@ class TestUnpack:
         (output / "leftover.txt").write_text("ok")
         rsid = unpack_document(simple_docx, output)
         assert len(rsid) == 8
+
+    def test_unpack_rejects_output_path_that_is_a_file(self, temp_dir, simple_docx):
+        """Refuse to unpack when output_dir already exists as a regular file."""
+        output = temp_dir / "output"
+        output.write_text("i am a file")
+        with pytest.raises(InvalidDocumentError, match="Output path is not a directory"):
+            unpack_document(simple_docx, output)
 
     def test_is_symlink_entry_skips_non_unix_creator(self):
         """Non-Unix-created entries are not classified as symlinks even with S_IFLNK bits."""


### PR DESCRIPTION
## Summary
- `unpack_document()` previously called `ZipFile.extractall()` with no inspection of `ZipInfo` entries, allowing path traversal via malicious `.docx` files.
- `pack_document()` followed symlinks during `copytree`, which could leak host files into the archive.

## Changes
- `unpack` validates each entry before mkdir/extract: rejects absolute paths, drive letters, and any segment that normalizes to `..` (covers NTFS-stripped variants like `.. ` and `...`).
- `unpack` rejects symlink ZIP entries and refuses symlinked output destinations.
- `pack` skips symlinks via `shutil.copytree(ignore=...)` and rejects a symlinked input directory.
- Out of scope: zip-bomb / resource-limit detection.

## Test plan
- [ ] `uv run pytest tests/test_ooxml.py`
- [ ] Confirm round-trip pack/unpack still succeeds on the existing fixtures
- [ ] Confirm crafted traversal entries and symlink entries raise `InvalidDocumentError`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened extraction safeguards by validating ZIP entry paths and rejecting unsafe names to prevent path-traversal and symlink-based attacks.
  * Ensured repackaging skips symlinked files/directories and rejects a symlinked input directory to avoid leaking or following links.

* **Tests**
  * Added focused regression tests covering ZIP safety, path-traversal cases, symlink entries, and packing behavior around symlinks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pablospe/docx-editor/pull/20?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->