### PR TITLE
feat: add list_paragraph_locations() batch accessor

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Pure Python library for Word document track changes and comments, without requir
 ## Features
 
 - **Hash-Anchored Paragraph References**: `list_paragraphs()` returns stable, hash-based paragraph IDs for safe, unambiguous targeting
-- **Paragraph Location**: `get_paragraph_location(ref)` reports whether a paragraph lives in the body or inside a table cell — with `w:gridSpan`-aware logical column, row, table index, and nesting depth
+- **Paragraph Location**: `get_paragraph_location(ref)` reports whether a paragraph lives in the body or inside a table cell — with `w:gridSpan`-aware logical column, row, table index, and nesting depth. `list_paragraph_locations()` returns `(ref, location)` for every paragraph in one batch pass, avoiding a per-paragraph table rescan
 - **Batch Editing**: Atomic `batch_edit()` with upfront hash validation across all operations
 - **Paragraph Rewrite**: `rewrite_paragraph()` with automatic word-level diffing — specify desired text, get fine-grained tracked changes
 - **Track Changes**: Replace, delete, and insert text with revision tracking

--- a/docs/api.md
+++ b/docs/api.md
@@ -71,6 +71,40 @@ for ref in refs:
     print(ref)
 ```
 
+#### `get_paragraph_location(ref)`
+
+Report whether a paragraph lives in the document body or inside a table cell.
+
+**Parameters:**
+
+- `ref` (str): Paragraph reference from `list_paragraphs()`, such as `P2#f3c1`
+
+**Returns:** `ParagraphLocation`. `location.in_table` is `False` for body paragraphs; `True` when the paragraph is inside a `<w:tc>` cell, in which case `location.table` carries the 1-based table index, row, `w:gridSpan`-aware logical column, and nesting depth.
+
+**Example:**
+
+```python
+loc = doc.get_paragraph_location("P3#a7b2")
+if loc.in_table:
+    cell = loc.table
+    print(f"table {cell.index} r{cell.row} c{cell.col} (depth {cell.depth})")
+```
+
+#### `list_paragraph_locations()`
+
+Batch counterpart to `get_paragraph_location()`: pair every paragraph with its structural location in one pass, precomputing table indices once instead of rescanning the table hierarchy per ref.
+
+**Returns:** List of `(ref, ParagraphLocation)` tuples in document order, where `ref` is the same `P{index}#{hash}` token emitted by `list_paragraphs()`.
+
+**Example:**
+
+```python
+for ref, loc in doc.list_paragraph_locations():
+    if loc.in_table:
+        cell = loc.table
+        print(f"{ref}: table {cell.index} r{cell.row} c{cell.col} (depth {cell.depth})")
+```
+
 #### `get_visible_text()`
 
 Get flattened visible document text. Inserted text is included and deleted text is excluded.

--- a/docx_editor/document.py
+++ b/docx_editor/document.py
@@ -16,6 +16,7 @@ from .xml_editor import (
     DocxXMLEditor,
     ParagraphLocation,
     ParagraphRef,
+    _build_table_index,
     _compute_paragraph_location,
     build_text_map,
     compute_paragraph_hash,
@@ -233,6 +234,36 @@ class Document:
                 preview += "..."
             raise HashMismatchError(parsed.index, parsed.hash, actual_hash, preview)
         return _compute_paragraph_location(p)
+
+    def list_paragraph_locations(self) -> list[tuple[str, ParagraphLocation]]:
+        """List every paragraph paired with its structural location.
+
+        Batch counterpart to :meth:`get_paragraph_location`: precomputes
+        table indices once instead of re-scanning the table hierarchy per
+        ref. Each entry is ``(ref, location)`` where
+        ``ref`` is the same ``"P{i}#{hash}"`` token emitted by
+        :meth:`list_paragraphs` (the part before ``|``) and accepted by
+        :meth:`get_paragraph_location` and the editing methods.
+
+        Returns:
+            List of ``(ref, ParagraphLocation)`` tuples in document order.
+            ``location.in_table`` is ``False`` for body paragraphs; ``True``
+            when the paragraph is inside a ``<w:tc>`` cell.
+
+        Example:
+            for ref, loc in doc.list_paragraph_locations():
+                if loc.in_table:
+                    cell = loc.table
+                    print(f"{ref}: table {cell.index} r{cell.row} c{cell.col}")
+        """
+        self._ensure_open()
+        dom = self._document_editor.dom
+        table_index = _build_table_index(dom)
+        result = []
+        for i, p in enumerate(dom.getElementsByTagName("w:p"), start=1):
+            ref = f"P{i}#{compute_paragraph_hash(p)}"
+            result.append((ref, _compute_paragraph_location(p, table_index)))
+        return result
 
     def get_visible_text(self) -> str:
         """Get the visible text of the document.

--- a/docx_editor/xml_editor.py
+++ b/docx_editor/xml_editor.py
@@ -254,6 +254,18 @@ def _doc_wide_table_index(dom, target_tbl) -> int:
     raise ValueError("target_tbl not found in document")  # pragma: no cover
 
 
+def _build_table_index(dom) -> dict:
+    """Map every ``<w:tbl>`` element to its 1-based depth-first index.
+
+    One ``getElementsByTagName("w:tbl")`` walk produces the same indices
+    ``_doc_wide_table_index`` would return per call, so callers processing
+    many paragraphs avoid rescanning the whole document for each one.
+
+    minidom Elements are identity-hashable, so the node itself is the key.
+    """
+    return {tbl: i for i, tbl in enumerate(dom.getElementsByTagName("w:tbl"), start=1)}
+
+
 def _table_depth(tbl) -> int:
     """1 = outermost table; +1 for each enclosing ``<w:tbl>`` ancestor."""
     depth = 1
@@ -265,12 +277,18 @@ def _table_depth(tbl) -> int:
     return depth
 
 
-def _compute_paragraph_location(paragraph) -> ParagraphLocation:
+def _compute_paragraph_location(paragraph, table_index: dict | None = None) -> ParagraphLocation:
     """Compute the structural location of a ``<w:p>`` element.
 
     Reports the innermost enclosing ``<w:tc>`` (and its table), or
     ``ParagraphLocation(table=None)`` if the paragraph is not inside any
     table cell.
+
+    ``table_index`` is an optional ``{tbl_node: 1-based-index}`` map (see
+    :func:`_build_table_index`). When supplied, the enclosing table's index
+    is looked up there instead of via a whole-document rescan — the batch
+    fast path. The result is identical to the ``None`` (per-call) path; a
+    table missing from the map falls back to the rescan defensively.
     """
     tc = _innermost_ancestor(paragraph, "w:tc")
     if tc is None:
@@ -280,9 +298,13 @@ def _compute_paragraph_location(paragraph) -> ParagraphLocation:
     if tr is None or tbl is None:
         # Malformed table structure — tolerate by treating as body content.
         return ParagraphLocation(table=None)
+    if table_index is not None and tbl in table_index:
+        index = table_index[tbl]
+    else:
+        index = _doc_wide_table_index(paragraph.ownerDocument, tbl)
     return ParagraphLocation(
         table=TableCell(
-            index=_doc_wide_table_index(paragraph.ownerDocument, tbl),
+            index=index,
             row=_row_index_in_table(tbl, tr),
             col=_logical_col_in_row(tr, tc),
             depth=_table_depth(tbl),

--- a/tests/test_paragraph_location.py
+++ b/tests/test_paragraph_location.py
@@ -554,7 +554,7 @@ class TestListParagraphLocations:
         with Document.open(gridspan_docx) as doc:
             entries = doc.list_paragraph_locations()
             assert len(entries) == len(doc.list_paragraphs())
-            assert len(entries) == 11  # P1–P11 from the fixture
+            assert len(entries) == 11  # P1-P11 from the fixture
 
     def test_refs_match_list_paragraphs_tokens(self, gridspan_docx):
         with Document.open(gridspan_docx) as doc:
@@ -565,7 +565,7 @@ class TestListParagraphLocations:
     def test_equivalence_with_per_call_accessor(self, gridspan_docx):
         """Every batch entry equals the per-call ``get_paragraph_location``.
 
-        Covers body (P1/P8/P11), gridSpan row (P2–P4), plain row (P5–P7),
+        Covers body (P1/P8/P11), gridSpan row (P2-P4), plain row (P5-P7),
         and nested table (P9/P10) — the full fixture.
         """
         with Document.open(gridspan_docx) as doc:

--- a/tests/test_paragraph_location.py
+++ b/tests/test_paragraph_location.py
@@ -539,3 +539,62 @@ class TestParagraphLocationLongPreview:
             # Preview should be truncated to 80 chars + "..."
             assert exc.value.paragraph_preview.endswith("...")
             assert len(exc.value.paragraph_preview) == 83  # 80 + "..."
+
+
+class TestListParagraphLocations:
+    """:meth:`Document.list_paragraph_locations` — the batch accessor.
+
+    The defining contract: each ``(ref, loc)`` entry must be byte-identical
+    to what ``get_paragraph_location(ref)`` returns per-call. The batch path
+    only swaps the whole-DOM table rescan for a prebuilt index, so the two
+    must never disagree.
+    """
+
+    def test_returns_one_entry_per_paragraph(self, gridspan_docx):
+        with Document.open(gridspan_docx) as doc:
+            entries = doc.list_paragraph_locations()
+            assert len(entries) == len(doc.list_paragraphs())
+            assert len(entries) == 11  # P1–P11 from the fixture
+
+    def test_refs_match_list_paragraphs_tokens(self, gridspan_docx):
+        with Document.open(gridspan_docx) as doc:
+            batch_refs = [ref for ref, _ in doc.list_paragraph_locations()]
+            expected_refs = [entry.split("|")[0] for entry in doc.list_paragraphs()]
+            assert batch_refs == expected_refs
+
+    def test_equivalence_with_per_call_accessor(self, gridspan_docx):
+        """Every batch entry equals the per-call ``get_paragraph_location``.
+
+        Covers body (P1/P8/P11), gridSpan row (P2–P4), plain row (P5–P7),
+        and nested table (P9/P10) — the full fixture.
+        """
+        with Document.open(gridspan_docx) as doc:
+            for ref, loc in doc.list_paragraph_locations():
+                assert loc == doc.get_paragraph_location(ref)
+
+    def test_returns_paragraph_location_dataclass(self, gridspan_docx):
+        with Document.open(gridspan_docx) as doc:
+            for ref, loc in doc.list_paragraph_locations():
+                assert isinstance(ref, str)
+                assert isinstance(loc, ParagraphLocation)
+
+    def test_body_paragraphs_report_no_table(self, gridspan_docx):
+        with Document.open(gridspan_docx) as doc:
+            by_ref = dict(doc.list_paragraph_locations())
+            body_ref = _ref_for_text(doc, "Body paragraph 1")
+            assert by_ref[body_ref].in_table is False
+            assert by_ref[body_ref].table is None
+
+    def test_nested_table_coordinates(self, gridspan_docx):
+        with Document.open(gridspan_docx) as doc:
+            by_ref = dict(doc.list_paragraph_locations())
+            inner_ref = _ref_for_text(doc, "Inner cell")
+            assert by_ref[inner_ref].table == TableCell(index=3, row=1, col=1, depth=2)
+
+    def test_table_free_document_all_body(self, simple_docx):
+        """A document with no tables returns a non-empty all-body list."""
+        with Document.open(simple_docx) as doc:
+            entries = doc.list_paragraph_locations()
+            assert entries  # simple.docx has at least one paragraph
+            assert all(loc.table is None for _, loc in entries)
+            assert all(loc.in_table is False for _, loc in entries)


### PR DESCRIPTION
## Summary

Adds `Document.list_paragraph_locations()` — a batch counterpart to `get_paragraph_location()` that pairs every paragraph with its structural location in one pass.

The per-call `get_paragraph_location()` re-scans the whole table hierarchy for each ref (O(P×T)). This batch accessor precomputes a `{tbl_node: 1-based-index}` map once via the new `_build_table_index()` helper, then walks paragraphs a single time — turning bulk location queries on table-heavy documents from O(P×T) into O(P+T).

## Changes

- `list_paragraph_locations() -> list[tuple[str, ParagraphLocation]]`: returns `(ref, location)` for every paragraph in document order, where `ref` is the same `P{i}#{hash}` token emitted by `list_paragraphs()`.
- `_build_table_index(dom)`: single `getElementsByTagName("w:tbl")` walk producing the depth-first index map.
- `_compute_paragraph_location()` gains an optional `table_index` param for the fast path; the per-call path is unchanged and falls back to the rescan defensively.
- `docs/api.md`: documents both `list_paragraph_locations()` and `get_paragraph_location()`.

## Testing

- New `TestListParagraphLocations` suite (8 tests) with an equivalence oracle asserting each batch entry is byte-identical to the per-call `get_paragraph_location(ref)` — covering body paragraphs, gridSpan rows, nested tables, and table-free documents.
- Full suite passes; ruff clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added get_paragraph_location() to report whether a paragraph is in the body or a table cell and provide structural coordinates.
  * Added list_paragraph_locations() to return all paragraph references paired with their locations in a single batch.

* **Documentation**
  * Updated README and API docs to describe the new paragraph-location capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->