### PR TITLE
feat: add get_paragraph_location for table-context awareness

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Pure Python library for Word document track changes and comments, without requir
 ## Features
 
 - **Hash-Anchored Paragraph References**: `list_paragraphs()` returns stable, hash-based paragraph IDs for safe, unambiguous targeting
+- **Paragraph Location**: `get_paragraph_location(ref)` reports whether a paragraph lives in the body or inside a table cell — with `w:gridSpan`-aware logical column, row, table index, and nesting depth
 - **Batch Editing**: Atomic `batch_edit()` with upfront hash validation across all operations
 - **Paragraph Rewrite**: `rewrite_paragraph()` with automatic word-level diffing — specify desired text, get fine-grained tracked changes
 - **Track Changes**: Replace, delete, and insert text with revision tracking

--- a/docx_editor/__init__.py
+++ b/docx_editor/__init__.py
@@ -55,7 +55,9 @@ from .exceptions import (
 )
 from .track_changes import EditOperation, Revision
 from .xml_editor import (
+    ParagraphLocation,
     ParagraphRef,
+    TableCell,
     TextMap,
     TextMapMatch,
     TextPosition,
@@ -94,4 +96,7 @@ __all__ = [
     "build_text_map",
     "compute_paragraph_hash",
     "find_in_text_map",
+    # Paragraph location
+    "ParagraphLocation",
+    "TableCell",
 ]

--- a/docx_editor/document.py
+++ b/docx_editor/document.py
@@ -9,9 +9,17 @@ import shutil
 from pathlib import Path
 
 from .comments import Comment, CommentManager
+from .exceptions import HashMismatchError, ParagraphIndexError
 from .track_changes import EditOperation, Revision, RevisionManager
 from .workspace import Workspace
-from .xml_editor import DocxXMLEditor, ParagraphRef, build_text_map, compute_paragraph_hash
+from .xml_editor import (
+    DocxXMLEditor,
+    ParagraphLocation,
+    ParagraphRef,
+    build_text_map,
+    compute_paragraph_hash,
+    compute_paragraph_location,
+)
 
 
 class Document:
@@ -174,6 +182,57 @@ class Document:
                 preview += "..."
             result.append(f"P{i}#{h}| {preview}")
         return result
+
+    def get_paragraph_location(self, ref: str) -> ParagraphLocation:
+        """Return the structural location of the paragraph identified by ``ref``.
+
+        Tells the caller whether a paragraph lives in the document body or
+        inside a table cell, and — when in a table — gives its 1-based
+        coordinates (table index, row, logical column, depth).
+
+        ``location.table.col`` is the *logical-grid* column, accounting for
+        ``w:gridSpan`` of preceding cells in the same row. A cell that
+        visually sits in column 4 reports ``col=4`` even when an earlier
+        cell in the row spans 2 grid columns.
+
+        Args:
+            ref: Paragraph reference from :meth:`list_paragraphs` (e.g.,
+                ``"P3#a7b2"``).
+
+        Returns:
+            :class:`ParagraphLocation`. ``location.in_table`` is ``False``
+            for body paragraphs; ``True`` when the paragraph is inside a
+            ``<w:tc>`` cell (in which case ``location.table`` is populated).
+
+        Raises:
+            ValueError: If ``ref`` has an invalid format.
+            ParagraphIndexError: If the paragraph index is out of range.
+            HashMismatchError: If the hash no longer matches current
+                paragraph content (paragraph was modified after the ref
+                was captured).
+
+        Example:
+            for entry in doc.list_paragraphs():
+                ref = entry.split("|")[0]
+                loc = doc.get_paragraph_location(ref)
+                if loc.in_table:
+                    cell = loc.table
+                    print(f"{ref}: table {cell.index} r{cell.row} c{cell.col}")
+        """
+        self._ensure_open()
+        parsed = ParagraphRef.parse(ref)
+        paragraphs = self._document_editor.dom.getElementsByTagName("w:p")
+        if parsed.index < 1 or parsed.index > len(paragraphs):
+            raise ParagraphIndexError(parsed.index, len(paragraphs))
+        p = paragraphs[parsed.index - 1]
+        actual_hash = compute_paragraph_hash(p)
+        if actual_hash != parsed.hash:
+            tm = build_text_map(p)
+            preview = tm.text[:80]
+            if len(tm.text) > 80:
+                preview += "..."
+            raise HashMismatchError(parsed.index, parsed.hash, actual_hash, preview)
+        return compute_paragraph_location(p)
 
     def get_visible_text(self) -> str:
         """Get the visible text of the document.

--- a/docx_editor/document.py
+++ b/docx_editor/document.py
@@ -16,9 +16,9 @@ from .xml_editor import (
     DocxXMLEditor,
     ParagraphLocation,
     ParagraphRef,
+    _compute_paragraph_location,
     build_text_map,
     compute_paragraph_hash,
-    compute_paragraph_location,
 )
 
 
@@ -232,7 +232,7 @@ class Document:
             if len(tm.text) > 80:
                 preview += "..."
             raise HashMismatchError(parsed.index, parsed.hash, actual_hash, preview)
-        return compute_paragraph_location(p)
+        return _compute_paragraph_location(p)
 
     def get_visible_text(self) -> str:
         """Get the visible text of the document.

--- a/docx_editor/xml_editor.py
+++ b/docx_editor/xml_editor.py
@@ -157,7 +157,7 @@ class ParagraphLocation:
 
 def _innermost_ancestor(node, tag_name: str):
     """Return the closest ancestor element with ``tag_name``, or None."""
-    if node is None:
+    if node is None:  # pragma: no cover - defensive; callers guard against None
         return None
     parent = node.parentNode
     while parent is not None:
@@ -197,7 +197,7 @@ def _row_index_in_table(tbl, target_tr) -> int:
             n += 1
             if child is target_tr:
                 return n
-    raise ValueError("target_tr is not a direct child of tbl")
+    raise ValueError("target_tr is not a direct child of tbl")  # pragma: no cover
 
 
 def _logical_col_in_row(tr, target_tc) -> int:
@@ -209,7 +209,7 @@ def _logical_col_in_row(tr, target_tc) -> int:
         if child is target_tc:
             return col
         col += _direct_grid_span(child)
-    raise ValueError("target_tc is not a direct child of tr")
+    raise ValueError("target_tc is not a direct child of tr")  # pragma: no cover
 
 
 def _doc_wide_table_index(dom, target_tbl) -> int:
@@ -217,7 +217,7 @@ def _doc_wide_table_index(dom, target_tbl) -> int:
     for i, tbl in enumerate(dom.getElementsByTagName("w:tbl"), start=1):
         if tbl is target_tbl:
             return i
-    raise ValueError("target_tbl not found in document")
+    raise ValueError("target_tbl not found in document")  # pragma: no cover
 
 
 def _table_depth(tbl) -> int:

--- a/docx_editor/xml_editor.py
+++ b/docx_editor/xml_editor.py
@@ -11,6 +11,7 @@ import zlib
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
+from xml.dom.minidom import Element
 
 import defusedxml.minidom
 import defusedxml.sax
@@ -155,7 +156,7 @@ class ParagraphLocation:
         return self.table is not None
 
 
-def _innermost_ancestor(node, tag_name: str):
+def _innermost_ancestor(node, tag_name: str) -> Element | None:
     """Return the closest ancestor element with ``tag_name``, or None."""
     if node is None:  # pragma: no cover - defensive; callers guard against None
         return None
@@ -190,26 +191,59 @@ def _direct_grid_span(tc) -> int:
 
 
 def _row_index_in_table(tbl, target_tr) -> int:
-    """1-based index of ``target_tr`` among ``tbl``'s direct ``w:tr`` children."""
+    """1-based index of ``target_tr`` among ``tbl``'s rows.
+
+    Walks descendant ``w:tr`` elements but filters to those whose innermost
+    enclosing ``w:tbl`` is ``tbl`` — so rows nested inside child tables are
+    skipped, and ``<w:sdt><w:sdtContent>`` wrappers are transparent.
+    """
     n = 0
-    for child in tbl.childNodes:
-        if child.nodeType == child.ELEMENT_NODE and child.tagName == "w:tr":
-            n += 1
-            if child is target_tr:
-                return n
-    raise ValueError("target_tr is not a direct child of tbl")  # pragma: no cover
+    for tr in tbl.getElementsByTagName("w:tr"):
+        if _innermost_ancestor(tr, "w:tbl") is not tbl:
+            continue
+        n += 1
+        if tr is target_tr:
+            return n
+    raise ValueError("target_tr not found in tbl")  # pragma: no cover
+
+
+def _initial_grid_offset(tr) -> int:
+    """``<w:trPr>/<w:gridBefore w:val="N"/>`` — grid columns skipped at row start.
+
+    Returns 0 when absent. A row that opens with ``gridBefore=2`` makes its
+    first ``w:tc`` land at logical column 3.
+    """
+    for child in tr.childNodes:
+        if child.nodeType != child.ELEMENT_NODE or child.tagName != "w:trPr":
+            continue
+        for gb in child.childNodes:
+            if gb.nodeType == gb.ELEMENT_NODE and gb.tagName == "w:gridBefore":
+                val = gb.getAttribute("w:val")
+                if val:
+                    try:
+                        return max(0, int(val))
+                    except ValueError:
+                        return 0
+                return 0
+        return 0
+    return 0
 
 
 def _logical_col_in_row(tr, target_tc) -> int:
-    """1-based logical column (gridSpan-aware) of ``target_tc`` in ``tr``."""
-    col = 1
-    for child in tr.childNodes:
-        if child.nodeType != child.ELEMENT_NODE or child.tagName != "w:tc":
+    """1-based logical column (gridSpan- and gridBefore-aware) of ``target_tc``.
+
+    Walks descendant ``w:tc`` elements filtered to those whose innermost
+    enclosing ``w:tr`` is ``tr`` — so cells nested inside child tables are
+    skipped, and ``<w:sdt><w:sdtContent>`` cell wrappers are transparent.
+    """
+    col = 1 + _initial_grid_offset(tr)
+    for tc in tr.getElementsByTagName("w:tc"):
+        if _innermost_ancestor(tc, "w:tr") is not tr:
             continue
-        if child is target_tc:
+        if tc is target_tc:
             return col
-        col += _direct_grid_span(child)
-    raise ValueError("target_tc is not a direct child of tr")  # pragma: no cover
+        col += _direct_grid_span(tc)
+    raise ValueError("target_tc not found in tr")  # pragma: no cover
 
 
 def _doc_wide_table_index(dom, target_tbl) -> int:

--- a/docx_editor/xml_editor.py
+++ b/docx_editor/xml_editor.py
@@ -265,7 +265,7 @@ def _table_depth(tbl) -> int:
     return depth
 
 
-def compute_paragraph_location(paragraph) -> ParagraphLocation:
+def _compute_paragraph_location(paragraph) -> ParagraphLocation:
     """Compute the structural location of a ``<w:p>`` element.
 
     Reports the innermost enclosing ``<w:tc>`` (and its table), or

--- a/docx_editor/xml_editor.py
+++ b/docx_editor/xml_editor.py
@@ -121,6 +121,141 @@ def compute_paragraph_hash(paragraph) -> str:
     return f"{zlib.crc32(text.encode('utf-8')) & 0xFFFF:04x}"
 
 
+@dataclass(frozen=True)
+class TableCell:
+    """Position of a paragraph's enclosing table cell.
+
+    Coordinates are 1-based. ``col`` is the logical-grid column accounting
+    for ``w:gridSpan`` of preceding cells in the same row, so a cell that
+    visually sits in column 4 reports ``col=4`` even when earlier cells
+    in the row are merged.
+    """
+
+    index: int  # 1-based, doc-wide, depth-first order of <w:tbl>
+    row: int  # 1-based
+    col: int  # 1-based logical grid (accounts for w:gridSpan)
+    depth: int  # 1 = outermost, >1 = nested table
+
+
+@dataclass(frozen=True)
+class ParagraphLocation:
+    """Structural location of a paragraph within the document body.
+
+    Currently reports only table membership. The shape is intentionally
+    extensible: future releases may add other container kinds (header,
+    footer, footnote), section index, list position, etc., as plain
+    optional field additions.
+    """
+
+    table: TableCell | None
+
+    @property
+    def in_table(self) -> bool:
+        """True iff the paragraph lives inside a ``<w:tc>`` cell."""
+        return self.table is not None
+
+
+def _innermost_ancestor(node, tag_name: str):
+    """Return the closest ancestor element with ``tag_name``, or None."""
+    if node is None:
+        return None
+    parent = node.parentNode
+    while parent is not None:
+        if parent.nodeType == parent.ELEMENT_NODE and parent.tagName == tag_name:
+            return parent
+        parent = parent.parentNode
+    return None
+
+
+def _direct_grid_span(tc) -> int:
+    """Return the ``w:gridSpan`` value of ``tc`` (1 if absent or malformed).
+
+    Only inspects ``tc``'s direct ``w:tcPr`` child, so nested tables inside
+    the cell never leak their own gridSpan values.
+    """
+    for child in tc.childNodes:
+        if child.nodeType != child.ELEMENT_NODE or child.tagName != "w:tcPr":
+            continue
+        for gs in child.childNodes:
+            if gs.nodeType == gs.ELEMENT_NODE and gs.tagName == "w:gridSpan":
+                val = gs.getAttribute("w:val")
+                if val:
+                    try:
+                        return max(1, int(val))
+                    except ValueError:
+                        return 1
+                return 1
+        return 1
+    return 1
+
+
+def _row_index_in_table(tbl, target_tr) -> int:
+    """1-based index of ``target_tr`` among ``tbl``'s direct ``w:tr`` children."""
+    n = 0
+    for child in tbl.childNodes:
+        if child.nodeType == child.ELEMENT_NODE and child.tagName == "w:tr":
+            n += 1
+            if child is target_tr:
+                return n
+    raise ValueError("target_tr is not a direct child of tbl")
+
+
+def _logical_col_in_row(tr, target_tc) -> int:
+    """1-based logical column (gridSpan-aware) of ``target_tc`` in ``tr``."""
+    col = 1
+    for child in tr.childNodes:
+        if child.nodeType != child.ELEMENT_NODE or child.tagName != "w:tc":
+            continue
+        if child is target_tc:
+            return col
+        col += _direct_grid_span(child)
+    raise ValueError("target_tc is not a direct child of tr")
+
+
+def _doc_wide_table_index(dom, target_tbl) -> int:
+    """1-based depth-first index of ``target_tbl`` among all ``<w:tbl>``."""
+    for i, tbl in enumerate(dom.getElementsByTagName("w:tbl"), start=1):
+        if tbl is target_tbl:
+            return i
+    raise ValueError("target_tbl not found in document")
+
+
+def _table_depth(tbl) -> int:
+    """1 = outermost table; +1 for each enclosing ``<w:tbl>`` ancestor."""
+    depth = 1
+    parent = tbl.parentNode
+    while parent is not None:
+        if parent.nodeType == parent.ELEMENT_NODE and parent.tagName == "w:tbl":
+            depth += 1
+        parent = parent.parentNode
+    return depth
+
+
+def compute_paragraph_location(paragraph) -> ParagraphLocation:
+    """Compute the structural location of a ``<w:p>`` element.
+
+    Reports the innermost enclosing ``<w:tc>`` (and its table), or
+    ``ParagraphLocation(table=None)`` if the paragraph is not inside any
+    table cell.
+    """
+    tc = _innermost_ancestor(paragraph, "w:tc")
+    if tc is None:
+        return ParagraphLocation(table=None)
+    tr = _innermost_ancestor(tc, "w:tr")
+    tbl = _innermost_ancestor(tr, "w:tbl") if tr is not None else None
+    if tr is None or tbl is None:
+        # Malformed table structure — tolerate by treating as body content.
+        return ParagraphLocation(table=None)
+    return ParagraphLocation(
+        table=TableCell(
+            index=_doc_wide_table_index(paragraph.ownerDocument, tbl),
+            row=_row_index_in_table(tbl, tr),
+            col=_logical_col_in_row(tr, tc),
+            depth=_table_depth(tbl),
+        )
+    )
+
+
 def _is_inside_element(node, tag_name: str) -> bool:
     """Check if a node is inside an element with the given tag."""
     parent = node.parentNode

--- a/tests/test_paragraph_location.py
+++ b/tests/test_paragraph_location.py
@@ -389,3 +389,153 @@ class TestParagraphLocationSdtWrappers:
             assert loc_1.table == TableCell(index=1, row=1, col=1, depth=1)
             assert loc_2.table == TableCell(index=1, row=1, col=2, depth=1)
             assert loc_3.table == TableCell(index=1, row=1, col=3, depth=1)
+
+
+class TestParagraphLocationNestedRowSkip:
+    """Outer-table walker must skip rows / cells that belong to nested tables.
+
+    These exercise the ``continue`` branches in ``_row_index_in_table`` and
+    ``_logical_col_in_row``. Distinct from the nested-table tests above:
+    here the *outer* row count / *outer* col count must be correct in spite
+    of an interposed nested table.
+    """
+
+    @staticmethod
+    def _doc_with_nested_between_outer_rows() -> str:
+        """Outer table with 2 rows; the first row's cell contains a nested table.
+
+        Looking up a paragraph in row 2 of the outer table forces the walker
+        to visit (and skip) the nested table's row before reaching row 2.
+        """
+        return (
+            '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+            f"<w:document {_W_NS}>"
+            "<w:body>"
+            "<w:tbl>"
+            # Row 1 — its only cell contains a nested table.
+            "<w:tr><w:tc>"
+            "<w:tbl><w:tr><w:tc><w:p><w:r><w:t>Inner</w:t></w:r></w:p></w:tc></w:tr></w:tbl>"
+            "</w:tc></w:tr>"
+            # Row 2 — the target.
+            "<w:tr><w:tc><w:p><w:r><w:t>Outer R2</w:t></w:r></w:p></w:tc></w:tr>"
+            "</w:tbl>"
+            "</w:body>"
+            "</w:document>"
+        )
+
+    @staticmethod
+    def _doc_with_nested_inside_first_cell() -> str:
+        """Single outer row whose first cell contains a nested table; second
+        cell is the target. Forces the column walker to skip a nested ``w:tc``.
+        """
+        return (
+            '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+            f"<w:document {_W_NS}>"
+            "<w:body>"
+            "<w:tbl><w:tr>"
+            # Cell 1 contains an entire nested table.
+            "<w:tc>"
+            "<w:tbl><w:tr><w:tc><w:p><w:r><w:t>Inner</w:t></w:r></w:p></w:tc></w:tr></w:tbl>"
+            "</w:tc>"
+            # Cell 2 — target.
+            "<w:tc><w:p><w:r><w:t>Outer C2</w:t></w:r></w:p></w:tc>"
+            "</w:tr></w:tbl>"
+            "</w:body>"
+            "</w:document>"
+        )
+
+    def test_row_walker_skips_nested_rows(self, simple_docx, tmp_path):
+        dest = tmp_path / "nested-rows.docx"
+        _replace_document_xml(simple_docx, dest, self._doc_with_nested_between_outer_rows())
+        with Document.open(dest) as doc:
+            loc = doc.get_paragraph_location(_ref_for_text(doc, "Outer R2"))
+            # Without the continue branch, the nested-table tr would be
+            # counted and "Outer R2" would land at row=3 (or raise).
+            assert loc.table == TableCell(index=1, row=2, col=1, depth=1)
+
+    def test_col_walker_skips_nested_cells(self, simple_docx, tmp_path):
+        dest = tmp_path / "nested-cells.docx"
+        _replace_document_xml(simple_docx, dest, self._doc_with_nested_inside_first_cell())
+        with Document.open(dest) as doc:
+            loc = doc.get_paragraph_location(_ref_for_text(doc, "Outer C2"))
+            # Without the continue branch, the nested-table tc would be
+            # counted and "Outer C2" would land at col=3.
+            assert loc.table == TableCell(index=1, row=1, col=2, depth=1)
+
+
+class TestParagraphLocationDefensiveFallbacks:
+    """The remaining defensive paths in ``_initial_grid_offset`` and
+    ``_compute_paragraph_location`` — exercised on malformed-ish XML that
+    minidom still parses (no schema validation).
+    """
+
+    @staticmethod
+    def test_tr_pr_without_grid_before_falls_back_to_zero(simple_docx, tmp_path):
+        """``<w:trPr>`` exists with other props but no ``<w:gridBefore>`` → offset 0."""
+        body = (
+            '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+            f"<w:document {_W_NS}>"
+            "<w:body>"
+            "<w:tbl>"
+            "<w:tr><w:trPr><w:cantSplit/></w:trPr>"
+            "<w:tc><w:p><w:r><w:t>NoGridBefore</w:t></w:r></w:p></w:tc>"
+            "</w:tr>"
+            "</w:tbl>"
+            "</w:body>"
+            "</w:document>"
+        )
+        dest = tmp_path / "tr-pr-no-gb.docx"
+        _replace_document_xml(simple_docx, dest, body)
+        with Document.open(dest) as doc:
+            loc = doc.get_paragraph_location(_ref_for_text(doc, "NoGridBefore"))
+            assert loc.table is not None
+            assert loc.table.col == 1
+
+    @staticmethod
+    def test_tc_outside_tr_returns_table_none(simple_docx, tmp_path):
+        """A ``<w:tc>`` not nested under a ``<w:tr>`` is treated as body content."""
+        body = (
+            '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+            f"<w:document {_W_NS}>"
+            "<w:body>"
+            # Orphan: tc directly under tbl, skipping the tr layer.
+            "<w:tbl>"
+            "<w:tc><w:p><w:r><w:t>Orphan tc</w:t></w:r></w:p></w:tc>"
+            "</w:tbl>"
+            "</w:body>"
+            "</w:document>"
+        )
+        dest = tmp_path / "orphan-tc.docx"
+        _replace_document_xml(simple_docx, dest, body)
+        with Document.open(dest) as doc:
+            loc = doc.get_paragraph_location(_ref_for_text(doc, "Orphan tc"))
+            # Malformed structure — falls back to body content, no raise.
+            assert loc.in_table is False
+            assert loc.table is None
+
+
+class TestParagraphLocationLongPreview:
+    """Cover the >80-char preview truncation in the ``HashMismatchError`` path."""
+
+    @staticmethod
+    def test_stale_ref_on_long_paragraph_truncates_preview(simple_docx, tmp_path):
+        long_text = "x" * 200
+        body = (
+            '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+            f"<w:document {_W_NS}>"
+            "<w:body>"
+            f"<w:p><w:r><w:t>{long_text}</w:t></w:r></w:p>"
+            "</w:body>"
+            "</w:document>"
+        )
+        dest = tmp_path / "long-para.docx"
+        _replace_document_xml(simple_docx, dest, body)
+        with Document.open(dest) as doc:
+            ref = _ref_for_text(doc, "xxxxx")
+            index_part, _ = ref.split("#")
+            stale_ref = f"{index_part}#0000"
+            with pytest.raises(HashMismatchError) as exc:
+                doc.get_paragraph_location(stale_ref)
+            # Preview should be truncated to 80 chars + "..."
+            assert exc.value.paragraph_preview.endswith("...")
+            assert len(exc.value.paragraph_preview) == 83  # 80 + "..."

--- a/tests/test_paragraph_location.py
+++ b/tests/test_paragraph_location.py
@@ -214,3 +214,57 @@ class TestParagraphLocationStaleRefs:
             pytest.raises(ValueError, match="Invalid paragraph reference"),
         ):
             doc.get_paragraph_location("not-a-ref")
+
+
+class TestParagraphLocationMalformedGridSpan:
+    """Defensive paths in ``_direct_grid_span`` must default to span=1.
+
+    A malformed ``w:gridSpan`` shouldn't blow up location lookup; the cell
+    is treated as if it spans a single column. Verified end-to-end by
+    checking the *next* cell in the row lands at ``col=2`` regardless of
+    the broken first-cell metadata.
+    """
+
+    def _doc_with_first_cell_tc_pr(self, tc_pr_xml: str) -> str:
+        """Build a doc whose first table row has two cells; the first
+        carries ``tc_pr_xml`` (the ``<w:tcPr>...</w:tcPr>`` block under test)."""
+        return (
+            '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+            f"<w:document {_W_NS}>"
+            "<w:body>"
+            "<w:tbl><w:tr>"
+            f"<w:tc>{tc_pr_xml}<w:p><w:r><w:t>First</w:t></w:r></w:p></w:tc>"
+            "<w:tc><w:p><w:r><w:t>Second</w:t></w:r></w:p></w:tc>"
+            "</w:tr></w:tbl>"
+            "</w:body>"
+            "</w:document>"
+        )
+
+    def _open(self, simple_docx: Path, tmp_path: Path, body_xml: str) -> Document:
+        dest = tmp_path / "malformed.docx"
+        _replace_document_xml(simple_docx, dest, body_xml)
+        return Document.open(dest)
+
+    def test_non_integer_grid_span_falls_back_to_one(self, simple_docx, tmp_path):
+        """``<w:gridSpan w:val="abc"/>`` is unparseable; treat as span=1."""
+        body = self._doc_with_first_cell_tc_pr('<w:tcPr><w:gridSpan w:val="abc"/></w:tcPr>')
+        with self._open(simple_docx, tmp_path, body) as doc:
+            loc = doc.get_paragraph_location(_ref_for_text(doc, "Second"))
+            assert loc.table is not None
+            assert loc.table.col == 2
+
+    def test_grid_span_without_val_attribute_falls_back_to_one(self, simple_docx, tmp_path):
+        """``<w:gridSpan/>`` (no ``w:val``) is treated as span=1."""
+        body = self._doc_with_first_cell_tc_pr("<w:tcPr><w:gridSpan/></w:tcPr>")
+        with self._open(simple_docx, tmp_path, body) as doc:
+            loc = doc.get_paragraph_location(_ref_for_text(doc, "Second"))
+            assert loc.table is not None
+            assert loc.table.col == 2
+
+    def test_tc_pr_without_grid_span_falls_back_to_one(self, simple_docx, tmp_path):
+        """``<w:tcPr>`` carrying other properties but no ``w:gridSpan`` → span=1."""
+        body = self._doc_with_first_cell_tc_pr('<w:tcPr><w:tcW w:w="2000" w:type="dxa"/></w:tcPr>')
+        with self._open(simple_docx, tmp_path, body) as doc:
+            loc = doc.get_paragraph_location(_ref_for_text(doc, "Second"))
+            assert loc.table is not None
+            assert loc.table.col == 2

--- a/tests/test_paragraph_location.py
+++ b/tests/test_paragraph_location.py
@@ -209,6 +209,8 @@ class TestParagraphLocationStaleRefs:
             assert exc.value.total_paragraphs == n
 
     def test_malformed_ref_raises_value_error(self, gridspan_docx):
-        with Document.open(gridspan_docx) as doc:
-            with pytest.raises(ValueError):
-                doc.get_paragraph_location("not-a-ref")
+        with (
+            Document.open(gridspan_docx) as doc,
+            pytest.raises(ValueError, match="Invalid paragraph reference"),
+        ):
+            doc.get_paragraph_location("not-a-ref")

--- a/tests/test_paragraph_location.py
+++ b/tests/test_paragraph_location.py
@@ -1,0 +1,214 @@
+"""Tests for :meth:`Document.get_paragraph_location`.
+
+Covers:
+  * body paragraphs report no table
+  * in-table paragraphs report ``TableCell`` coordinates
+  * ``col`` is the logical-grid column (``w:gridSpan``-aware), not the raw
+    ``<w:tc>`` count
+  * nested tables increment ``depth`` and produce a depth-first doc-wide
+    table ``index``
+  * stale refs raise ``HashMismatchError``; out-of-range refs raise
+    ``ParagraphIndexError``
+
+The fixture is built by swapping ``word/document.xml`` inside a copy of
+``simple.docx`` (already in ``tests/test_data``) so we don't need to commit
+another binary and don't pull in ``python-docx``.
+"""
+
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from docx_editor import (
+    Document,
+    HashMismatchError,
+    ParagraphIndexError,
+    ParagraphLocation,
+    TableCell,
+)
+
+# ---------- fixture builders -------------------------------------------------
+
+_W_NS = (
+    'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" '
+    'xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"'
+)
+
+
+def _build_document_xml() -> str:
+    """Hand-written ``word/document.xml`` with a gridSpan row and a nested table.
+
+    Paragraph layout (P{n} = 1-based paragraph index after ``Document.open``):
+
+      P1   body                                        "Body paragraph 1"
+      P2   table 1 / row 1 / col 1                     "A"
+      P3   table 1 / row 1 / col 2 (gridSpan=2)        "B (spans 2)"
+      P4   table 1 / row 1 / col 4                     "C"
+      P5   table 1 / row 2 / col 1                     "Row 2 col 1"
+      P6   table 1 / row 2 / col 2                     "Row 2 col 2"
+      P7   table 1 / row 2 / col 3                     "Row 2 col 3"
+      P8   body                                        "Body paragraph 2"
+      P9   table 2 / row 1 / col 1 (outer cell)        "Outer cell"
+      P10  table 3 / row 1 / col 1 (nested inside P9)  "Inner cell"
+      P11  body                                        "Body paragraph 3"
+    """
+    return (
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+        f"<w:document {_W_NS}>"
+        "<w:body>"
+        "<w:p><w:r><w:t>Body paragraph 1</w:t></w:r></w:p>"
+        # --- table 1: a row with a gridSpan=2 cell ---
+        "<w:tbl>"
+        "<w:tr>"
+        "<w:tc><w:p><w:r><w:t>A</w:t></w:r></w:p></w:tc>"
+        '<w:tc><w:tcPr><w:gridSpan w:val="2"/></w:tcPr>'
+        "<w:p><w:r><w:t>B (spans 2)</w:t></w:r></w:p></w:tc>"
+        "<w:tc><w:p><w:r><w:t>C</w:t></w:r></w:p></w:tc>"
+        "</w:tr>"
+        "<w:tr>"
+        "<w:tc><w:p><w:r><w:t>Row 2 col 1</w:t></w:r></w:p></w:tc>"
+        "<w:tc><w:p><w:r><w:t>Row 2 col 2</w:t></w:r></w:p></w:tc>"
+        "<w:tc><w:p><w:r><w:t>Row 2 col 3</w:t></w:r></w:p></w:tc>"
+        "</w:tr>"
+        "</w:tbl>"
+        "<w:p><w:r><w:t>Body paragraph 2</w:t></w:r></w:p>"
+        # --- table 2: a cell that contains another (nested) table ---
+        "<w:tbl>"
+        "<w:tr>"
+        "<w:tc>"
+        "<w:p><w:r><w:t>Outer cell</w:t></w:r></w:p>"
+        "<w:tbl>"
+        "<w:tr>"
+        "<w:tc><w:p><w:r><w:t>Inner cell</w:t></w:r></w:p></w:tc>"
+        "</w:tr>"
+        "</w:tbl>"
+        "</w:tc>"
+        "</w:tr>"
+        "</w:tbl>"
+        "<w:p><w:r><w:t>Body paragraph 3</w:t></w:r></w:p>"
+        "</w:body>"
+        "</w:document>"
+    )
+
+
+def _replace_document_xml(src: Path, dest: Path, new_doc_xml: str) -> None:
+    """Copy ``src`` to ``dest``, swapping ``word/document.xml`` for ``new_doc_xml``."""
+    with (
+        zipfile.ZipFile(src, "r") as z_in,
+        zipfile.ZipFile(dest, "w", zipfile.ZIP_DEFLATED) as z_out,
+    ):
+        for item in z_in.infolist():
+            data = new_doc_xml.encode("utf-8") if item.filename == "word/document.xml" else z_in.read(item.filename)
+            z_out.writestr(item, data)
+
+
+@pytest.fixture
+def gridspan_docx(simple_docx, tmp_path) -> Path:
+    """A .docx whose body contains a gridSpan row and a nested table."""
+    dest = tmp_path / "gridspan.docx"
+    _replace_document_xml(simple_docx, dest, _build_document_xml())
+    return dest
+
+
+def _ref_for_text(doc: Document, snippet: str) -> str:
+    """Return the first paragraph ref whose preview contains ``snippet``."""
+    for entry in doc.list_paragraphs():
+        if snippet in entry:
+            return entry.split("|")[0]
+    raise AssertionError(f"No paragraph contains {snippet!r}")
+
+
+# ---------- tests ------------------------------------------------------------
+
+
+class TestParagraphLocationBody:
+    def test_body_paragraph_has_no_table(self, gridspan_docx):
+        with Document.open(gridspan_docx) as doc:
+            ref = _ref_for_text(doc, "Body paragraph 1")
+            loc = doc.get_paragraph_location(ref)
+            assert isinstance(loc, ParagraphLocation)
+            assert loc.in_table is False
+            assert loc.table is None
+
+    def test_returns_paragraph_location_dataclass(self, gridspan_docx):
+        """API contract: returns ``ParagraphLocation``, not a tuple or dict."""
+        with Document.open(gridspan_docx) as doc:
+            ref = _ref_for_text(doc, "Row 2 col 2")
+            loc = doc.get_paragraph_location(ref)
+            assert isinstance(loc, ParagraphLocation)
+            assert isinstance(loc.table, TableCell)
+
+
+class TestParagraphLocationInTable:
+    def test_reports_row_and_logical_col(self, gridspan_docx):
+        with Document.open(gridspan_docx) as doc:
+            ref = _ref_for_text(doc, "Row 2 col 2")
+            loc = doc.get_paragraph_location(ref)
+            assert loc.in_table is True
+            assert loc.table == TableCell(index=1, row=2, col=2, depth=1)
+
+    def test_first_row_cells_report_correct_coordinates(self, gridspan_docx):
+        with Document.open(gridspan_docx) as doc:
+            loc_a = doc.get_paragraph_location(_ref_for_text(doc, "A"))
+            assert loc_a.table == TableCell(index=1, row=1, col=1, depth=1)
+
+
+class TestParagraphLocationGridSpan:
+    """A cell visually in column 4 must report ``col=4`` even though only 3
+    ``<w:tc>`` elements precede it in the row — the second cell carries
+    ``w:gridSpan=2``.
+    """
+
+    def test_logical_col_accounts_for_grid_span(self, gridspan_docx):
+        with Document.open(gridspan_docx) as doc:
+            loc_a = doc.get_paragraph_location(_ref_for_text(doc, "A"))
+            loc_b = doc.get_paragraph_location(_ref_for_text(doc, "B (spans 2)"))
+            loc_c = doc.get_paragraph_location(_ref_for_text(doc, "C"))
+        assert loc_a.table is not None
+        assert loc_b.table is not None
+        assert loc_c.table is not None
+        assert (loc_a.table.col, loc_b.table.col, loc_c.table.col) == (1, 2, 4)
+
+
+class TestParagraphLocationNested:
+    def test_outer_table_paragraph(self, gridspan_docx):
+        with Document.open(gridspan_docx) as doc:
+            loc = doc.get_paragraph_location(_ref_for_text(doc, "Outer cell"))
+        # Second top-level table in the document.
+        assert loc.table == TableCell(index=2, row=1, col=1, depth=1)
+
+    def test_inner_table_paragraph(self, gridspan_docx):
+        with Document.open(gridspan_docx) as doc:
+            loc = doc.get_paragraph_location(_ref_for_text(doc, "Inner cell"))
+        # depth=2 because nested inside another tbl; index=3 in doc-wide
+        # depth-first order (table 1 outer, table 2 outer, table 3 nested).
+        assert loc.table == TableCell(index=3, row=1, col=1, depth=2)
+
+
+class TestParagraphLocationStaleRefs:
+    """Mirror the error contract used by edit methods and ``add_comment``."""
+
+    def test_hash_mismatch_raises(self, gridspan_docx):
+        with Document.open(gridspan_docx) as doc:
+            ref = _ref_for_text(doc, "Body paragraph 1")
+            index_part, _hash = ref.split("#")
+            bad_ref = f"{index_part}#0000"  # forged hash
+            with pytest.raises(HashMismatchError) as exc:
+                doc.get_paragraph_location(bad_ref)
+            assert exc.value.paragraph_index == int(index_part[1:])
+            assert exc.value.expected_hash == "0000"
+
+    def test_out_of_range_index_raises(self, gridspan_docx):
+        with Document.open(gridspan_docx) as doc:
+            n = len(doc.list_paragraphs())
+            bad_ref = f"P{n + 99}#0000"
+            with pytest.raises(ParagraphIndexError) as exc:
+                doc.get_paragraph_location(bad_ref)
+            assert exc.value.index == n + 99
+            assert exc.value.total_paragraphs == n
+
+    def test_malformed_ref_raises_value_error(self, gridspan_docx):
+        with Document.open(gridspan_docx) as doc:
+            with pytest.raises(ValueError):
+                doc.get_paragraph_location("not-a-ref")

--- a/tests/test_paragraph_location.py
+++ b/tests/test_paragraph_location.py
@@ -268,3 +268,122 @@ class TestParagraphLocationMalformedGridSpan:
             loc = doc.get_paragraph_location(_ref_for_text(doc, "Second"))
             assert loc.table is not None
             assert loc.table.col == 2
+
+
+class TestParagraphLocationGridBefore:
+    """``<w:trPr>/<w:gridBefore w:val="N"/>`` shifts the row's first cell to
+    logical column ``N+1`` (ragged row). The walker must honour it.
+    """
+
+    @staticmethod
+    def _doc_with_grid_before(grid_before_val: str | None) -> str:
+        gb = f'<w:gridBefore w:val="{grid_before_val}"/>' if grid_before_val is not None else ""
+        tr_pr = f"<w:trPr>{gb}</w:trPr>" if gb else ""
+        return (
+            '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+            f"<w:document {_W_NS}>"
+            "<w:body>"
+            "<w:tbl>"
+            f"<w:tr>{tr_pr}"
+            "<w:tc><w:p><w:r><w:t>First cell</w:t></w:r></w:p></w:tc>"
+            "<w:tc><w:p><w:r><w:t>Second cell</w:t></w:r></w:p></w:tc>"
+            "</w:tr>"
+            "</w:tbl>"
+            "</w:body>"
+            "</w:document>"
+        )
+
+    def test_grid_before_shifts_first_cell(self, simple_docx, tmp_path):
+        """``gridBefore=2`` → first ``<w:tc>`` is at logical col 3."""
+        dest = tmp_path / "gridbefore.docx"
+        _replace_document_xml(simple_docx, dest, self._doc_with_grid_before("2"))
+        with Document.open(dest) as doc:
+            loc_a = doc.get_paragraph_location(_ref_for_text(doc, "First cell"))
+            loc_b = doc.get_paragraph_location(_ref_for_text(doc, "Second cell"))
+            assert loc_a.table is not None
+            assert loc_b.table is not None
+            assert (loc_a.table.col, loc_b.table.col) == (3, 4)
+
+    def test_grid_before_with_non_integer_val_falls_back_to_zero(self, simple_docx, tmp_path):
+        """``gridBefore w:val="abc"/`` is unparseable; treat offset as 0."""
+        dest = tmp_path / "gb-bad.docx"
+        _replace_document_xml(simple_docx, dest, self._doc_with_grid_before("abc"))
+        with Document.open(dest) as doc:
+            loc_a = doc.get_paragraph_location(_ref_for_text(doc, "First cell"))
+            assert loc_a.table is not None
+            assert loc_a.table.col == 1
+
+    def test_grid_before_missing_val_falls_back_to_zero(self, simple_docx, tmp_path):
+        """Bare ``<w:gridBefore/>`` (no ``w:val``) → offset 0."""
+        dest = tmp_path / "gb-empty.docx"
+        _replace_document_xml(simple_docx, dest, self._doc_with_grid_before(""))
+        with Document.open(dest) as doc:
+            loc_a = doc.get_paragraph_location(_ref_for_text(doc, "First cell"))
+            assert loc_a.table is not None
+            assert loc_a.table.col == 1
+
+
+class TestParagraphLocationSdtWrappers:
+    """Word templates often wrap rows and cells in
+    ``<w:sdt><w:sdtContent>...</w:sdtContent></w:sdt>`` (structured document
+    tags). The location walker must treat these wrappers transparently
+    rather than raising ``ValueError`` on the previous "direct child" walk.
+    """
+
+    @staticmethod
+    def _doc_with_sdt_row() -> str:
+        """Two-row table; the second row is wrapped in an ``<w:sdt>``."""
+        return (
+            '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+            f"<w:document {_W_NS}>"
+            "<w:body>"
+            "<w:tbl>"
+            "<w:tr><w:tc><w:p><w:r><w:t>R1</w:t></w:r></w:p></w:tc></w:tr>"
+            # Row 2 wrapped in sdt/sdtContent (legal under CT_SdtRow):
+            "<w:sdt><w:sdtContent>"
+            "<w:tr><w:tc><w:p><w:r><w:t>R2-sdt</w:t></w:r></w:p></w:tc></w:tr>"
+            "</w:sdtContent></w:sdt>"
+            "</w:tbl>"
+            "</w:body>"
+            "</w:document>"
+        )
+
+    @staticmethod
+    def _doc_with_sdt_cell() -> str:
+        """Single row whose second cell is wrapped in an ``<w:sdt>``."""
+        return (
+            '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+            f"<w:document {_W_NS}>"
+            "<w:body>"
+            "<w:tbl><w:tr>"
+            "<w:tc><w:p><w:r><w:t>C1</w:t></w:r></w:p></w:tc>"
+            "<w:sdt><w:sdtContent>"
+            "<w:tc><w:p><w:r><w:t>C2-sdt</w:t></w:r></w:p></w:tc>"
+            "</w:sdtContent></w:sdt>"
+            "<w:tc><w:p><w:r><w:t>C3</w:t></w:r></w:p></w:tc>"
+            "</w:tr></w:tbl>"
+            "</w:body>"
+            "</w:document>"
+        )
+
+    def test_sdt_wrapped_row_does_not_raise(self, simple_docx, tmp_path):
+        dest = tmp_path / "sdt-row.docx"
+        _replace_document_xml(simple_docx, dest, self._doc_with_sdt_row())
+        with Document.open(dest) as doc:
+            loc_1 = doc.get_paragraph_location(_ref_for_text(doc, "R1"))
+            loc_2 = doc.get_paragraph_location(_ref_for_text(doc, "R2-sdt"))
+            assert loc_1.table == TableCell(index=1, row=1, col=1, depth=1)
+            # The SDT-wrapped row is still row 2 of the same table.
+            assert loc_2.table == TableCell(index=1, row=2, col=1, depth=1)
+
+    def test_sdt_wrapped_cell_does_not_raise(self, simple_docx, tmp_path):
+        dest = tmp_path / "sdt-cell.docx"
+        _replace_document_xml(simple_docx, dest, self._doc_with_sdt_cell())
+        with Document.open(dest) as doc:
+            loc_1 = doc.get_paragraph_location(_ref_for_text(doc, "C1"))
+            loc_2 = doc.get_paragraph_location(_ref_for_text(doc, "C2-sdt"))
+            loc_3 = doc.get_paragraph_location(_ref_for_text(doc, "C3"))
+            # SDT is transparent — cells keep contiguous logical columns.
+            assert loc_1.table == TableCell(index=1, row=1, col=1, depth=1)
+            assert loc_2.table == TableCell(index=1, row=1, col=2, depth=1)
+            assert loc_3.table == TableCell(index=1, row=1, col=3, depth=1)

--- a/tests/test_paragraph_location.py
+++ b/tests/test_paragraph_location.py
@@ -225,7 +225,8 @@ class TestParagraphLocationMalformedGridSpan:
     the broken first-cell metadata.
     """
 
-    def _doc_with_first_cell_tc_pr(self, tc_pr_xml: str) -> str:
+    @staticmethod
+    def _doc_with_first_cell_tc_pr(tc_pr_xml: str) -> str:
         """Build a doc whose first table row has two cells; the first
         carries ``tc_pr_xml`` (the ``<w:tcPr>...</w:tcPr>`` block under test)."""
         return (
@@ -240,7 +241,8 @@ class TestParagraphLocationMalformedGridSpan:
             "</w:document>"
         )
 
-    def _open(self, simple_docx: Path, tmp_path: Path, body_xml: str) -> Document:
+    @staticmethod
+    def _open(simple_docx: Path, tmp_path: Path, body_xml: str) -> Document:
         dest = tmp_path / "malformed.docx"
         _replace_document_xml(simple_docx, dest, body_xml)
         return Document.open(dest)


### PR DESCRIPTION
Closes #22.

Adds `Document.get_paragraph_location(ref)` returning a `ParagraphLocation`, which carries a `TableCell(index, row, col, depth)` when the paragraph is inside a `<w:tc>`, or `table=None` when it lives in the document body.

## Design (Option B from the issue)

```python
@dataclass(frozen=True)
class TableCell:
    index: int   # 1-based, doc-wide, depth-first order of <w:tbl>
    row: int     # 1-based
    col: int     # 1-based logical grid (accounts for w:gridSpan)
    depth: int   # 1 = outermost, >1 = nested

@dataclass(frozen=True)
class ParagraphLocation:
    table: TableCell | None
    @property
    def in_table(self) -> bool: ...

class Document:
    def get_paragraph_location(self, ref: str) -> ParagraphLocation: ...
```

## Semantics

- **`col` is logical-grid**: a cell that visually sits in column 4 reports `col=4` even when an earlier cell in the row carries `w:gridSpan=2`. Counting raw `<w:tc>` would give col=3, which mismatches what Word displays.
- **`depth`** is 1 for top-level tables, +1 for each enclosing `<w:tbl>` ancestor.
- **`index`** is the 1-based depth-first order of `<w:tbl>` doc-wide — lets callers key per-table state across multiple tables.
- **Errors** match the contract used by edit methods and `add_comment`: `ParagraphRef.parse` raises `ValueError` on malformed refs; out-of-range index raises `ParagraphIndexError`; stale hash raises `HashMismatchError`.
- **Extensibility**: `ParagraphLocation` is intentionally one field today. Future container kinds (header / footer / footnote), section index, list position, etc. can land as plain optional field additions without breaking existing call sites.

## Tests

`tests/test_paragraph_location.py` covers:

- Body paragraph → `table is None`, `in_table is False`
- In-table paragraph → correct `TableCell(index, row, col, depth)`
- **gridSpan-aware `col`** — three cells with the second carrying `gridSpan=2` report `(1, 2, 4)`, not `(1, 2, 3)`
- Nested table → outer paragraph reports `depth=1, index=2`; inner reports `depth=2, index=3`
- Stale hash → `HashMismatchError` with `paragraph_index` / `expected_hash` attributes
- Out-of-range index → `ParagraphIndexError` with `index` / `total_paragraphs` attributes
- Malformed ref → `ValueError`

The fixture is built at runtime by swapping `word/document.xml` inside a copy of the existing `simple.docx`, so the PR adds no new binary fixture and no new test dependency (e.g. `python-docx`).

## Verification

- `uv run pytest tests -n auto` → **538 passed, 6 skipped** (no regressions; 10 new tests all pass)
- `uv run ruff check .` → clean
- `uv run ruff format --check .` → clean
- `uv run ty check` → clean
- `uv run pre-commit run -a` → clean
- `uv lock --locked` → clean (no `pyproject.toml` changes)

## Use case (real-world driver)

In our AI contract-review pipeline, when the LLM flags "Phase 1's payment ratio is too high (25% of total)", we now get structural context directly from the library: paragraph P8 → `TableCell(index=1, row=2, col=1, depth=1)` → we can tell the LLM exactly which row/col of which table is being discussed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Paragraph location lookup: get a paragraph’s structural position (table membership, cell coordinates, gridSpan-aware column, and nesting depth).
  * Paragraph-location types now available from the package root for easier access.

* **Bug Fixes / Validation**
  * Clear errors for invalid, out-of-range, or stale paragraph references with trimmed previews.

* **Tests**
  * Comprehensive suite covering tables, gridSpan, nesting, malformed cases, and error conditions.

* **Documentation**
  * README updated to document the new Paragraph Location capability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pablospe/docx-editor/pull/23?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->