### PR TITLE
feat: add pagination to list_paragraphs() and paragraph_count()

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,8 @@ with Document.open("reviewed.docx", author="Editor") as doc:
     total = doc.paragraph_count()
     page_size = 50
     for start in range(1, total + 1, page_size):
-        page = doc.list_paragraphs(start=start, limit=page_size)
+        for ref in doc.list_paragraphs(start=start, limit=page_size):
+            print(ref)  # process this page of refs
 
     # Find text across element boundaries
     match = doc.find_text("Aim: To")

--- a/README.md
+++ b/README.md
@@ -117,9 +117,12 @@ with Document.open("reviewed.docx", author="Editor") as doc:
     # List paragraphs to find hash-anchored references
     refs = doc.list_paragraphs()
 
-    # Page through large documents (refs stay globally indexed: P51, P52, ...)
+    # Page through large documents — you choose the page size; refs stay
+    # globally indexed (page 2 with size 50 starts at P51, not P1)
     total = doc.paragraph_count()
-    page = doc.list_paragraphs(start=51, limit=50)
+    page_size = 50
+    for start in range(1, total + 1, page_size):
+        page = doc.list_paragraphs(start=start, limit=page_size)
 
     # Find text across element boundaries
     match = doc.find_text("Aim: To")

--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ with Document.open("reviewed.docx", author="Editor") as doc:
     # List paragraphs to find hash-anchored references
     refs = doc.list_paragraphs()
 
+    # Page through large documents (refs stay globally indexed: P51, P52, ...)
+    total = doc.paragraph_count()
+    page = doc.list_paragraphs(start=51, limit=50)
+
     # Find text across element boundaries
     match = doc.find_text("Aim: To")
     if match and match.spans_boundary:

--- a/docs/api.md
+++ b/docs/api.md
@@ -84,10 +84,12 @@ refs = doc.list_paragraphs()
 for ref in refs:
     print(ref)
 
-# Page through a large document
+# Page through a large document — you pick the page size; refs stay
+# globally indexed (with size 50, page 2 starts at P51)
 count = doc.paragraph_count()
-page1 = doc.list_paragraphs(start=1, limit=50)
-page2 = doc.list_paragraphs(start=51, limit=50)
+page_size = 50
+for start in range(1, count + 1, page_size):
+    page = doc.list_paragraphs(start=start, limit=page_size)
 ```
 
 #### `get_visible_text()`

--- a/docs/api.md
+++ b/docs/api.md
@@ -57,7 +57,7 @@ print(doc.source_path)  # Path("/path/to/contract.docx")
 
 Return the total number of paragraphs in the document. A cheap bounds check for pagination — avoids building the full `list_paragraphs()` result just to learn the count.
 
-**Returns:** Total number of paragraphs (the highest valid 1-based ref index) (int)
+**Returns:** Total number of paragraphs (the highest valid 1-based ref index).
 
 **Example:**
 
@@ -65,17 +65,17 @@ Return the total number of paragraphs in the document. A cheap bounds check for 
 count = doc.paragraph_count()
 ```
 
-#### `list_paragraphs(max_chars=80, start=1, limit=None)`
+#### `list_paragraphs(max_chars=80, *, start=1, limit=None)`
 
 List paragraphs with hash-anchored references. Refs are **1-based global** indexes (`P1`, `P2`, …) and stay correct across pages — a slice starting at paragraph 51 emits `P51#…`, not `P1#…`.
 
 **Parameters:**
 
-- `max_chars` (int): Maximum preview length. Use `0` for refs only (e.g. `P1#a7b2`), with no preview or `| ` separator.
+- `max_chars` (int): Maximum preview length (must be `>= 0`). Use `0` for refs only (e.g. `P1#a7b2`), with no preview or `| ` separator.
 - `start` (int): 1-based index of the first paragraph to return (default 1). A `start` beyond the last paragraph yields an empty list.
 - `limit` (int | None): Maximum number of paragraphs to return, or `None` for all paragraphs from `start` onward (default `None`).
 
-**Returns:** List of strings in the form `P{index}#{hash}| preview text`
+**Returns:** List of strings in the form `P{index}#{hash}| preview text`, or bare `P{index}#{hash}` (no `| ` separator) when `max_chars=0`.
 
 **Example:**
 
@@ -89,7 +89,8 @@ for ref in refs:
 count = doc.paragraph_count()
 page_size = 50
 for start in range(1, count + 1, page_size):
-    page = doc.list_paragraphs(start=start, limit=page_size)
+    for ref in doc.list_paragraphs(start=start, limit=page_size):
+        print(ref)  # process this page of refs
 ```
 
 #### `get_visible_text()`

--- a/docs/api.md
+++ b/docs/api.md
@@ -53,13 +53,27 @@ print(doc.source_path)  # Path("/path/to/contract.docx")
 
 ### Track Changes Methods
 
-#### `list_paragraphs(max_chars=80)`
+#### `paragraph_count()`
 
-List paragraphs with hash-anchored references.
+Return the total number of paragraphs in the document. A cheap bounds check for pagination — avoids building the full `list_paragraphs()` result just to learn the count.
+
+**Returns:** Total number of paragraphs (the highest valid 1-based ref index) (int)
+
+**Example:**
+
+```python
+count = doc.paragraph_count()
+```
+
+#### `list_paragraphs(max_chars=80, start=1, limit=None)`
+
+List paragraphs with hash-anchored references. Refs are **1-based global** indexes (`P1`, `P2`, …) and stay correct across pages — a slice starting at paragraph 51 emits `P51#…`, not `P1#…`.
 
 **Parameters:**
 
-- `max_chars` (int): Maximum preview length. Use 0 for refs only.
+- `max_chars` (int): Maximum preview length. Use `0` for refs only (e.g. `P1#a7b2`), with no preview or `| ` separator.
+- `start` (int): 1-based index of the first paragraph to return (default 1). A `start` beyond the last paragraph yields an empty list.
+- `limit` (int | None): Maximum number of paragraphs to return, or `None` for all paragraphs from `start` onward (default `None`).
 
 **Returns:** List of strings in the form `P{index}#{hash}| preview text`
 
@@ -69,6 +83,11 @@ List paragraphs with hash-anchored references.
 refs = doc.list_paragraphs()
 for ref in refs:
     print(ref)
+
+# Page through a large document
+count = doc.paragraph_count()
+page1 = doc.list_paragraphs(start=1, limit=50)
+page2 = doc.list_paragraphs(start=51, limit=50)
 ```
 
 #### `get_visible_text()`

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -47,13 +47,15 @@ P2#f3c1| Payment is due within 30 days...
 P3#b2c4| Section 5 describes review obligations...
 ```
 
-For large documents, page through paragraphs with `start`/`limit`. Refs keep their global 1-based index (page 2 starts at `P51`, not `P1`):
+For large documents, page through paragraphs with `start`/`limit`. You choose the page size; refs keep their global 1-based index (with a page size of 50, page 2 starts at `P51`, not `P1`):
 
 ```python
 with Document.open("contract.docx") as doc:
     total = doc.paragraph_count()
-    for paragraph in doc.list_paragraphs(start=51, limit=50):
-        print(paragraph)
+    page_size = 50
+    for start in range(1, total + 1, page_size):
+        for paragraph in doc.list_paragraphs(start=start, limit=page_size):
+            print(paragraph)
 ```
 
 Use the `P{index}#{hash}` part as the `paragraph=` argument. Edit methods return a new paragraph ref after the hash changes, so keep the returned value when chaining edits in the same paragraph.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -47,6 +47,15 @@ P2#f3c1| Payment is due within 30 days...
 P3#b2c4| Section 5 describes review obligations...
 ```
 
+For large documents, page through paragraphs with `start`/`limit`. Refs keep their global 1-based index (page 2 starts at `P51`, not `P1`):
+
+```python
+with Document.open("contract.docx") as doc:
+    total = doc.paragraph_count()
+    for paragraph in doc.list_paragraphs(start=51, limit=50):
+        print(paragraph)
+```
+
 Use the `P{index}#{hash}` part as the `paragraph=` argument. Edit methods return a new paragraph ref after the hash changes, so keep the returned value when chaining edits in the same paragraph.
 
 ## Track Changes

--- a/docx_editor/document.py
+++ b/docx_editor/document.py
@@ -158,25 +158,56 @@ class Document:
         new_hash = compute_paragraph_hash(p)
         return f"P{ref.index}#{new_hash}"
 
-    def list_paragraphs(self, max_chars: int = 80) -> list[str]:
-        """List all paragraphs with hash-anchored references.
+    def paragraph_count(self) -> int:
+        """Return the total number of paragraphs in the document.
+
+        Cheap bounds check for pagination — avoids building the full
+        :meth:`list_paragraphs` result just to learn the count.
+
+        Returns:
+            Total number of paragraphs (the highest valid 1-based ref index).
+        """
+        self._ensure_open()
+        return len(self._document_editor.dom.getElementsByTagName("w:p"))
+
+    def list_paragraphs(self, max_chars: int = 80, start: int = 1, limit: int | None = None) -> list[str]:
+        """List paragraphs with hash-anchored references.
 
         Returns a list of strings like "P1#a7b2| Introduction to the..."
-        for use as stable paragraph references in editing operations.
+        for use as stable paragraph references in editing operations. Refs
+        are **1-based global** indexes (P1, P2, …) and stay correct across
+        pages — a slice starting at paragraph 51 emits "P51#…", not "P1#…".
 
         Args:
             max_chars: Maximum characters for the preview text (default 80).
-                Use 0 to get only hash refs without preview text.
+                Use 0 to get only the hash refs (e.g. "P1#a7b2"), with no
+                preview or "| " separator.
+            start: 1-based index of the first paragraph to return (default 1).
+                A ``start`` beyond the last paragraph yields an empty list.
+            limit: Maximum number of paragraphs to return, or ``None`` for all
+                paragraphs from ``start`` onward (default ``None``).
 
         Returns:
-            List of hash-tagged paragraph preview strings
+            List of hash-tagged paragraph preview strings.
+
+        Example:
+            Page through a large document::
+
+                count = doc.paragraph_count()
+                page1 = doc.list_paragraphs(start=1, limit=50)
+                page2 = doc.list_paragraphs(start=51, limit=50)
         """
         self._ensure_open()
         paragraphs = self._document_editor.dom.getElementsByTagName("w:p")
+        begin = max(0, start - 1)  # guard 0/negative start; keep refs correct
+        end = begin + limit if limit is not None else None
         result = []
-        for i, p in enumerate(paragraphs, start=1):
+        for i, p in enumerate(paragraphs[begin:end], start=begin + 1):
             h = compute_paragraph_hash(p)
             tm = build_text_map(p)
+            if max_chars == 0:
+                result.append(f"P{i}#{h}")
+                continue
             preview = tm.text[:max_chars]
             if len(tm.text) > max_chars:
                 preview += "..."

--- a/docx_editor/document.py
+++ b/docx_editor/document.py
@@ -183,31 +183,38 @@ class Document:
                 Use 0 to get only the hash refs (e.g. "P1#a7b2"), with no
                 preview or "| " separator.
             start: 1-based index of the first paragraph to return (default 1).
-                A ``start`` beyond the last paragraph yields an empty list.
+                Must be >= 1. A ``start`` beyond the last paragraph yields an
+                empty list.
             limit: Maximum number of paragraphs to return, or ``None`` for all
-                paragraphs from ``start`` onward (default ``None``).
+                paragraphs from ``start`` onward (default ``None``). Must be
+                >= 0 when given; ``0`` yields an empty list.
 
         Returns:
             List of hash-tagged paragraph preview strings.
 
-        Example:
-            Page through a large document::
+        Raises:
+            ValueError: If ``start`` < 1 or ``limit`` < 0.
 
-                count = doc.paragraph_count()
-                page1 = doc.list_paragraphs(start=1, limit=50)
-                page2 = doc.list_paragraphs(start=51, limit=50)
+        Example:
+            count = doc.paragraph_count()
+            page1 = doc.list_paragraphs(start=1, limit=50)
+            page2 = doc.list_paragraphs(start=51, limit=50)
         """
         self._ensure_open()
+        if start < 1:
+            raise ValueError(f"start must be >= 1, got {start}")
+        if limit is not None and limit < 0:
+            raise ValueError(f"limit must be >= 0, got {limit}")
         paragraphs = self._document_editor.dom.getElementsByTagName("w:p")
-        begin = max(0, start - 1)  # guard 0/negative start; keep refs correct
+        begin = start - 1
         end = begin + limit if limit is not None else None
         result = []
         for i, p in enumerate(paragraphs[begin:end], start=begin + 1):
             h = compute_paragraph_hash(p)
-            tm = build_text_map(p)
             if max_chars == 0:
                 result.append(f"P{i}#{h}")
                 continue
+            tm = build_text_map(p)
             preview = tm.text[:max_chars]
             if len(tm.text) > max_chars:
                 preview += "..."

--- a/docx_editor/document.py
+++ b/docx_editor/document.py
@@ -170,7 +170,7 @@ class Document:
         self._ensure_open()
         return len(self._document_editor.dom.getElementsByTagName("w:p"))
 
-    def list_paragraphs(self, max_chars: int = 80, start: int = 1, limit: int | None = None) -> list[str]:
+    def list_paragraphs(self, max_chars: int = 80, *, start: int = 1, limit: int | None = None) -> list[str]:
         """List paragraphs with hash-anchored references.
 
         Returns a list of strings like "P1#a7b2| Introduction to the..."
@@ -180,8 +180,8 @@ class Document:
 
         Args:
             max_chars: Maximum characters for the preview text (default 80).
-                Use 0 to get only the hash refs (e.g. "P1#a7b2"), with no
-                preview or "| " separator.
+                Must be >= 0. Use 0 to get only the hash refs (e.g. "P1#a7b2"),
+                with no preview or "| " separator.
             start: 1-based index of the first paragraph to return (default 1).
                 Must be >= 1. A ``start`` beyond the last paragraph yields an
                 empty list.
@@ -193,16 +193,19 @@ class Document:
             List of hash-tagged paragraph preview strings.
 
         Raises:
-            ValueError: If ``start`` < 1 or ``limit`` < 0.
+            ValueError: If ``max_chars`` < 0, ``start`` < 1, or ``limit`` < 0.
 
         Example:
             # Caller chooses the page size; ``start`` walks forward by it.
             count = doc.paragraph_count()
             page_size = 50
             for start in range(1, count + 1, page_size):
-                page = doc.list_paragraphs(start=start, limit=page_size)
+                for ref in doc.list_paragraphs(start=start, limit=page_size):
+                    print(ref)
         """
         self._ensure_open()
+        if max_chars < 0:
+            raise ValueError(f"max_chars must be >= 0, got {max_chars}")
         if start < 1:
             raise ValueError(f"start must be >= 1, got {start}")
         if limit is not None and limit < 0:

--- a/docx_editor/document.py
+++ b/docx_editor/document.py
@@ -196,9 +196,11 @@ class Document:
             ValueError: If ``start`` < 1 or ``limit`` < 0.
 
         Example:
+            # Caller chooses the page size; ``start`` walks forward by it.
             count = doc.paragraph_count()
-            page1 = doc.list_paragraphs(start=1, limit=50)
-            page2 = doc.list_paragraphs(start=51, limit=50)
+            page_size = 50
+            for start in range(1, count + 1, page_size):
+                page = doc.list_paragraphs(start=start, limit=page_size)
         """
         self._ensure_open()
         if start < 1:

--- a/skills/docx/SKILL.md
+++ b/skills/docx/SKILL.md
@@ -399,11 +399,12 @@ with Document.open("file.docx", author=author) as doc:
     doc.save()
 ```
 
-Refs are **1-based** global indexes (`P1`, not `P0`). For large documents, page through paragraphs to save tokens — `paragraph_count()` gives the total for bounds, and `start`/`limit` return a slice whose refs keep their global index (page 2 starts at `P51`, not `P1`). Pass `max_chars=0` to get bare refs (`P1#a7b2`) with no preview text or `| ` separator:
+Refs are **1-based** global indexes (`P1`, not `P0`). For large documents, page through paragraphs to save tokens — `paragraph_count()` gives the total for bounds, and `start`/`limit` return a slice whose refs keep their global index. You pick the page size (there's no built-in limit); with `limit=N` the next page starts at `start + N`. Pass `max_chars=0` to get bare refs (`P1#a7b2`) with no preview text or `| ` separator:
 
 ```python
-total = doc.paragraph_count()                       # cheap bounds check
-page2 = doc.list_paragraphs(start=51, limit=50)      # refs P51..P100
+total = doc.paragraph_count()                        # cheap bounds check
+page_size = 50                                        # caller's choice
+page2 = doc.list_paragraphs(start=1 + page_size, limit=page_size)  # refs P51..P100
 refs_only = doc.list_paragraphs(max_chars=0)         # "P1#a7b2", no preview
 ```
 

--- a/skills/docx/SKILL.md
+++ b/skills/docx/SKILL.md
@@ -399,6 +399,14 @@ with Document.open("file.docx", author=author) as doc:
     doc.save()
 ```
 
+Refs are **1-based** global indexes (`P1`, not `P0`). For large documents, page through paragraphs to save tokens — `paragraph_count()` gives the total for bounds, and `start`/`limit` return a slice whose refs keep their global index (page 2 starts at `P51`, not `P1`). Pass `max_chars=0` to get bare refs (`P1#a7b2`) with no preview text or `| ` separator:
+
+```python
+total = doc.paragraph_count()                       # cheap bounds check
+page2 = doc.list_paragraphs(start=51, limit=50)      # refs P51..P100
+refs_only = doc.list_paragraphs(max_chars=0)         # "P1#a7b2", no preview
+```
+
 The `paragraph` argument is **required** for all edit methods. If the paragraph content has changed since you called `list_paragraphs()`, a `HashMismatchError` is raised — preventing edits to the wrong location.
 
 **Every edit method returns the new paragraph ref as a plain string.** Chain edits without calling `list_paragraphs()` again:

--- a/tests/test_paragraph_hash.py
+++ b/tests/test_paragraph_hash.py
@@ -235,6 +235,30 @@ class TestListParagraphs:
         finally:
             doc.close()
 
+    def test_pagination_limit_zero_returns_empty(self, temp_docx):
+        doc = Document.open(temp_docx)
+        try:
+            assert doc.list_paragraphs(limit=0) == []
+        finally:
+            doc.close()
+
+    def test_pagination_invalid_start_raises(self, temp_docx):
+        doc = Document.open(temp_docx)
+        try:
+            for bad in (0, -1):
+                with pytest.raises(ValueError, match="start must be >= 1"):
+                    doc.list_paragraphs(start=bad)
+        finally:
+            doc.close()
+
+    def test_pagination_negative_limit_raises(self, temp_docx):
+        doc = Document.open(temp_docx)
+        try:
+            with pytest.raises(ValueError, match="limit must be >= 0"):
+                doc.list_paragraphs(limit=-1)
+        finally:
+            doc.close()
+
 
 # ==================== Scoped Operations Tests ====================
 

--- a/tests/test_paragraph_hash.py
+++ b/tests/test_paragraph_hash.py
@@ -176,6 +176,65 @@ class TestListParagraphs:
         finally:
             doc.close()
 
+    def test_paragraph_count_matches_list_len(self, temp_docx):
+        doc = Document.open(temp_docx)
+        try:
+            count = doc.paragraph_count()
+            assert isinstance(count, int)
+            assert count == len(doc.list_paragraphs())
+        finally:
+            doc.close()
+
+    def test_pagination_slice(self, temp_docx):
+        doc = Document.open(temp_docx)
+        try:
+            full = doc.list_paragraphs()
+            assert len(full) >= 3, "fixture needs >=3 paragraphs for this test"
+            page = doc.list_paragraphs(start=2, limit=2)
+            assert len(page) == 2
+            # Global 1-based indexing preserved across pages
+            assert page[0].startswith("P2#")
+            assert page[1].startswith("P3#")
+            assert page == full[1:3]
+        finally:
+            doc.close()
+
+    def test_pagination_start_only(self, temp_docx):
+        doc = Document.open(temp_docx)
+        try:
+            full = doc.list_paragraphs()
+            assert doc.list_paragraphs(start=2) == full[1:]
+        finally:
+            doc.close()
+
+    def test_pagination_start_beyond_total_returns_empty(self, temp_docx):
+        doc = Document.open(temp_docx)
+        try:
+            beyond = doc.paragraph_count() + 5
+            assert doc.list_paragraphs(start=beyond) == []
+        finally:
+            doc.close()
+
+    def test_max_chars_zero_refs_only(self, temp_docx):
+        doc = Document.open(temp_docx)
+        try:
+            refs_only = doc.list_paragraphs(max_chars=0)
+            default = doc.list_paragraphs()
+            for entry, default_entry in zip(refs_only, default, strict=True):
+                # Bare ref: no separator, no trailing space
+                assert re.match(r"^P\d+#[0-9a-f]{4}$", entry), f"Bad format: {entry}"
+                # Ref matches the prefix of the default listing
+                assert default_entry.startswith(entry + "| ")
+        finally:
+            doc.close()
+
+    def test_default_behavior_unchanged(self, temp_docx):
+        doc = Document.open(temp_docx)
+        try:
+            assert doc.list_paragraphs() == doc.list_paragraphs(start=1, limit=None)
+        finally:
+            doc.close()
+
 
 # ==================== Scoped Operations Tests ====================
 

--- a/tests/test_paragraph_hash.py
+++ b/tests/test_paragraph_hash.py
@@ -259,6 +259,14 @@ class TestListParagraphs:
         finally:
             doc.close()
 
+    def test_negative_max_chars_raises(self, temp_docx):
+        doc = Document.open(temp_docx)
+        try:
+            with pytest.raises(ValueError, match="max_chars must be >= 0"):
+                doc.list_paragraphs(max_chars=-1)
+        finally:
+            doc.close()
+
 
 # ==================== Scoped Operations Tests ====================
 


### PR DESCRIPTION
## Summary

Adds token-efficient pagination to `list_paragraphs()` for large documents, plus a cheap `paragraph_count()` bounds-check helper.

- `list_paragraphs(max_chars=80, start=1, limit=None)` — `start`/`limit` slice the paragraph list while keeping refs **1-based and globally indexed** (page 2 starts at `P51#…`, not `P1#…`).
- `paragraph_count()` — returns the total paragraph count without building the full listing.
- `max_chars=0` now emits bare refs (`P1#a7b2`) with no `| ` separator, and skips text-map construction on that path.
- Invalid input raises `ValueError` (`start < 1` or `limit < 0`) rather than silently coercing or returning a near-complete listing via slice semantics — consistent with the project's no-magic principle.

## Tests

9 new tests covering `paragraph_count()`, pagination slicing, global ref indexing, out-of-range start, `limit=0`, invalid `start`/`limit`, the `max_chars=0` format, and default-arg backward compatibility. Full suite: 560 passed, 6 skipped.

## Docs

Updated `docs/api.md`, `README.md`, `docs/quickstart.md`, and `skills/docx/SKILL.md` with pagination examples and 1-based indexing notes.