### PR TITLE
Atomic save + open-document guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,3 +152,37 @@ with Document.open("contract.docx", author="Editor") as doc:
     ])
     doc.save()
 ```
+
+### Saving into synced folders
+
+`docx-editor` is safe to use inside cloud-synced folders (OneDrive, Dropbox,
+Google Drive, iCloud) and while Word is running.
+
+- **Atomic save.** `save()` writes the new document to a temporary file in the
+  destination's own directory and promotes it with a single atomic rename. The
+  destination is never observed half-written, so a sync client can never upload a
+  torn file. If the write (or `validate=True`) fails, the original is left exactly
+  as it was — a failed validation can no longer destroy your document.
+
+- **Open-in-Word guard.** Before writing, `save()` checks for the `~$` owner
+  (lock) file Word places next to any open document. If the destination looks
+  open, it raises `DocumentOpenError` rather than racing Word's writes:
+
+  ```python
+  from docx_editor import Document, DocumentOpenError
+
+  try:
+      doc.save()
+  except DocumentOpenError:
+      # Someone has this document open in Word — close it and retry.
+      ...
+  ```
+
+  If you are certain the `~$` file is a stale lock left by a crashed session, pass
+  `force=True` to save anyway: `doc.save(force=True)`.
+
+- **Limitation — remote co-authoring is undetectable.** The guard only sees a
+  *local* `~$` file. A document being edited remotely (OneDrive/SharePoint
+  co-authoring, or Word for the web) leaves **no local lock file**, so it cannot
+  be detected from the filesystem. In that case, rely on the cloud provider's
+  version history to recover if edits collide.

--- a/README.md
+++ b/README.md
@@ -170,6 +170,12 @@ Google Drive, iCloud) and while Word is running.
   permission on the **containing directory**, not just on the document itself. If
   the directory is read-only, `save()` raises `PermissionError`.
 
+  An atomic rename replaces the file's inode, so state bound to the *old* inode
+  does not survive it: the saved document keeps its **permissions**, but its
+  ownership, POSIX ACLs, extended attributes, and any hardlinks to it do not carry
+  over. This is inherent to atomic saving (every editor that writes this way behaves
+  the same). If a document depends on an ACL or a hardlink, save to a new path.
+
 - **Open-in-Word guard.** Before writing, `save()` checks for the `~$` owner
   (lock) file Word places next to any open document. If the destination looks
   open, it raises `DocumentOpenError` rather than racing Word's writes:

--- a/README.md
+++ b/README.md
@@ -170,6 +170,10 @@ Google Drive, iCloud) and while Word is running.
   permission on the **containing directory**, not just on the document itself. If
   the directory is read-only, `save()` raises `PermissionError`.
 
+  A **write-protected document is refused**, not silently replaced: `save()` raises
+  `PermissionError` if the destination is read-only, even though the rename itself
+  would have been permitted by the directory.
+
   An atomic rename replaces the file's inode, so state bound to the *old* inode
   does not survive it: the saved document keeps its **permissions**, but its
   ownership, POSIX ACLs, extended attributes, and any hardlinks to it do not carry

--- a/README.md
+++ b/README.md
@@ -159,10 +159,16 @@ with Document.open("contract.docx", author="Editor") as doc:
 Google Drive, iCloud) and while Word is running.
 
 - **Atomic save.** `save()` writes the new document to a temporary file in the
-  destination's own directory and promotes it with a single atomic rename. The
-  destination is never observed half-written, so a sync client can never upload a
-  torn file. If the write (or `validate=True`) fails, the original is left exactly
-  as it was — a failed validation can no longer destroy your document.
+  destination's own directory and promotes it with a single atomic rename, flushed
+  to disk. The destination is never observed half-written, so a sync client can
+  never upload a torn file. If the write (or `validate=True`) fails, the original
+  is left exactly as it was — a failed validation can no longer destroy your
+  document. The saved file keeps the original's permissions, and a symlinked
+  destination is followed to the file it points at.
+
+  Because the temp file is created next to the destination, saving needs write
+  permission on the **containing directory**, not just on the document itself. If
+  the directory is read-only, `save()` raises `PermissionError`.
 
 - **Open-in-Word guard.** Before writing, `save()` checks for the `~$` owner
   (lock) file Word places next to any open document. If the destination looks

--- a/docs/superpowers/plans/2026-07-04-atomic-save-open-document-guard.md
+++ b/docs/superpowers/plans/2026-07-04-atomic-save-open-document-guard.md
@@ -1,0 +1,97 @@
+# Atomic Save + Open-Document Guard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Use superpowers:test-driven-development within each task — every behavior change gets a failing test first.
+
+**Goal:** Make `Document.save()` safe inside cloud-synced folders (Dropbox/OneDrive/SharePoint): the destination file is never observable in a half-written state, `validate=True` can no longer destroy the original document, and saving over a document that Word has open locally raises a structured error instead of setting up a silent-overwrite data loss.
+
+**Architecture:** Two independent changes meeting in `save()`. (1) `pack_document()` stops writing the zip directly onto the destination; it writes to a temp file in the destination's parent directory, optionally validates *that*, and promotes it with `os.replace()` — atomic on the same volume on both POSIX and Windows. (2) A new owner-file check (`~$` stub detection) runs where the final destination is known, raising `DocumentOpenError` unless `force=True`. No new dependencies; no behavior change to unpacking, anchoring, or editing.
+
+**Tech Stack:** Python ≥3.10, stdlib only (`zipfile`, `os`, `tempfile`, `pathlib`), pytest, uv, ruff.
+
+**Background (why — from the 2026-07-04 cloud-sync research, verified against Microsoft docs and MS-FSSHTTP):**
+
+- **The current write is not atomic.** `docx_editor/ooxml/pack.py:47` opens `zipfile.ZipFile(output_file, "w")` directly on the destination and streams members into it. A sync client, Word, or any pipeline sampling the file mid-write sees a truncated, invalid zip — and sync clients can propagate that state to other machines.
+- **`validate=True` can destroy the document.** `pack.py:55` unlinks the freshly written output when LibreOffice validation fails — but in the default save-in-place case the output *is* the original, already overwritten. Validation failure currently leaves the user with **no file at all**. Validating the temp file before `os.replace()` fixes this as a side effect of atomicity.
+- **Writing while Word has the document open loses data silently.** Word keeps its own in-memory copy and does not watch the disk; its next save overwrites whatever an external tool wrote. The `~$` owner file next to the document is the standard local signal, and docx-editor currently ignores it.
+- **Known limitation (document, don't solve):** remote co-authoring (OneDrive/SharePoint/Word-for-the-web) leaves **no local filesystem signal** — no `~$` stub is created on this machine. Detecting it requires server APIs (Graph checkout / SharePoint `lockedByUser`), which is explicitly out of scope. The guard is best-effort for the *local* case and the docs must say exactly that.
+- Sync-client behavior that motivates atomic replace: OneDrive and Dropbox both sync at block/file granularity (fixed blocks; the zip-container byte-shift defeats deltas anyway), so the destination should transition in a single rename, not a stream of partial writes.
+
+## Global Constraints
+
+- **Out of scope:** relocating the `.docx/<stem>/` unpack workspace (separate plan/PR); anything under the open MCP draft PR #7; server-side lock detection (Graph/SharePoint).
+- **Coordination note:** the persistent-session plan (`2026-07-04-persistent-session-mode.md`, Task modifying `document.py` / `workspace.py`) also threads a `force` parameter through `Document.save()` to skip its *staleness* check. If both land, `force=True` must mean "skip all save-time guards" (staleness **and** open-document) — one parameter, unified semantics, documented as such. Whichever plan lands second reconciles.
+- `requires-python = ">=3.10,<4.0"`; core `dependencies = ["defusedxml>=0.7.1"]` must NOT gain new entries.
+- Line length 120 (ruff); run `uv run ruff check .` and `uv run ruff format .` before every commit.
+- Run commands with `uv run ...` (`uv sync --dev` to install).
+- Commits: conventional-commit style, never mention Claude/AI, never `git add -A` — always add specific files.
+- Tests live in `tests/`, plain pytest style. `tests/conftest.py` provides `test_data_dir`, `simple_docx`, `temp_docx` (copy of simple.docx in a temp dir), `temp_dir`.
+- The existing suite (~626 tests) is the oracle for zip output compatibility — it must stay green untouched.
+
+---
+
+## File Structure
+
+- Modify: `docx_editor/ooxml/pack.py` — atomic emission + validate-before-replace (`pack_document`, lines 13–58)
+- Modify: `docx_editor/workspace.py:168` — owner-file guard in `Workspace.save()` (destination is resolved here)
+- Modify: `docx_editor/document.py:407` — `force: bool = False` parameter on `Document.save()`, passed through
+- Modify: `docx_editor/exceptions.py` — new `DocumentOpenError(DocxEditError)`
+- Create: `tests/test_atomic_save.py`
+- Create: `tests/test_open_document_guard.py`
+- Modify: `README.md`, `skills/docx/SKILL.md` — guard + `force` + remote-co-authoring caveat
+
+---
+
+### Task 1: Atomic pack + validate-before-replace
+
+**Files:**
+- Modify: `docx_editor/ooxml/pack.py`
+- Create: `tests/test_atomic_save.py`
+
+**Interfaces:**
+- `pack_document(input_dir, output_file, validate=False) -> bool` — signature unchanged; behavior contract strengthened: at every instant, `output_file` contains either the complete previous document or the complete new one, never a partial zip; on any failure (exception or validation) the previous file is untouched and no temp file is left behind.
+
+- [ ] **Step 1 (RED): failure mid-pack preserves the original.** Test: copy `simple_docx` to a temp dir, record its bytes; monkeypatch `zipfile.ZipFile.write` to raise `OSError` after the first member; call `pack_document` against that destination; assert the destination bytes are unchanged and no `*.tmp` (or chosen temp pattern) file remains in the directory.
+- [ ] **Step 2 (RED): validation failure preserves the original.** Test: monkeypatch `validate_document` to return `False`; `pack_document(..., validate=True)` returns `False`; destination bytes unchanged; no temp litter. (This is the regression test for the current data-loss bug at `pack.py:55`.)
+- [ ] **Step 3 (RED): success is a single-rename promotion.** Test: pack to a destination and assert the result is a valid zip (`zipfile.ZipFile(dest).testzip() is None`) and that the temp file is gone. Optionally assert rename semantics by monkeypatching `os.replace` to record its call (temp path in same parent dir as destination).
+- [ ] **Step 4 (GREEN):** implement in `pack_document`: create the zip at `output_file.parent / f".{output_file.name}.<random>.tmp"` (same directory ⇒ same volume ⇒ atomic `os.replace`; leading dot + `.tmp` suffix keeps sync-adjacent tools from ingesting it); run `condense_xml` and member writes exactly as today; if `validate` and validation fails → unlink temp, return `False`; else `os.replace(temp, output_file)`. Wrap in `try/finally` so every failure path unlinks the temp.
+- [ ] **Step 5:** run the FULL suite — zip output must be byte-compatible with whatever the existing tests assert (do not change compression, member order, or XML condensing).
+
+---
+
+### Task 2: Open-document guard (`~$` stub) with `force` override
+
+**Files:**
+- Modify: `docx_editor/exceptions.py`, `docx_editor/workspace.py:168`, `docx_editor/document.py:407`
+- Create: `tests/test_open_document_guard.py`
+
+**Interfaces:**
+- New exception: `DocumentOpenError(DocxEditError)` — message names the stub path found and the recovery options ("close the document in Word, or pass force=True if this is a stale lock from a crashed session").
+- `Document.save(path=None, validate=False, force=False)` — `force=True` skips the guard. Guard applies to the **destination** path (saving a copy to a fresh path while the source is open in Word is safe and must not be blocked).
+- Helper (workspace-level or module function): `owner_file_candidates(path: Path) -> list[Path]`.
+
+- [ ] **Step 1: verify Word's owner-file naming rule** against the Microsoft support doc ("The document is locked for editing by another user") before coding. Known shape: same directory, prefix `~$`, and for longer filenames the first characters of the stem are dropped (`Report.docx` → `~$port.docx`); short names keep the full stem (`ab.docx` → `~$ab.docx`). Implement `owner_file_candidates()` returning both `~$<name>` and `~$<name[2:]>` forms; existence check only (stubs are hidden system files on Windows — `Path.exists()` sees them regardless).
+- [ ] **Step 2 (RED): guard blocks the save.** Test: `temp_docx` plus a fabricated `~$` stub (both naming variants, parametrized); `doc.replace(...)` then `doc.save()` raises `DocumentOpenError`; the destination file is unchanged.
+- [ ] **Step 3 (RED): `force=True` saves.** Same setup; `doc.save(force=True)` succeeds and the edit is present on reopen.
+- [ ] **Step 4 (RED): no false positives.** A stub for a *different* document in the same folder does not block; saving to a **fresh destination** path while the source has a stub does not block.
+- [ ] **Step 5 (GREEN):** implement the check in `Workspace.save()` (where `destination` is resolved, line 168) before calling `pack_document`; thread `force` from `Document.save()`.
+- [ ] **Step 6 (GREEN, Windows mapping):** catch `PermissionError` from the final `os.replace` in the pack/save path and re-raise as `DocumentOpenError` (Word genuinely holding the destination is exactly this condition; on POSIX this branch is effectively dead but harmless). Unit-test via monkeypatched `os.replace` raising `PermissionError`.
+- [ ] **Step 7:** full suite + ruff green.
+
+---
+
+### Task 3: Documentation
+
+**Files:**
+- Modify: `README.md`, `skills/docx/SKILL.md`
+
+- [ ] **Step 1:** README: short "Saving into synced folders" section — atomic save guarantee, the guard, `force=True` for stale stubs, and the explicit limitation: *remote co-authoring (OneDrive/SharePoint/Word-for-the-web) creates no local lock stub and cannot be detected from the filesystem; prefer editing when the document is not being actively collaborated on, and rely on cloud version history as the backstop.*
+- [ ] **Step 2:** `skills/docx/SKILL.md`: teach the model the guard exists, that `DocumentOpenError` means "someone has this open locally — stop and tell the user," and that `force=True` is only for confirmed-stale stubs (crashed Word).
+
+---
+
+## Verification checklist (before PR)
+
+- [ ] Full suite green (`uv run pytest`), ruff check + format clean.
+- [ ] Manual probe: start a save, kill the process mid-pack (or simulate via the monkeypatch test) → original intact, no temp litter.
+- [ ] Manual probe with real Word/LibreOffice if available: open a doc, attempt `save()` → `DocumentOpenError`; close app → save succeeds.
+- [ ] PR description leads with the `validate=True` data-loss fix, then atomicity, then the guard; states the remote-co-authoring limitation; no AI attribution anywhere.

--- a/docx_editor/__init__.py
+++ b/docx_editor/__init__.py
@@ -40,6 +40,7 @@ from .exceptions import (
     BatchOperationError,
     CommentError,
     DocumentNotFoundError,
+    DocumentOpenError,
     DocxEditError,
     HashMismatchError,
     InvalidDocumentError,
@@ -77,6 +78,7 @@ __all__ = [
     # Exceptions
     "DocxEditError",
     "DocumentNotFoundError",
+    "DocumentOpenError",
     "InvalidDocumentError",
     "WorkspaceError",
     "WorkspaceExistsError",

--- a/docx_editor/document.py
+++ b/docx_editor/document.py
@@ -125,7 +125,11 @@ class Document:
             doc = Document.open("contract.docx")
             doc = Document.open("contract.docx", author="Legal Team")
         """
-        path = Path(path).resolve()
+        # Deliberately not resolved: Workspace resolves internally for source_path,
+        # but it also needs the name the caller actually opened. If that is a symlink,
+        # it is the name Word was told to open, and therefore the name its ~$ owner
+        # file sits beside — the save-time guard has no other way to find that stub.
+        path = Path(path)
 
         if force_recreate:
             Workspace.delete(path, workspace_dir=workspace_dir)

--- a/docx_editor/document.py
+++ b/docx_editor/document.py
@@ -832,7 +832,12 @@ class Document:
         Args:
             path: Output path (defaults to original source path)
             validate: If True, validate with LibreOffice before saving
-            force: If True, overwrite the source even if it changed on disk
+            force: If True, skip save-time safety checks. By default save()
+                refuses to overwrite the source if it changed on disk since it
+                was opened (raising WorkspaceSyncError) or if the destination
+                appears open in Word — a ``~$`` owner file exists next to it
+                (raising DocumentOpenError). Pass force=True only for a
+                confirmed-stale lock left by a crashed session.
 
         Returns:
             Path to the saved document
@@ -841,6 +846,8 @@ class Document:
             WorkspaceSyncError: If the source document changed on disk since
                 it was opened (protects long-lived sessions from overwriting
                 edits made in Word). Pass force=True to overwrite anyway.
+            DocumentOpenError: If the destination appears open in Word and
+                force is False.
 
         Example:
             doc.save()  # Save to original path

--- a/docx_editor/document.py
+++ b/docx_editor/document.py
@@ -846,8 +846,11 @@ class Document:
             WorkspaceSyncError: If the source document changed on disk since
                 it was opened (protects long-lived sessions from overwriting
                 edits made in Word). Pass force=True to overwrite anyway.
-            DocumentOpenError: If the destination appears open in Word and
-                force is False.
+            DocumentOpenError: If the destination appears open in Word (a ``~$``
+                owner file exists) and force is False, or if the OS denies the
+                final replace because another program holds the destination open.
+                force=True skips the ``~$`` check but cannot suppress the latter —
+                the OS still refuses the write.
 
         Example:
             doc.save()  # Save to original path

--- a/docx_editor/exceptions.py
+++ b/docx_editor/exceptions.py
@@ -43,6 +43,19 @@ class SessionError(DocxEditError):
     pass
 
 
+class DocumentOpenError(DocxEditError):
+    """Raised when saving to a destination that appears open in Word.
+
+    Word writes a ``~$`` owner (lock) file next to any document it has open. If
+    that stub exists at save time, saving would race Word's own writes and risk
+    corruption, so ``save()`` refuses unless ``force=True``. Also raised when the
+    OS denies the write with a ``PermissionError`` — on Windows, Word holding the
+    file open is exactly this case.
+    """
+
+    pass
+
+
 class XMLError(DocxEditError):
     """Raised when there's an error parsing or manipulating XML."""
 

--- a/docx_editor/exceptions.py
+++ b/docx_editor/exceptions.py
@@ -1,5 +1,7 @@
 """Custom exceptions for docx_editor library."""
 
+from pathlib import Path
+
 
 class DocxEditError(Exception):
     """Base exception for all docx_editor errors."""
@@ -44,16 +46,30 @@ class SessionError(DocxEditError):
 
 
 class DocumentOpenError(DocxEditError):
-    """Raised when saving to a destination that appears open in Word.
+    """Raised when saving to a destination that appears open in another program.
 
     Word writes a ``~$`` owner (lock) file next to any document it has open. If
     that stub exists at save time, saving would race Word's own writes and risk
     corruption, so ``save()`` refuses unless ``force=True``. Also raised when the
-    OS denies the write with a ``PermissionError`` — on Windows, Word holding the
-    file open is exactly this case.
+    OS denies the final replace with a ``PermissionError`` — on Windows, Word
+    holding the file open is exactly this case.
+
+    Attributes:
+        path: The destination that could not be written.
+        owner_file: The ``~$`` owner file that triggered the guard, or None when
+            the error came from the OS denying the replace instead.
     """
 
-    pass
+    def __init__(
+        self,
+        message: str,
+        *,
+        path: Path | None = None,
+        owner_file: Path | None = None,
+    ):
+        self.path = path
+        self.owner_file = owner_file
+        super().__init__(message)
 
 
 class XMLError(DocxEditError):

--- a/docx_editor/ooxml/pack.py
+++ b/docx_editor/ooxml/pack.py
@@ -68,6 +68,12 @@ def pack_document(input_dir: str | Path, output_file: str | Path, validate: bool
     # path for writing and therefore followed the link; preserve that.
     target = Path(os.path.realpath(output_file))
 
+    # Refuse a write-protected destination up front, before doing any work. The
+    # pre-atomic code failed the moment it opened the file for writing, so a
+    # validate=True run must not be able to return False first and quietly swallow
+    # the refusal. _replace() checks again as a race guard.
+    _assert_writable(target)
+
     # Work in temporary directory to avoid modifying original
     with tempfile.TemporaryDirectory() as temp_dir:
         temp_content_dir = Path(temp_dir) / "content"
@@ -228,14 +234,21 @@ def _chmod(tmp_file: BinaryIO, tmp_path: Path, mode: int) -> None:
         os.chmod(tmp_path, mode)
 
 
-def _replace(tmp_path: Path, target: Path) -> None:
-    """Atomically move the finished archive onto the destination, and persist it."""
-    # Refuse a write-protected destination. rename(2) only needs write permission on
-    # the *directory*, so the promotion would happily replace a file the user marked
-    # read-only — something the pre-atomic in-place write could never do, and that
-    # Windows still refuses. Keep that contract, and keep both platforms agreeing.
+def _assert_writable(target: Path) -> None:
+    """Refuse a write-protected destination.
+
+    rename(2) only needs write permission on the *directory*, so the atomic promotion
+    would happily replace a file the user marked read-only — something the pre-atomic
+    in-place write could never do, and that Windows still refuses. Keep that contract,
+    and keep both platforms agreeing.
+    """
     if target.exists() and not os.access(target, os.W_OK):
         raise PermissionError(errno.EACCES, os.strerror(errno.EACCES), str(target))
+
+
+def _replace(tmp_path: Path, target: Path) -> None:
+    """Atomically move the finished archive onto the destination, and persist it."""
+    _assert_writable(target)  # re-check: the mode may have changed while we packed
 
     try:
         os.replace(tmp_path, target)

--- a/docx_editor/ooxml/pack.py
+++ b/docx_editor/ooxml/pack.py
@@ -20,6 +20,10 @@ from ..exceptions import DocumentOpenError
 # relative — a hypothetical subpart literally named "meta.json" is unaffected.
 EXCLUDED_PATHS = {Path("meta.json")}
 
+# Bytes left for the destination's name inside the promotion temp file's name, whose
+# shape is ".<name>.<8 random chars>.tmp" against a 255-byte NAME_MAX.
+_TEMP_NAME_BUDGET = 255 - len(".") - len(".") - 8 - len(".tmp")
+
 
 def _ignore_symlinks(directory: str, names: list[str]) -> list[str]:
     """Skip symlinks so they cannot leak external host content into the archive."""
@@ -82,9 +86,14 @@ def pack_document(input_dir: str | Path, output_file: str | Path, validate: bool
         # observed half-written (safe inside cloud-synced folders), and any failure
         # — a write error or a failed validation — leaves the existing destination
         # untouched. Same directory ⇒ same volume ⇒ os.replace() is a true atomic
-        # rename (no cross-device error). The name is clamped so a long destination
-        # name cannot push the temp name past the filesystem's limit.
-        fd, tmp_name = tempfile.mkstemp(dir=target.parent, prefix=f".{target.name[:200]}.", suffix=".tmp")
+        # rename (no cross-device error).
+        #
+        # mkstemp builds "<prefix><8 random chars><suffix>", and NAME_MAX is a *byte*
+        # budget (255), not a character count — so clamp the encoded name. Slicing
+        # characters would still overflow on a non-ASCII destination, whose name can
+        # run to 4 bytes per character.
+        stem = target.name.encode()[:_TEMP_NAME_BUDGET].decode(errors="ignore")
+        fd, tmp_name = tempfile.mkstemp(dir=target.parent, prefix=f".{stem}.", suffix=".tmp")
         os.close(fd)
         tmp_path = Path(tmp_name)
         try:
@@ -106,8 +115,10 @@ def pack_document(input_dir: str | Path, output_file: str | Path, validate: bool
             # Validate the temp file, never the destination, so a failure cannot
             # destroy the original (historic data-loss bug: unlink of output_file).
             # Pass the real extension: the temp file is named .tmp, and soffice's
-            # export filter is chosen from the suffix.
-            if validate and not validate_document(tmp_path, suffix=target.suffix):
+            # export filter is chosen from the suffix. Use output_file's suffix, not
+            # target's — output_file is what the extension check above accepted, and
+            # a symlink may point at a name with any extension at all.
+            if validate and not validate_document(tmp_path, suffix=output_file.suffix):
                 return False
 
             _promote(tmp_path, target)
@@ -125,11 +136,28 @@ def pack_document(input_dir: str | Path, output_file: str | Path, validate: bool
 def _promote(tmp_path: Path, target: Path) -> None:
     """Atomically move the finished archive onto the destination.
 
-    os.replace() swaps in the temp file's inode wholesale, so anything that rides
-    on the destination's inode must be carried over first — most importantly its
-    permissions, since mkstemp() creates the temp file 0600 and would otherwise
-    silently strip group/world access from every saved document.
+    Three things happen here, in an order that matters:
+
+    1. The archive is flushed to disk. os.replace() is atomic with respect to other
+       processes, but without an fsync a crash could leave the destination name
+       pointing at an inode whose data blocks were never written.
+    2. The destination's permissions are carried over. os.replace() swaps in the
+       temp file's inode wholesale, and mkstemp() creates that file 0600, so without
+       this every save would silently strip group/world access from the document.
+       Only the mode is carried — ownership, ACLs, xattrs and hardlinks belong to
+       the replaced inode and cannot survive an atomic rename (see README).
+    3. The rename itself is persisted, so a crash cannot undo it.
+
+    A PermissionError from the rename is mapped to DocumentOpenError on Windows,
+    where a destination held open by Word is exactly what it means.
     """
+    # Fsync BEFORE chmod: the temp file is still 0600 (owner-writable) here. Doing it
+    # after would make reopening a read-only destination's mode (0444) fail outright.
+    # Opened "rb+", not "rb": on Windows os.fsync() maps to FlushFileBuffers, which
+    # needs write access on the handle and fails on a read-only one.
+    with open(tmp_path, "rb+") as f:
+        os.fsync(f.fileno())
+
     if target.exists():
         os.chmod(tmp_path, stat.S_IMODE(target.stat().st_mode))
     else:
@@ -138,27 +166,23 @@ def _promote(tmp_path: Path, target: Path) -> None:
         os.umask(umask)
         os.chmod(tmp_path, 0o666 & ~umask)
 
-    # Flush the archive before promoting it. os.replace() is atomic with respect to
-    # other processes, but without this a crash could leave the destination name
-    # pointing at an inode whose data blocks were never written to disk.
-    with open(tmp_path, "rb") as f:
-        os.fsync(f.fileno())
-
     try:
         os.replace(tmp_path, target)
     except PermissionError as e:
-        # The destination is held open by another program — on Windows this is
-        # exactly what Word does. Map only *this* step: a PermissionError from
-        # anywhere earlier (e.g. a non-writable directory) is a genuine
-        # filesystem problem and must not be reported as "close the document".
+        # On Windows a destination locked by another program (Word) surfaces here as
+        # PermissionError. On POSIX it cannot: rename(2) over a file another process
+        # holds open always succeeds. A denial there means something else entirely —
+        # a sticky-bit directory, an immutable file, an SELinux denial — and calling
+        # that "the document is open" would send the caller down a dead end.
+        if sys.platform != "win32":
+            raise
         raise DocumentOpenError(
             f"{target} could not be replaced (permission denied); it is likely open "
             f"in another program. Close it and retry.",
             path=target,
         ) from e
 
-    # Persist the rename itself, so a crash cannot undo it. Directory fsync is not
-    # supported on Windows, where it is also unnecessary.
+    # Persist the rename. Directory fsync is unsupported on Windows, and unnecessary.
     with contextlib.suppress(OSError):
         dir_fd = os.open(target.parent, os.O_RDONLY)
         try:

--- a/docx_editor/ooxml/pack.py
+++ b/docx_editor/ooxml/pack.py
@@ -1,6 +1,7 @@
 """Pack a directory back into a .docx, .pptx, or .xlsx file."""
 
 import contextlib
+import errno
 import os
 import secrets
 import shutil
@@ -10,6 +11,7 @@ import sys
 import tempfile
 import zipfile
 from pathlib import Path
+from typing import BinaryIO
 
 import defusedxml.minidom
 
@@ -89,14 +91,14 @@ def pack_document(input_dir: str | Path, output_file: str | Path, validate: bool
         # — a write error or a failed validation — leaves the existing destination
         # untouched. Same directory ⇒ same volume ⇒ os.replace() is a true atomic
         # rename (no cross-device error).
-        fd, tmp_path = _create_temp(target)
+        tmp_file, tmp_path = _create_temp(target)
         try:
             # Write through the temp file's own fd rather than reopening it by name.
             # Reopening would fail wherever the created file is not owner-writable —
-            # a directory with a restrictive default POSIX ACL masks the new file down
-            # to 0400 — and it would leave a window in which the name could be swapped
-            # under us.
-            with os.fdopen(fd, "w+b") as tmp_file:
+            # a directory with a restrictive default POSIX ACL masks the new file so
+            # its owner cannot write it — and it would leave a window in which the name
+            # could be swapped under us.
+            with tmp_file:
                 # Take the destination's permissions *before* writing any content, so
                 # the document is never briefly more readable than the file it replaces.
                 if target.exists():
@@ -135,6 +137,12 @@ def pack_document(input_dir: str | Path, output_file: str | Path, validate: bool
 
             _replace(tmp_path, target)
         finally:
+            # The temp file carries the destination's mode, and on Windows a read-only
+            # file cannot be deleted — clear that before trying, or a read-only
+            # destination would leave the temp archive littering a synced folder.
+            if sys.platform == "win32":  # pragma: no cover - CI is POSIX
+                with contextlib.suppress(OSError):
+                    os.chmod(tmp_path, stat.S_IWRITE | stat.S_IREAD)
             # Remove the temp file on every failure path (write error, validation
             # failure). On success os.replace() consumed it, so this is a no-op.
             # Suppress errors so a doomed cleanup cannot turn a completed save into
@@ -145,8 +153,41 @@ def pack_document(input_dir: str | Path, output_file: str | Path, validate: bool
     return True
 
 
-def _create_temp(target: Path) -> tuple[int, Path]:
-    """Create the promotion temp file next to ``target``; return its fd and path.
+def _has_surrogates(text: str) -> bool:
+    """True if ``text`` carries surrogateescape markers for undecodable bytes."""
+    return any(0xDC80 <= ord(ch) <= 0xDCFF for ch in text)
+
+
+def _clamp_name(name: str, budget: int) -> str:
+    """Trim ``name`` to at most ``budget`` bytes, without splitting a character.
+
+    NAME_MAX is a byte budget, not a character count, so the clamp has to happen on
+    the encoding — slicing characters would still overflow for a non-ASCII name at up
+    to 4 bytes each. Go through os.fsencode/os.fsdecode rather than str.encode:
+    Linux filenames are bytes, and an undecodable one arrives here as surrogates that
+    strict UTF-8 would reject.
+
+    Slicing bytes can cut a multibyte character in half, and the halves come back as
+    lone surrogates that macOS and Windows refuse in a filename. So back off to a
+    character boundary — unless the name was *already* undecodable, in which case its
+    surrogates are legitimate and must survive.
+    """
+    raw = os.fsencode(name)
+    if len(raw) <= budget:
+        return name
+
+    was_undecodable = _has_surrogates(name)
+    raw = raw[:budget]
+    stem = os.fsdecode(raw)
+    if not was_undecodable:
+        while raw and _has_surrogates(stem):
+            raw = raw[:-1]
+            stem = os.fsdecode(raw)
+    return stem
+
+
+def _create_temp(target: Path) -> tuple[BinaryIO, Path]:
+    """Create the promotion temp file next to ``target``; return it open, with its path.
 
     Deliberately not tempfile.mkstemp(): that forces mode 0600, which for a
     brand-new destination would then have to be corrected back to the process
@@ -155,39 +196,47 @@ def _create_temp(target: Path) -> tuple[int, Path]:
     lets the kernel apply the umask (and any default ACL) itself, so a new
     destination lands on exactly the mode a plain open() would have produced, with
     no race. O_EXCL keeps the name ours alone.
+
+    The file is returned already wrapped, so the raw fd is never exposed unowned.
     """
-    # NAME_MAX is a *byte* budget, not a character count, so clamp the encoded name —
-    # slicing characters would still overflow for a non-ASCII name at up to 4 bytes
-    # each. Go through os.fsencode/os.fsdecode, not str.encode: Linux filenames are
-    # bytes, and an undecodable one arrives here as surrogates that strict UTF-8
-    # encoding would reject.
     try:
         name_max = os.pathconf(target.parent, "PC_NAME_MAX")
     except (AttributeError, OSError, ValueError):  # pragma: no cover - platform-dependent
         name_max = 255
-    budget = max(8, name_max - _TEMP_NAME_OVERHEAD)
-    stem = os.fsdecode(os.fsencode(target.name)[:budget])
+    stem = _clamp_name(target.name, max(8, name_max - _TEMP_NAME_OVERHEAD))
 
     flags = os.O_RDWR | os.O_CREAT | os.O_EXCL | getattr(os, "O_BINARY", 0)
     for _ in range(_TEMP_NAME_ATTEMPTS):
         candidate = target.parent / f".{stem}.{secrets.token_hex(4)}.tmp"
         try:
-            return os.open(candidate, flags, 0o666), candidate
+            fd = os.open(candidate, flags, 0o666)
         except FileExistsError:  # pragma: no cover - requires a name collision
             continue
+        try:
+            return os.fdopen(fd, "w+b"), candidate
+        except BaseException:  # pragma: no cover - fdopen failing on a fresh fd
+            os.close(fd)
+            raise
     raise OSError(f"Could not create a unique temp file next to {target}")  # pragma: no cover
 
 
-def _chmod(tmp_file: object, tmp_path: Path, mode: int) -> None:
+def _chmod(tmp_file: BinaryIO, tmp_path: Path, mode: int) -> None:
     """Set the temp file's mode, preferring the fd so no path race is possible."""
     if hasattr(os, "fchmod"):
-        os.fchmod(tmp_file.fileno(), mode)  # ty: ignore[unresolved-attribute]
+        os.fchmod(tmp_file.fileno(), mode)
     else:  # pragma: no cover - Windows has no fchmod
         os.chmod(tmp_path, mode)
 
 
 def _replace(tmp_path: Path, target: Path) -> None:
     """Atomically move the finished archive onto the destination, and persist it."""
+    # Refuse a write-protected destination. rename(2) only needs write permission on
+    # the *directory*, so the promotion would happily replace a file the user marked
+    # read-only — something the pre-atomic in-place write could never do, and that
+    # Windows still refuses. Keep that contract, and keep both platforms agreeing.
+    if target.exists() and not os.access(target, os.W_OK):
+        raise PermissionError(errno.EACCES, os.strerror(errno.EACCES), str(target))
+
     try:
         os.replace(tmp_path, target)
     except PermissionError as e:
@@ -198,9 +247,11 @@ def _replace(tmp_path: Path, target: Path) -> None:
         # that "the document is open" would send the caller down a dead end.
         #
         # A read-only destination on Windows also lands here (MoveFileEx refuses to
-        # replace a FILE_ATTRIBUTE_READONLY file), and that is not an open document
-        # either — so only claim "open" when the destination is otherwise writable.
-        if sys.platform != "win32" or (target.exists() and not os.access(target, os.W_OK)):
+        # replace a FILE_ATTRIBUTE_READONLY file), and a destination that does not
+        # exist yet cannot be open in anything. Neither is an open document — only
+        # claim "open" for an existing, otherwise-writable file.
+        looks_open = sys.platform == "win32" and target.exists() and os.access(target, os.W_OK)
+        if not looks_open:
             raise
         raise DocumentOpenError(
             f"{target} could not be replaced (permission denied); it is likely open "

--- a/docx_editor/ooxml/pack.py
+++ b/docx_editor/ooxml/pack.py
@@ -1,7 +1,9 @@
 """Pack a directory back into a .docx, .pptx, or .xlsx file."""
 
+import contextlib
 import os
 import shutil
+import stat
 import subprocess
 import sys
 import tempfile
@@ -9,6 +11,8 @@ import zipfile
 from pathlib import Path
 
 import defusedxml.minidom
+
+from ..exceptions import DocumentOpenError
 
 # Workspace-root paths that must not be packed into the output.
 # meta.json is workspace bookkeeping (see Workspace.META_FILE); packing it makes
@@ -37,6 +41,8 @@ def pack_document(input_dir: str | Path, output_file: str | Path, validate: bool
     Raises:
         ValueError: If input_dir is a symlink, doesn't exist, or output_file has
             the wrong extension
+        DocumentOpenError: If the OS denies the final replace (the destination is
+            held open by another program, e.g. Word on Windows)
     """
     input_dir = Path(input_dir)
     output_file = Path(output_file)
@@ -47,6 +53,12 @@ def pack_document(input_dir: str | Path, output_file: str | Path, validate: bool
         raise ValueError(f"{input_dir} is not a directory")
     if output_file.suffix.lower() not in {".docx", ".pptx", ".xlsx"}:
         raise ValueError(f"{output_file} must be a .docx, .pptx, or .xlsx file")
+
+    # Follow a symlinked destination to the file it points at. os.replace() acts on
+    # the name it is given, so replacing the link itself would leave the real
+    # document untouched while reporting success. The pre-atomic code opened the
+    # path for writing and therefore followed the link; preserve that.
+    target = Path(os.path.realpath(output_file))
 
     # Work in temporary directory to avoid modifying original
     with tempfile.TemporaryDirectory() as temp_dir:
@@ -59,7 +71,7 @@ def pack_document(input_dir: str | Path, output_file: str | Path, validate: bool
                 condense_xml(xml_file)
 
         # Deterministic ZIP: sorted POSIX names, fixed 1980 timestamps, pinned metadata - cross-platform byte stability.
-        output_file.parent.mkdir(parents=True, exist_ok=True)
+        target.parent.mkdir(parents=True, exist_ok=True)
         entries = sorted(
             (f for f in temp_content_dir.rglob("*") if f.is_file()),
             key=lambda f: f.relative_to(temp_content_dir).as_posix(),
@@ -70,9 +82,9 @@ def pack_document(input_dir: str | Path, output_file: str | Path, validate: bool
         # observed half-written (safe inside cloud-synced folders), and any failure
         # — a write error or a failed validation — leaves the existing destination
         # untouched. Same directory ⇒ same volume ⇒ os.replace() is a true atomic
-        # rename (no cross-device error). Leading '.' + '.tmp' keeps sync clients
-        # from ingesting the transient file.
-        fd, tmp_name = tempfile.mkstemp(dir=output_file.parent, prefix=f".{output_file.name}.", suffix=".tmp")
+        # rename (no cross-device error). The name is clamped so a long destination
+        # name cannot push the temp name past the filesystem's limit.
+        fd, tmp_name = tempfile.mkstemp(dir=target.parent, prefix=f".{target.name[:200]}.", suffix=".tmp")
         os.close(fd)
         tmp_path = Path(tmp_name)
         try:
@@ -93,22 +105,79 @@ def pack_document(input_dir: str | Path, output_file: str | Path, validate: bool
 
             # Validate the temp file, never the destination, so a failure cannot
             # destroy the original (historic data-loss bug: unlink of output_file).
-            if validate and not validate_document(tmp_path):
+            # Pass the real extension: the temp file is named .tmp, and soffice's
+            # export filter is chosen from the suffix.
+            if validate and not validate_document(tmp_path, suffix=target.suffix):
                 return False
 
-            os.replace(tmp_path, output_file)
+            _promote(tmp_path, target)
         finally:
             # Remove the temp file on every failure path (write error, validation
             # failure). On success os.replace() consumed it, so this is a no-op.
-            tmp_path.unlink(missing_ok=True)
+            # Suppress errors so a doomed cleanup cannot turn a completed save into
+            # a reported failure (or mask an in-flight exception).
+            with contextlib.suppress(OSError):
+                tmp_path.unlink(missing_ok=True)
 
     return True
 
 
-def validate_document(doc_path: Path) -> bool:  # pragma: no cover
-    """Validate document by converting to HTML with soffice."""
+def _promote(tmp_path: Path, target: Path) -> None:
+    """Atomically move the finished archive onto the destination.
+
+    os.replace() swaps in the temp file's inode wholesale, so anything that rides
+    on the destination's inode must be carried over first — most importantly its
+    permissions, since mkstemp() creates the temp file 0600 and would otherwise
+    silently strip group/world access from every saved document.
+    """
+    if target.exists():
+        os.chmod(tmp_path, stat.S_IMODE(target.stat().st_mode))
+    else:
+        # New file: match what a plain open() would have produced under the umask.
+        umask = os.umask(0)
+        os.umask(umask)
+        os.chmod(tmp_path, 0o666 & ~umask)
+
+    # Flush the archive before promoting it. os.replace() is atomic with respect to
+    # other processes, but without this a crash could leave the destination name
+    # pointing at an inode whose data blocks were never written to disk.
+    with open(tmp_path, "rb") as f:
+        os.fsync(f.fileno())
+
+    try:
+        os.replace(tmp_path, target)
+    except PermissionError as e:
+        # The destination is held open by another program — on Windows this is
+        # exactly what Word does. Map only *this* step: a PermissionError from
+        # anywhere earlier (e.g. a non-writable directory) is a genuine
+        # filesystem problem and must not be reported as "close the document".
+        raise DocumentOpenError(
+            f"{target} could not be replaced (permission denied); it is likely open "
+            f"in another program. Close it and retry.",
+            path=target,
+        ) from e
+
+    # Persist the rename itself, so a crash cannot undo it. Directory fsync is not
+    # supported on Windows, where it is also unnecessary.
+    with contextlib.suppress(OSError):
+        dir_fd = os.open(target.parent, os.O_RDONLY)
+        try:
+            os.fsync(dir_fd)
+        finally:
+            os.close(dir_fd)
+
+
+def validate_document(doc_path: Path, suffix: str | None = None) -> bool:  # pragma: no cover
+    """Validate document by converting to HTML with soffice.
+
+    Args:
+        doc_path: File to validate. May be a temp file whose own extension does
+            not reflect the real format.
+        suffix: The real OOXML extension (".docx"/".pptx"/".xlsx") to pick the
+            soffice export filter with. Defaults to doc_path's own suffix.
+    """
     # Determine the correct filter based on file extension
-    match doc_path.suffix.lower():
+    match (suffix or doc_path.suffix).lower():
         case ".docx":
             filter_name = "html:HTML"
         case ".pptx":

--- a/docx_editor/ooxml/pack.py
+++ b/docx_editor/ooxml/pack.py
@@ -1,5 +1,6 @@
 """Pack a directory back into a .docx, .pptx, or .xlsx file."""
 
+import os
 import shutil
 import subprocess
 import sys
@@ -63,26 +64,43 @@ def pack_document(input_dir: str | Path, output_file: str | Path, validate: bool
             (f for f in temp_content_dir.rglob("*") if f.is_file()),
             key=lambda f: f.relative_to(temp_content_dir).as_posix(),
         )
-        with zipfile.ZipFile(output_file, "w", zipfile.ZIP_DEFLATED) as zf:
-            for f in entries:
-                rel = f.relative_to(temp_content_dir)
-                if rel in EXCLUDED_PATHS:
-                    continue
-                info = zipfile.ZipInfo(rel.as_posix(), date_time=(1980, 1, 1, 0, 0, 0))
-                info.compress_type = zipfile.ZIP_DEFLATED
-                info.create_system = 3  # Unix, pinned for cross-platform byte stability
-                info.external_attr = 0o644 << 16
-                # _compresslevel: stdlib's documented per-entry escape hatch (stable since 3.7);
-                # ZipFile.compresslevel is not propagated to ZipInfo entries.
-                info._compresslevel = 6  # ty: ignore[unresolved-attribute]
-                with f.open("rb") as src, zf.open(info, "w") as dst:
-                    shutil.copyfileobj(src, dst)
 
-        # Validate if requested
-        if validate:  # pragma: no cover
-            if not validate_document(output_file):
-                output_file.unlink()  # Delete the corrupt file
+        # Atomic write: build the archive in a temp file in the destination's own
+        # directory, then promote it with os.replace(). The destination is never
+        # observed half-written (safe inside cloud-synced folders), and any failure
+        # — a write error or a failed validation — leaves the existing destination
+        # untouched. Same directory ⇒ same volume ⇒ os.replace() is a true atomic
+        # rename (no cross-device error). Leading '.' + '.tmp' keeps sync clients
+        # from ingesting the transient file.
+        fd, tmp_name = tempfile.mkstemp(dir=output_file.parent, prefix=f".{output_file.name}.", suffix=".tmp")
+        os.close(fd)
+        tmp_path = Path(tmp_name)
+        try:
+            with zipfile.ZipFile(tmp_path, "w", zipfile.ZIP_DEFLATED) as zf:
+                for f in entries:
+                    rel = f.relative_to(temp_content_dir)
+                    if rel in EXCLUDED_PATHS:
+                        continue
+                    info = zipfile.ZipInfo(rel.as_posix(), date_time=(1980, 1, 1, 0, 0, 0))
+                    info.compress_type = zipfile.ZIP_DEFLATED
+                    info.create_system = 3  # Unix, pinned for cross-platform byte stability
+                    info.external_attr = 0o644 << 16
+                    # _compresslevel: stdlib's documented per-entry escape hatch (stable since 3.7);
+                    # ZipFile.compresslevel is not propagated to ZipInfo entries.
+                    info._compresslevel = 6  # ty: ignore[unresolved-attribute]
+                    with f.open("rb") as src, zf.open(info, "w") as dst:
+                        shutil.copyfileobj(src, dst)
+
+            # Validate the temp file, never the destination, so a failure cannot
+            # destroy the original (historic data-loss bug: unlink of output_file).
+            if validate and not validate_document(tmp_path):
                 return False
+
+            os.replace(tmp_path, output_file)
+        finally:
+            # Remove the temp file on every failure path (write error, validation
+            # failure). On success os.replace() consumed it, so this is a no-op.
+            tmp_path.unlink(missing_ok=True)
 
     return True
 

--- a/docx_editor/ooxml/pack.py
+++ b/docx_editor/ooxml/pack.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import os
+import secrets
 import shutil
 import stat
 import subprocess
@@ -20,9 +21,10 @@ from ..exceptions import DocumentOpenError
 # relative — a hypothetical subpart literally named "meta.json" is unaffected.
 EXCLUDED_PATHS = {Path("meta.json")}
 
-# Bytes left for the destination's name inside the promotion temp file's name, whose
-# shape is ".<name>.<8 random chars>.tmp" against a 255-byte NAME_MAX.
-_TEMP_NAME_BUDGET = 255 - len(".") - len(".") - 8 - len(".tmp")
+# The promotion temp file is named ".<destination name>.<8 random chars>.tmp"; this
+# is everything in that shape except the destination's own name.
+_TEMP_NAME_OVERHEAD = len(".") + len(".") + 8 + len(".tmp")
+_TEMP_NAME_ATTEMPTS = 100
 
 
 def _ignore_symlinks(directory: str, names: list[str]) -> list[str]:
@@ -87,30 +89,40 @@ def pack_document(input_dir: str | Path, output_file: str | Path, validate: bool
         # — a write error or a failed validation — leaves the existing destination
         # untouched. Same directory ⇒ same volume ⇒ os.replace() is a true atomic
         # rename (no cross-device error).
-        #
-        # mkstemp builds "<prefix><8 random chars><suffix>", and NAME_MAX is a *byte*
-        # budget (255), not a character count — so clamp the encoded name. Slicing
-        # characters would still overflow on a non-ASCII destination, whose name can
-        # run to 4 bytes per character.
-        stem = target.name.encode()[:_TEMP_NAME_BUDGET].decode(errors="ignore")
-        fd, tmp_name = tempfile.mkstemp(dir=target.parent, prefix=f".{stem}.", suffix=".tmp")
-        os.close(fd)
-        tmp_path = Path(tmp_name)
+        fd, tmp_path = _create_temp(target)
         try:
-            with zipfile.ZipFile(tmp_path, "w", zipfile.ZIP_DEFLATED) as zf:
-                for f in entries:
-                    rel = f.relative_to(temp_content_dir)
-                    if rel in EXCLUDED_PATHS:
-                        continue
-                    info = zipfile.ZipInfo(rel.as_posix(), date_time=(1980, 1, 1, 0, 0, 0))
-                    info.compress_type = zipfile.ZIP_DEFLATED
-                    info.create_system = 3  # Unix, pinned for cross-platform byte stability
-                    info.external_attr = 0o644 << 16
-                    # _compresslevel: stdlib's documented per-entry escape hatch (stable since 3.7);
-                    # ZipFile.compresslevel is not propagated to ZipInfo entries.
-                    info._compresslevel = 6  # ty: ignore[unresolved-attribute]
-                    with f.open("rb") as src, zf.open(info, "w") as dst:
-                        shutil.copyfileobj(src, dst)
+            # Write through the temp file's own fd rather than reopening it by name.
+            # Reopening would fail wherever the created file is not owner-writable —
+            # a directory with a restrictive default POSIX ACL masks the new file down
+            # to 0400 — and it would leave a window in which the name could be swapped
+            # under us.
+            with os.fdopen(fd, "w+b") as tmp_file:
+                # Take the destination's permissions *before* writing any content, so
+                # the document is never briefly more readable than the file it replaces.
+                if target.exists():
+                    _chmod(tmp_file, tmp_path, stat.S_IMODE(target.stat().st_mode))
+
+                with zipfile.ZipFile(tmp_file, "w", zipfile.ZIP_DEFLATED) as zf:
+                    for f in entries:
+                        rel = f.relative_to(temp_content_dir)
+                        if rel in EXCLUDED_PATHS:
+                            continue
+                        info = zipfile.ZipInfo(rel.as_posix(), date_time=(1980, 1, 1, 0, 0, 0))
+                        info.compress_type = zipfile.ZIP_DEFLATED
+                        info.create_system = 3  # Unix, pinned for cross-platform byte stability
+                        info.external_attr = 0o644 << 16
+                        # _compresslevel: stdlib's documented per-entry escape hatch (stable since 3.7);
+                        # ZipFile.compresslevel is not propagated to ZipInfo entries.
+                        info._compresslevel = 6  # ty: ignore[unresolved-attribute]
+                        with f.open("rb") as src, zf.open(info, "w") as dst:
+                            shutil.copyfileobj(src, dst)
+
+                # Flush contents and mode to disk before promoting. os.replace() is
+                # atomic with respect to other processes, but without this a crash
+                # could leave the destination name pointing at an inode whose data
+                # blocks were never written.
+                tmp_file.flush()
+                os.fsync(tmp_file.fileno())
 
             # Validate the temp file, never the destination, so a failure cannot
             # destroy the original (historic data-loss bug: unlink of output_file).
@@ -121,7 +133,7 @@ def pack_document(input_dir: str | Path, output_file: str | Path, validate: bool
             if validate and not validate_document(tmp_path, suffix=output_file.suffix):
                 return False
 
-            _promote(tmp_path, target)
+            _replace(tmp_path, target)
         finally:
             # Remove the temp file on every failure path (write error, validation
             # failure). On success os.replace() consumed it, so this is a no-op.
@@ -133,39 +145,49 @@ def pack_document(input_dir: str | Path, output_file: str | Path, validate: bool
     return True
 
 
-def _promote(tmp_path: Path, target: Path) -> None:
-    """Atomically move the finished archive onto the destination.
+def _create_temp(target: Path) -> tuple[int, Path]:
+    """Create the promotion temp file next to ``target``; return its fd and path.
 
-    Three things happen here, in an order that matters:
-
-    1. The archive is flushed to disk. os.replace() is atomic with respect to other
-       processes, but without an fsync a crash could leave the destination name
-       pointing at an inode whose data blocks were never written.
-    2. The destination's permissions are carried over. os.replace() swaps in the
-       temp file's inode wholesale, and mkstemp() creates that file 0600, so without
-       this every save would silently strip group/world access from the document.
-       Only the mode is carried — ownership, ACLs, xattrs and hardlinks belong to
-       the replaced inode and cannot survive an atomic rename (see README).
-    3. The rename itself is persisted, so a crash cannot undo it.
-
-    A PermissionError from the rename is mapped to DocumentOpenError on Windows,
-    where a destination held open by Word is exactly what it means.
+    Deliberately not tempfile.mkstemp(): that forces mode 0600, which for a
+    brand-new destination would then have to be corrected back to the process
+    default — and the only stdlib way to read the umask (set it to 0, then restore)
+    mutates global state a concurrent thread can observe. Creating the file 0666
+    lets the kernel apply the umask (and any default ACL) itself, so a new
+    destination lands on exactly the mode a plain open() would have produced, with
+    no race. O_EXCL keeps the name ours alone.
     """
-    # Fsync BEFORE chmod: the temp file is still 0600 (owner-writable) here. Doing it
-    # after would make reopening a read-only destination's mode (0444) fail outright.
-    # Opened "rb+", not "rb": on Windows os.fsync() maps to FlushFileBuffers, which
-    # needs write access on the handle and fails on a read-only one.
-    with open(tmp_path, "rb+") as f:
-        os.fsync(f.fileno())
+    # NAME_MAX is a *byte* budget, not a character count, so clamp the encoded name —
+    # slicing characters would still overflow for a non-ASCII name at up to 4 bytes
+    # each. Go through os.fsencode/os.fsdecode, not str.encode: Linux filenames are
+    # bytes, and an undecodable one arrives here as surrogates that strict UTF-8
+    # encoding would reject.
+    try:
+        name_max = os.pathconf(target.parent, "PC_NAME_MAX")
+    except (AttributeError, OSError, ValueError):  # pragma: no cover - platform-dependent
+        name_max = 255
+    budget = max(8, name_max - _TEMP_NAME_OVERHEAD)
+    stem = os.fsdecode(os.fsencode(target.name)[:budget])
 
-    if target.exists():
-        os.chmod(tmp_path, stat.S_IMODE(target.stat().st_mode))
-    else:
-        # New file: match what a plain open() would have produced under the umask.
-        umask = os.umask(0)
-        os.umask(umask)
-        os.chmod(tmp_path, 0o666 & ~umask)
+    flags = os.O_RDWR | os.O_CREAT | os.O_EXCL | getattr(os, "O_BINARY", 0)
+    for _ in range(_TEMP_NAME_ATTEMPTS):
+        candidate = target.parent / f".{stem}.{secrets.token_hex(4)}.tmp"
+        try:
+            return os.open(candidate, flags, 0o666), candidate
+        except FileExistsError:  # pragma: no cover - requires a name collision
+            continue
+    raise OSError(f"Could not create a unique temp file next to {target}")  # pragma: no cover
 
+
+def _chmod(tmp_file: object, tmp_path: Path, mode: int) -> None:
+    """Set the temp file's mode, preferring the fd so no path race is possible."""
+    if hasattr(os, "fchmod"):
+        os.fchmod(tmp_file.fileno(), mode)  # ty: ignore[unresolved-attribute]
+    else:  # pragma: no cover - Windows has no fchmod
+        os.chmod(tmp_path, mode)
+
+
+def _replace(tmp_path: Path, target: Path) -> None:
+    """Atomically move the finished archive onto the destination, and persist it."""
     try:
         os.replace(tmp_path, target)
     except PermissionError as e:
@@ -174,7 +196,11 @@ def _promote(tmp_path: Path, target: Path) -> None:
         # holds open always succeeds. A denial there means something else entirely —
         # a sticky-bit directory, an immutable file, an SELinux denial — and calling
         # that "the document is open" would send the caller down a dead end.
-        if sys.platform != "win32":
+        #
+        # A read-only destination on Windows also lands here (MoveFileEx refuses to
+        # replace a FILE_ATTRIBUTE_READONLY file), and that is not an open document
+        # either — so only claim "open" when the destination is otherwise writable.
+        if sys.platform != "win32" or (target.exists() and not os.access(target, os.W_OK)):
             raise
         raise DocumentOpenError(
             f"{target} could not be replaced (permission denied); it is likely open "

--- a/docx_editor/workspace.py
+++ b/docx_editor/workspace.py
@@ -74,19 +74,26 @@ def _default_cache_dir() -> Path:
 
 
 def owner_file_candidates(path: str | Path) -> list[Path]:
-    """Return the ``~$`` owner (lock) file paths Word would use for ``path``.
+    """Return the ``~$`` owner (lock) file paths Word may use for ``path``.
 
-    Word writes a hidden ``~$`` owner file next to any document it has open. Its
-    naming is length-dependent: for a normal filename Word drops the first two
-    characters (``Report.docx`` → ``~$port.docx``); for very short names it keeps
-    them (``ab.docx`` → ``~$ab.docx``). We return both the full-name form and the
-    two-char-truncated form and let the caller check for either, so a save-time
-    guard never under-detects an open document regardless of Word's exact rule
-    for a given name.
+    Word writes a hidden ``~$`` owner file next to any document it has open. The
+    name is derived from the document's: Word drops the first two characters of
+    the filename when the stem is longer than two characters (``Report.docx`` →
+    ``~$port.docx``), and keeps the name in full for very short stems
+    (``ab.docx`` → ``~$ab.docx``).
+
+    Both forms are returned as a deliberately conservative superset — checking a
+    stub that Word would not have written costs a false positive (recoverable via
+    ``force=True``), while missing one risks saving over a live document. The
+    truncated form is inherently ambiguous: ``01_intro.docx`` and
+    ``02_intro.docx`` share the stub ``~$_intro.docx``. That ambiguity is Word's
+    own — it uses the same owner file for both, and the stub records the *user*
+    who holds the lock, not the document — so it cannot be disambiguated here.
     """
     path = Path(path)
     candidates = [path.parent / f"~${path.name}"]
-    if len(path.name) > 2:
+    # Guard on the stem so short names don't yield junk like "~$.docx".
+    if len(path.stem) > 2:
         candidates.append(path.parent / f"~${path.name[2:]}")
     return candidates
 
@@ -346,8 +353,8 @@ class Workspace:
             WorkspaceSyncError: If saving to the original path and the source
                 document changed on disk since the workspace was created
             DocumentOpenError: If the destination appears open in Word (a ``~$``
-                owner file exists) and ``force`` is False, or if the OS denies
-                the write with a PermissionError.
+                owner file exists) and ``force`` is False, or if the OS denies the
+                final replace because another program holds the destination open.
             WorkspaceError: If packing fails
         """
         # Keep the caller's path for packing and for the return value; resolution is
@@ -369,28 +376,32 @@ class Workspace:
         # Guard the destination only — saving a copy to a fresh path while the
         # source is open is fine. force=True skips this (and any other save-time
         # safety check) for confirmed-stale locks from a crashed session.
+        #
+        # Check next to the *resolved* destination: pack_document() promotes into
+        # the symlink target, so that is where Word's stub would sit.
         if not force:
-            owner_file = next((c for c in owner_file_candidates(output_path) if c.exists()), None)
+            resolved = Path(os.path.realpath(output_path))
+            owner_file = next((c for c in owner_file_candidates(resolved) if os.path.lexists(c)), None)
             if owner_file is not None:
                 raise DocumentOpenError(
                     f"{output_path} appears to be open in Word (found owner file "
-                    f"{owner_file.name}). Close the document in Word, or pass "
-                    f"force=True if this is a stale lock from a crashed session."
+                    f"{owner_file.name}; note Word shares one owner file between "
+                    f"documents whose names differ only in the first two characters). "
+                    f"Close the document in Word, or pass force=True if this is a "
+                    f"stale lock from a crashed session.",
+                    path=output_path,
+                    owner_file=owner_file,
                 )
 
         # Update metadata before saving
         self.meta["last_saved"] = datetime.now(timezone.utc).isoformat()
         self._save_meta()
 
-        # Pack the document. A PermissionError here almost always means Word holds
-        # the destination open (Windows); map it to the same guard exception.
-        try:
-            success = pack_document(self.workspace_path, output_path, validate=validate)
-        except PermissionError as e:
-            raise DocumentOpenError(
-                f"{output_path} could not be written (permission denied); it may be "
-                f"open in Word or read-only. Close the document in Word and retry."
-            ) from e
+        # Pack the document. pack_document() maps a PermissionError from the final
+        # replace to DocumentOpenError itself; any other PermissionError (e.g. a
+        # non-writable directory) is a genuine filesystem error and propagates
+        # unchanged rather than being mislabeled as "the document is open".
+        success = pack_document(self.workspace_path, output_path, validate=validate)
 
         if not success:
             raise WorkspaceError(f"Failed to pack document to {output_path}")

--- a/docx_editor/workspace.py
+++ b/docx_editor/workspace.py
@@ -144,10 +144,13 @@ class Workspace:
             InvalidDocumentError: If the file is not a .docx file
             WorkspaceExistsError: If workspace exists and create=True
         """
-        # Keep the name the caller actually opened, unresolved. If they opened a
-        # symlink, that is the name Word was told to open — and therefore the name
-        # its ~$ owner file sits beside. save() needs it to find that stub.
-        self._given_path = Path(source_path)
+        # Keep the name the caller actually opened. If they opened a symlink, that is
+        # the name Word was told to open — and therefore the name its ~$ owner file
+        # sits beside. save() needs it to find that stub. Made absolute but NOT
+        # resolved: resolving would collapse the symlink and lose the very name we are
+        # keeping, while leaving it relative would break if the cwd moves before save().
+        given = Path(source_path)
+        self._given_path = given if given.is_absolute() else Path.cwd() / given
         self.source_path = Path(source_path).resolve()
 
         if not self.source_path.exists():
@@ -430,7 +433,11 @@ class Workspace:
         if not success:
             raise WorkspaceError(f"Failed to pack document to {output_path}")
 
-        # Update source_mtime if saving to original location
+        # Update source_mtime/source_size if saving to the original location.
+        # overwrites_source uses os.path.samefile (see _is_source), so a different
+        # name for the same file — including through a symlink — still refreshes the
+        # workspace's stat, or the next open() would report a stale workspace. Both
+        # mtime and size are updated because sync_check() compares both.
         if overwrites_source:
             saved_stat = output_path.stat()
             self.meta["source_mtime"] = saved_stat.st_mtime

--- a/docx_editor/workspace.py
+++ b/docx_editor/workspace.py
@@ -76,10 +76,10 @@ def _default_cache_dir() -> Path:
 def owner_file_candidates(path: str | Path) -> list[Path]:
     """Return the ``~$`` owner (lock) file paths Word may use for ``path``.
 
-    Word writes a hidden ``~$`` owner file next to any document it has open. The
-    name is derived from the document's: Word drops the first two characters of
-    the filename when the stem is longer than two characters (``Report.docx`` →
-    ``~$port.docx``), and keeps the name in full for very short stems
+    Word writes a hidden ``~$`` owner file next to any document it has open. Its
+    name is derived from the document's filename: Word drops the first two
+    characters when the stem is longer than two characters (``Report.docx`` →
+    ``~$port.docx``), and keeps the filename in full for very short stems
     (``ab.docx`` → ``~$ab.docx``).
 
     Both forms are returned as a deliberately conservative superset — checking a
@@ -377,11 +377,14 @@ class Workspace:
         # source is open is fine. force=True skips this (and any other save-time
         # safety check) for confirmed-stale locks from a crashed session.
         #
-        # Check next to the *resolved* destination: pack_document() promotes into
-        # the symlink target, so that is where Word's stub would sit.
+        # Check next to BOTH the given path and the resolved one. Word writes its
+        # stub beside the name the user opened — the symlink, if that is what they
+        # double-clicked — while pack_document() promotes into the resolved file.
+        # Checking only one of the two misses a genuinely open document.
         if not force:
             resolved = Path(os.path.realpath(output_path))
-            owner_file = next((c for c in owner_file_candidates(resolved) if os.path.lexists(c)), None)
+            candidates = dict.fromkeys(owner_file_candidates(output_path) + owner_file_candidates(resolved))
+            owner_file = next((c for c in candidates if os.path.lexists(c)), None)
             if owner_file is not None:
                 raise DocumentOpenError(
                     f"{output_path} appears to be open in Word (found owner file "

--- a/docx_editor/workspace.py
+++ b/docx_editor/workspace.py
@@ -144,6 +144,10 @@ class Workspace:
             InvalidDocumentError: If the file is not a .docx file
             WorkspaceExistsError: If workspace exists and create=True
         """
+        # Keep the name the caller actually opened, unresolved. If they opened a
+        # symlink, that is the name Word was told to open — and therefore the name
+        # its ~$ owner file sits beside. save() needs it to find that stub.
+        self._given_path = Path(source_path)
         self.source_path = Path(source_path).resolve()
 
         if not self.source_path.exists():
@@ -332,6 +336,40 @@ class Workspace:
         with open(meta_path, "w", encoding="utf-8") as f:
             json.dump(self.meta, f, indent=2)
 
+    def _check_not_open(self, output_path: Path, *, saving_in_place: bool) -> None:
+        """Raise DocumentOpenError if Word appears to have the destination open.
+
+        Word writes its ``~$`` owner file beside the name it was told to open, which
+        is not necessarily the name we are about to write. So check beside every name
+        this destination is known by: the path given, the path it resolves to (which
+        is where the archive actually lands), and — when saving in place — the
+        possibly-symlinked path the caller originally opened.
+
+        A destination that does not exist yet is never guarded: a stale stub beside a
+        name with no document behind it has nothing to protect.
+        """
+        if not os.path.lexists(output_path):
+            return
+
+        names = [output_path, Path(os.path.realpath(output_path))]
+        if saving_in_place:
+            names.append(self._given_path)
+
+        candidates = dict.fromkeys(c for name in names for c in owner_file_candidates(name))
+        owner_file = next((c for c in candidates if os.path.lexists(c)), None)
+        if owner_file is None:
+            return
+
+        raise DocumentOpenError(
+            f"{output_path} appears to be open in Word (found owner file "
+            f"{owner_file.name}). Close the document in Word, or pass force=True if "
+            f"this is a stale lock from a crashed session. Note the stub name is "
+            f"ambiguous: Word derives it by dropping the first two characters, so it "
+            f"may belong to a different document in the same folder.",
+            path=output_path,
+            owner_file=owner_file,
+        )
+
     def save(
         self,
         destination: str | Path | None = None,
@@ -376,25 +414,8 @@ class Workspace:
         # Guard the destination only — saving a copy to a fresh path while the
         # source is open is fine. force=True skips this (and any other save-time
         # safety check) for confirmed-stale locks from a crashed session.
-        #
-        # Check next to BOTH the given path and the resolved one. Word writes its
-        # stub beside the name the user opened — the symlink, if that is what they
-        # double-clicked — while pack_document() promotes into the resolved file.
-        # Checking only one of the two misses a genuinely open document.
         if not force:
-            resolved = Path(os.path.realpath(output_path))
-            candidates = dict.fromkeys(owner_file_candidates(output_path) + owner_file_candidates(resolved))
-            owner_file = next((c for c in candidates if os.path.lexists(c)), None)
-            if owner_file is not None:
-                raise DocumentOpenError(
-                    f"{output_path} appears to be open in Word (found owner file "
-                    f"{owner_file.name}; note Word shares one owner file between "
-                    f"documents whose names differ only in the first two characters). "
-                    f"Close the document in Word, or pass force=True if this is a "
-                    f"stale lock from a crashed session.",
-                    path=output_path,
-                    owner_file=owner_file,
-                )
+            self._check_not_open(output_path, saving_in_place=destination is None)
 
         # Update metadata before saving
         self.meta["last_saved"] = datetime.now(timezone.utc).isoformat()

--- a/docx_editor/workspace.py
+++ b/docx_editor/workspace.py
@@ -19,6 +19,7 @@ from typing import Any
 
 from .exceptions import (
     DocumentNotFoundError,
+    DocumentOpenError,
     InvalidDocumentError,
     WorkspaceError,
     WorkspaceExistsError,
@@ -70,6 +71,24 @@ def _default_cache_dir() -> Path:
         return _home() / "Library" / "Caches" / "docx-editor"
     root = _cache_root_from_env("XDG_CACHE_HOME") or _home() / ".cache"
     return root / "docx-editor"
+
+
+def owner_file_candidates(path: str | Path) -> list[Path]:
+    """Return the ``~$`` owner (lock) file paths Word would use for ``path``.
+
+    Word writes a hidden ``~$`` owner file next to any document it has open. Its
+    naming is length-dependent: for a normal filename Word drops the first two
+    characters (``Report.docx`` → ``~$port.docx``); for very short names it keeps
+    them (``ab.docx`` → ``~$ab.docx``). We return both the full-name form and the
+    two-char-truncated form and let the caller check for either, so a save-time
+    guard never under-detects an open document regardless of Word's exact rule
+    for a given name.
+    """
+    path = Path(path)
+    candidates = [path.parent / f"~${path.name}"]
+    if len(path.name) > 2:
+        candidates.append(path.parent / f"~${path.name[2:]}")
+    return candidates
 
 
 class Workspace:
@@ -317,7 +336,8 @@ class Workspace:
         Args:
             destination: Output path (defaults to original source path)
             validate: If True, validate with LibreOffice
-            force: If True, overwrite the source even if it changed on disk
+            force: If True, skip save-time safety checks (the source-changed-on-disk
+                check and the open-in-Word guard)
 
         Returns:
             Path to the saved document
@@ -325,6 +345,9 @@ class Workspace:
         Raises:
             WorkspaceSyncError: If saving to the original path and the source
                 document changed on disk since the workspace was created
+            DocumentOpenError: If the destination appears open in Word (a ``~$``
+                owner file exists) and ``force`` is False, or if the OS denies
+                the write with a PermissionError.
             WorkspaceError: If packing fails
         """
         # Keep the caller's path for packing and for the return value; resolution is
@@ -341,12 +364,33 @@ class Workspace:
                 f"or save(destination=...) to write elsewhere."
             )
 
+        # Refuse to overwrite a document Word currently has open. Saving into
+        # Word's live file races its own writes and can corrupt the document.
+        # Guard the destination only — saving a copy to a fresh path while the
+        # source is open is fine. force=True skips this (and any other save-time
+        # safety check) for confirmed-stale locks from a crashed session.
+        if not force:
+            owner_file = next((c for c in owner_file_candidates(output_path) if c.exists()), None)
+            if owner_file is not None:
+                raise DocumentOpenError(
+                    f"{output_path} appears to be open in Word (found owner file "
+                    f"{owner_file.name}). Close the document in Word, or pass "
+                    f"force=True if this is a stale lock from a crashed session."
+                )
+
         # Update metadata before saving
         self.meta["last_saved"] = datetime.now(timezone.utc).isoformat()
         self._save_meta()
 
-        # Pack the document
-        success = pack_document(self.workspace_path, output_path, validate=validate)
+        # Pack the document. A PermissionError here almost always means Word holds
+        # the destination open (Windows); map it to the same guard exception.
+        try:
+            success = pack_document(self.workspace_path, output_path, validate=validate)
+        except PermissionError as e:
+            raise DocumentOpenError(
+                f"{output_path} could not be written (permission denied); it may be "
+                f"open in Word or read-only. Close the document in Word and retry."
+            ) from e
 
         if not success:
             raise WorkspaceError(f"Failed to pack document to {output_path}")

--- a/skills/docx/SKILL.md
+++ b/skills/docx/SKILL.md
@@ -451,6 +451,7 @@ All LLM-facing errors inherit from `DocxEditError` and carry structured fields s
 | `TextNotFoundError`    | `search_text`, `paragraph_ref`, `paragraph_preview`, `occurrence`, `total_occurrences`  | Use `paragraph_preview` to pick a substring that actually appears; if `total_occurrences` is set, retry with an `occurrence` < `total_occurrences`. |
 | `ParagraphIndexError`  | `index`, `total_paragraphs`                                                             | Clamp to `1..total_paragraphs` or call `list_paragraphs()` to pick a valid ref.                 |
 | `BatchOperationError`  | `operation_index`, `reason`                                                             | Fix the op at `operations[operation_index]` (or drop it) and retry the batch.                    |
+| `DocumentOpenError`    | — (message names the file)                                                              | **Do not retry blindly.** The destination is open in Word. Stop and tell the user to close it. Only pass `force=True` if the user confirms the `~$` lock is stale (crashed session). |
 
 ```python
 from docx_editor import (
@@ -479,6 +480,17 @@ except BatchOperationError as e:
     ops.pop(e.operation_index)
     doc.batch_edit(ops)
 ```
+
+**Saving safely (`DocumentOpenError`).** `save()` is atomic — it writes to a temp
+file and renames, so a failed save (including `validate=True`) never corrupts or
+deletes the existing document. Before writing it also checks for Word's `~$` lock
+file next to the destination and raises `DocumentOpenError` if the document looks
+open. This one is **not** an in-loop retry: it means a human has the file open, so
+stop and tell the user to close it in Word. `force=True` bypasses the guard and is
+only for a confirmed-stale lock left by a crashed session — never reach for it just
+to make the error go away. (The guard sees only *local* locks; remote co-authoring
+in OneDrive/SharePoint or Word-for-the-web leaves no local file and cannot be
+detected.)
 
 ### Paragraph Rewrite (Fallback for Structural Edits)
 

--- a/skills/docx/SKILL.md
+++ b/skills/docx/SKILL.md
@@ -495,9 +495,12 @@ just to make the error go away.
 Two limits worth knowing: the guard sees only *local* locks, so remote co-authoring
 in OneDrive/SharePoint or Word-for-the-web leaves no local file and cannot be
 detected; and because the save writes a temp file next to the destination, it needs
-**write permission on the containing directory**, not just on the document. A
-directory-permission problem surfaces as a plain `PermissionError`, not
-`DocumentOpenError` — do not tell the user to close Word for that one.
+**write permission on the containing directory**, not just on the document.
+
+A directory-permission problem surfaces as a plain `PermissionError`, not
+`DocumentOpenError` — do not tell the user to close Word for that one. So does a
+**write-protected document**: `save()` refuses it rather than replacing it, so offer
+to save under a new path instead.
 
 ### Paragraph Rewrite (Fallback for Structural Edits)
 

--- a/skills/docx/SKILL.md
+++ b/skills/docx/SKILL.md
@@ -451,7 +451,7 @@ All LLM-facing errors inherit from `DocxEditError` and carry structured fields s
 | `TextNotFoundError`    | `search_text`, `paragraph_ref`, `paragraph_preview`, `occurrence`, `total_occurrences`  | Use `paragraph_preview` to pick a substring that actually appears; if `total_occurrences` is set, retry with an `occurrence` < `total_occurrences`. |
 | `ParagraphIndexError`  | `index`, `total_paragraphs`                                                             | Clamp to `1..total_paragraphs` or call `list_paragraphs()` to pick a valid ref.                 |
 | `BatchOperationError`  | `operation_index`, `reason`                                                             | Fix the op at `operations[operation_index]` (or drop it) and retry the batch.                    |
-| `DocumentOpenError`    | — (message names the file)                                                              | **Do not retry blindly.** The destination is open in Word. Stop and tell the user to close it. Only pass `force=True` if the user confirms the `~$` lock is stale (crashed session). |
+| `DocumentOpenError`    | `path`, `owner_file`                                                                    | **Do not retry blindly.** The destination is open in Word. Stop and tell the user to close it. Only pass `force=True` if the user confirms the `~$` lock is stale (crashed session). |
 
 ```python
 from docx_editor import (
@@ -482,15 +482,22 @@ except BatchOperationError as e:
 ```
 
 **Saving safely (`DocumentOpenError`).** `save()` is atomic — it writes to a temp
-file and renames, so a failed save (including `validate=True`) never corrupts or
-deletes the existing document. Before writing it also checks for Word's `~$` lock
-file next to the destination and raises `DocumentOpenError` if the document looks
-open. This one is **not** an in-loop retry: it means a human has the file open, so
-stop and tell the user to close it in Word. `force=True` bypasses the guard and is
-only for a confirmed-stale lock left by a crashed session — never reach for it just
-to make the error go away. (The guard sees only *local* locks; remote co-authoring
+file in the destination's directory and renames, so a failed save (including
+`validate=True`) never corrupts or deletes the existing document, and the saved
+file keeps its original permissions. Before writing it also checks for Word's `~$`
+lock file next to the destination and raises `DocumentOpenError` if the document
+looks open. This one is **not** an in-loop retry: it means a human has the file
+open, so stop and tell the user to close it in Word. Use `e.path` and
+`e.owner_file` to tell them exactly which file. `force=True` bypasses the guard and
+is only for a confirmed-stale lock left by a crashed session — never reach for it
+just to make the error go away.
+
+Two limits worth knowing: the guard sees only *local* locks, so remote co-authoring
 in OneDrive/SharePoint or Word-for-the-web leaves no local file and cannot be
-detected.)
+detected; and because the save writes a temp file next to the destination, it needs
+**write permission on the containing directory**, not just on the document. A
+directory-permission problem surfaces as a plain `PermissionError`, not
+`DocumentOpenError` — do not tell the user to close Word for that one.
 
 ### Paragraph Rewrite (Fallback for Structural Edits)
 

--- a/tests/test_atomic_save.py
+++ b/tests/test_atomic_save.py
@@ -1,0 +1,91 @@
+"""Tests for atomic save.
+
+``pack_document`` must write the archive to a temp file in the destination's own
+directory and promote it with a single ``os.replace``. This guards two properties:
+
+  * A failure mid-pack, or a failed ``validate=True``, never touches the
+    destination. This fixes the historic data-loss bug where a failed validation
+    ran ``output_file.unlink()`` on the *original* during a save-in-place.
+  * A successful pack is a single rename, so the destination is never observed
+    half-written — critical inside cloud-synced folders (OneDrive/Dropbox/...).
+"""
+
+import shutil
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from docx_editor.ooxml import pack, unpack_document
+from docx_editor.ooxml.pack import pack_document
+
+
+@pytest.fixture
+def unpacked_dir(simple_docx, temp_dir) -> Path:
+    """A valid unpacked workspace directory to pack from."""
+    d = temp_dir / "unpacked"
+    unpack_document(simple_docx, d)
+    return d
+
+
+def _temp_litter(dest: Path) -> list[Path]:
+    """Leftover atomic-save temp files next to the destination, if any."""
+    return list(dest.parent.glob(f".{dest.name}.*"))
+
+
+def test_failure_mid_pack_preserves_original(unpacked_dir, simple_docx, temp_dir, monkeypatch):
+    """A write error mid-pack leaves the existing destination byte-for-byte intact."""
+    dest = temp_dir / "original.docx"
+    shutil.copy(simple_docx, dest)
+    original_bytes = dest.read_bytes()
+
+    def boom(*args, **kwargs):
+        raise OSError("simulated write failure")
+
+    monkeypatch.setattr(pack.shutil, "copyfileobj", boom)
+
+    with pytest.raises(OSError):
+        pack_document(unpacked_dir, dest)
+
+    assert dest.read_bytes() == original_bytes
+    assert _temp_litter(dest) == []
+
+
+def test_validation_failure_preserves_original(unpacked_dir, simple_docx, temp_dir, monkeypatch):
+    """A failed validation returns False and leaves the original untouched (data-loss regression)."""
+    dest = temp_dir / "original.docx"
+    shutil.copy(simple_docx, dest)
+    original_bytes = dest.read_bytes()
+
+    monkeypatch.setattr(pack, "validate_document", lambda p: False)
+
+    result = pack_document(unpacked_dir, dest, validate=True)
+
+    assert result is False
+    assert dest.read_bytes() == original_bytes
+    assert _temp_litter(dest) == []
+
+
+def test_success_is_single_replace_promotion(unpacked_dir, temp_dir, monkeypatch):
+    """A successful pack promotes one temp file — in the destination's own dir — via os.replace."""
+    dest = temp_dir / "out.docx"
+
+    real_replace = pack.os.replace
+    calls: list[tuple[Path, Path]] = []
+
+    def spy_replace(src, dst):
+        calls.append((Path(src), Path(dst)))
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(pack.os, "replace", spy_replace)
+
+    result = pack_document(unpacked_dir, dest)
+
+    assert result is True
+    with zipfile.ZipFile(dest) as zf:
+        assert zf.testzip() is None
+    assert len(calls) == 1
+    src, dst = calls[0]
+    assert src.parent == dest.parent  # same volume ⇒ atomic replace
+    assert dst == dest
+    assert _temp_litter(dest) == []

--- a/tests/test_atomic_save.py
+++ b/tests/test_atomic_save.py
@@ -10,8 +10,8 @@ directory and promote it with a single ``os.replace``. This guards two propertie
     half-written — critical inside cloud-synced folders (OneDrive/Dropbox/...).
 
 Because ``os.replace`` swaps in the temp file's *inode*, anything riding on the
-destination's inode must be carried over: these tests also pin the destination's
-permissions and the handling of a symlinked destination.
+destination's inode must be carried over deliberately: these tests also pin the
+destination's permissions and the handling of a symlinked destination.
 """
 
 import os
@@ -39,144 +39,174 @@ def _temp_litter(dest: Path) -> list[Path]:
     return list(dest.parent.glob(f".{dest.name}.*"))
 
 
-def test_failure_mid_pack_preserves_original(unpacked_dir, simple_docx, temp_dir, monkeypatch):
-    """A write error mid-archive leaves the existing destination byte-for-byte intact."""
-    dest = temp_dir / "original.docx"
-    shutil.copy(simple_docx, dest)
-    original_bytes = dest.read_bytes()
+class TestAtomicFailurePaths:
+    """A failed pack must leave the existing destination exactly as it was."""
 
-    # Fail on the *second* member so the archive is genuinely half-written, and
-    # record that a temp file existed at that moment — proving the failure happened
-    # after promotion started, not before the temp file was ever created (which
-    # would make this test pass vacuously).
-    state = {"calls": 0, "temp_existed_mid_write": False}
-    real_copyfileobj = shutil.copyfileobj
+    def test_failure_mid_pack_preserves_original(self, unpacked_dir, simple_docx, temp_dir, monkeypatch):
+        """A write error mid-archive leaves the existing destination byte-for-byte intact."""
+        dest = temp_dir / "original.docx"
+        shutil.copy(simple_docx, dest)
+        original_bytes = dest.read_bytes()
 
-    def boom(src, dst, *args, **kwargs):
-        state["calls"] += 1
-        if state["calls"] < 2:
-            return real_copyfileobj(src, dst, *args, **kwargs)
-        state["temp_existed_mid_write"] = bool(_temp_litter(dest))
-        raise OSError("simulated write failure")
+        # Fail on the *second* member so the archive is genuinely half-written, and
+        # record that a temp file existed at that moment — proving the failure struck
+        # after the temp was created, not before (which would pass vacuously).
+        state = {"calls": 0, "temp_existed_mid_write": False}
+        real_copyfileobj = shutil.copyfileobj
 
-    monkeypatch.setattr(pack.shutil, "copyfileobj", boom)
+        def boom(src, dst, *args, **kwargs):
+            state["calls"] += 1
+            if state["calls"] < 2:
+                return real_copyfileobj(src, dst, *args, **kwargs)
+            state["temp_existed_mid_write"] = bool(_temp_litter(dest))
+            raise OSError("simulated write failure")
 
-    with pytest.raises(OSError):
+        monkeypatch.setattr(pack.shutil, "copyfileobj", boom)
+
+        with pytest.raises(OSError):
+            pack_document(unpacked_dir, dest)
+
+        assert state["temp_existed_mid_write"], "failure did not occur mid-archive"
+        assert dest.read_bytes() == original_bytes
+        assert _temp_litter(dest) == []
+
+    def test_validation_failure_preserves_original(self, unpacked_dir, simple_docx, temp_dir, monkeypatch):
+        """A failed validation returns False and leaves the original untouched.
+
+        Regression for the data-loss bug: validation used to run against the
+        destination and unlink() it on failure.
+        """
+        dest = temp_dir / "original.docx"
+        shutil.copy(simple_docx, dest)
+        original_bytes = dest.read_bytes()
+
+        monkeypatch.setattr(pack, "validate_document", lambda p, **kw: False)
+
+        result = pack_document(unpacked_dir, dest, validate=True)
+
+        assert result is False
+        assert dest.read_bytes() == original_bytes
+        assert _temp_litter(dest) == []
+
+    def test_validation_receives_real_extension(self, unpacked_dir, temp_dir, monkeypatch):
+        """The temp file is named .tmp, so the real suffix must reach soffice explicitly.
+
+        Otherwise validate_document() picks its export filter from ".tmp", falling to
+        the default (Writer) filter — wrong for .pptx/.xlsx.
+        """
+        dest = temp_dir / "out.docx"
+        seen = {}
+
+        def spy_validate(path, suffix=None):
+            seen["suffix"] = suffix
+            return True
+
+        monkeypatch.setattr(pack, "validate_document", spy_validate)
+
+        assert pack_document(unpacked_dir, dest, validate=True) is True
+        assert seen["suffix"] == ".docx"
+
+
+class TestAtomicPromotion:
+    """A successful pack is a single rename from a temp file in the destination's dir."""
+
+    def test_success_is_single_replace_promotion(self, unpacked_dir, temp_dir, monkeypatch):
+        """Exactly one os.replace, sourced from the destination's own directory."""
+        dest = temp_dir / "out.docx"
+        resolved = Path(os.path.realpath(dest))
+
+        real_replace = pack.os.replace
+        calls: list[tuple[Path, Path]] = []
+
+        def spy_replace(src, dst):
+            calls.append((Path(src), Path(dst)))
+            return real_replace(src, dst)
+
+        monkeypatch.setattr(pack.os, "replace", spy_replace)
+
+        result = pack_document(unpacked_dir, dest)
+
+        assert result is True
+        with zipfile.ZipFile(dest) as zf:
+            assert zf.testzip() is None
+        assert len(calls) == 1
+        src, dst = calls[0]
+        assert src.parent == resolved.parent  # same volume ⇒ atomic replace
+        assert dst == resolved
+        assert _temp_litter(dest) == []
+
+    def test_long_destination_filename(self, unpacked_dir, temp_dir):
+        """A near-max-length filename must still save (the temp name is derived from it)."""
+        dest = temp_dir / ("a" * 245 + ".docx")  # 250 bytes, legal on ext4/APFS
         pack_document(unpacked_dir, dest)
 
-    assert state["temp_existed_mid_write"], "failure did not occur mid-archive"
-    assert dest.read_bytes() == original_bytes
-    assert _temp_litter(dest) == []
+        with zipfile.ZipFile(dest) as zf:
+            assert zf.testzip() is None
 
+    def test_long_non_ascii_destination_filename(self, unpacked_dir, temp_dir):
+        """NAME_MAX is a byte budget, not a character count.
 
-def test_validation_failure_preserves_original(unpacked_dir, simple_docx, temp_dir, monkeypatch):
-    """A failed validation returns False and leaves the original untouched (data-loss regression)."""
-    dest = temp_dir / "original.docx"
-    shutil.copy(simple_docx, dest)
-    original_bytes = dest.read_bytes()
-
-    monkeypatch.setattr(pack, "validate_document", lambda p, **kw: False)
-
-    result = pack_document(unpacked_dir, dest, validate=True)
-
-    assert result is False
-    assert dest.read_bytes() == original_bytes
-    assert _temp_litter(dest) == []
-
-
-def test_validation_receives_real_extension(unpacked_dir, temp_dir, monkeypatch):
-    """The temp file is named .tmp, so the real suffix must be passed to soffice explicitly.
-
-    Otherwise validate_document() picks its export filter from ".tmp" and falls to
-    the default (Writer) filter — wrong for .pptx/.xlsx.
-    """
-    dest = temp_dir / "out.docx"
-    seen = {}
-
-    def spy_validate(path, suffix=None):
-        seen["suffix"] = suffix
-        return True
-
-    monkeypatch.setattr(pack, "validate_document", spy_validate)
-
-    assert pack_document(unpacked_dir, dest, validate=True) is True
-    assert seen["suffix"] == ".docx"
-
-
-def test_success_is_single_replace_promotion(unpacked_dir, temp_dir, monkeypatch):
-    """A successful pack promotes one temp file — in the destination's own dir — via os.replace."""
-    dest = temp_dir / "out.docx"
-    resolved = Path(os.path.realpath(dest))
-
-    real_replace = pack.os.replace
-    calls: list[tuple[Path, Path]] = []
-
-    def spy_replace(src, dst):
-        calls.append((Path(src), Path(dst)))
-        return real_replace(src, dst)
-
-    monkeypatch.setattr(pack.os, "replace", spy_replace)
-
-    result = pack_document(unpacked_dir, dest)
-
-    assert result is True
-    with zipfile.ZipFile(dest) as zf:
-        assert zf.testzip() is None
-    assert len(calls) == 1
-    src, dst = calls[0]
-    assert src.parent == resolved.parent  # same volume ⇒ atomic replace
-    assert dst == resolved
-    assert _temp_litter(dest) == []
-
-
-def test_existing_destination_keeps_its_permissions(unpacked_dir, simple_docx, temp_dir):
-    """os.replace swaps the inode — the destination's mode must survive the save.
-
-    Without this, mkstemp's 0600 would silently strip group/world access from every
-    saved document.
-    """
-    dest = temp_dir / "shared.docx"
-    shutil.copy(simple_docx, dest)
-    dest.chmod(0o664)
-
-    pack_document(unpacked_dir, dest)
-
-    assert stat.S_IMODE(dest.stat().st_mode) == 0o664
-
-
-def test_new_destination_respects_umask(unpacked_dir, temp_dir):
-    """A brand-new file gets the mode a plain open() would have produced, not 0600."""
-    dest = temp_dir / "fresh.docx"
-    old_umask = os.umask(0o022)
-    try:
+        A legal non-ASCII name near the limit must not overflow the temp name — 80
+        Chinese characters is only 80 chars but 240 bytes.
+        """
+        dest = temp_dir / ("报" * 80 + ".docx")  # 245 bytes, 85 characters
         pack_document(unpacked_dir, dest)
-    finally:
-        os.umask(old_umask)
 
-    assert stat.S_IMODE(dest.stat().st_mode) == 0o644
-
-
-def test_symlinked_destination_is_followed(unpacked_dir, simple_docx, temp_dir):
-    """Saving to a symlink must update the file it points at, not replace the link."""
-    real = temp_dir / "real.docx"
-    shutil.copy(simple_docx, real)
-    original_bytes = real.read_bytes()
-    link = temp_dir / "link.docx"
-    link.symlink_to(real)
-
-    pack_document(unpacked_dir, link)
-
-    assert link.is_symlink(), "the symlink itself was replaced"
-    assert real.read_bytes() != original_bytes, "the real document was never updated"
-    with zipfile.ZipFile(real) as zf:
-        assert zf.testzip() is None
-    assert _temp_litter(real) == []
+        with zipfile.ZipFile(dest) as zf:
+            assert zf.testzip() is None
 
 
-def test_long_destination_filename(unpacked_dir, temp_dir):
-    """A near-max-length filename must still save (the temp name is derived from it)."""
-    dest = temp_dir / ("a" * 245 + ".docx")  # 250 chars, legal on ext4/APFS
-    pack_document(unpacked_dir, dest)
+class TestAtomicInodeState:
+    """os.replace swaps the inode — what rides on it must be carried over."""
 
-    with zipfile.ZipFile(dest) as zf:
-        assert zf.testzip() is None
+    def test_existing_destination_keeps_its_permissions(self, unpacked_dir, simple_docx, temp_dir):
+        """Without this, mkstemp's 0600 silently strips group/world access on every save."""
+        dest = temp_dir / "shared.docx"
+        shutil.copy(simple_docx, dest)
+        dest.chmod(0o664)
+
+        pack_document(unpacked_dir, dest)
+
+        assert stat.S_IMODE(dest.stat().st_mode) == 0o664
+
+    def test_read_only_destination_is_saved_and_keeps_its_mode(self, unpacked_dir, simple_docx, temp_dir):
+        """A 0444 destination must still save: the fsync must happen before the chmod.
+
+        Chmod-ing the temp file to 0444 first makes reopening it to fsync fail.
+        """
+        dest = temp_dir / "readonly.docx"
+        shutil.copy(simple_docx, dest)
+        original_bytes = dest.read_bytes()
+        dest.chmod(0o444)
+
+        pack_document(unpacked_dir, dest)
+
+        assert stat.S_IMODE(dest.stat().st_mode) == 0o444
+        assert dest.read_bytes() != original_bytes  # it really was written
+
+    def test_new_destination_respects_umask(self, unpacked_dir, temp_dir):
+        """A brand-new file gets the mode a plain open() would have produced, not 0600."""
+        dest = temp_dir / "fresh.docx"
+        old_umask = os.umask(0o022)
+        try:
+            pack_document(unpacked_dir, dest)
+        finally:
+            os.umask(old_umask)
+
+        assert stat.S_IMODE(dest.stat().st_mode) == 0o644
+
+    def test_symlinked_destination_is_followed(self, unpacked_dir, simple_docx, temp_dir):
+        """Saving to a symlink must update the file it points at, not replace the link."""
+        real = temp_dir / "real.docx"
+        shutil.copy(simple_docx, real)
+        original_bytes = real.read_bytes()
+        link = temp_dir / "link.docx"
+        link.symlink_to(real)
+
+        pack_document(unpacked_dir, link)
+
+        assert link.is_symlink(), "the symlink itself was replaced"
+        assert real.read_bytes() != original_bytes, "the real document was never updated"
+        with zipfile.ZipFile(real) as zf:
+            assert zf.testzip() is None
+        assert _temp_litter(real) == []

--- a/tests/test_atomic_save.py
+++ b/tests/test_atomic_save.py
@@ -201,6 +201,23 @@ class TestAtomicInodeState:
         assert dest.read_bytes() == original_bytes
         assert _temp_litter(dest) == []
 
+    def test_read_only_destination_is_refused_even_when_validation_fails(
+        self, unpacked_dir, simple_docx, temp_dir, monkeypatch
+    ):
+        """The refusal must not be swallowed by a validate=True run returning False first.
+
+        The pre-atomic code failed the moment it opened the destination for writing,
+        before validation could have any say.
+        """
+        dest = temp_dir / "readonly.docx"
+        shutil.copy(simple_docx, dest)
+        dest.chmod(0o444)
+
+        monkeypatch.setattr(pack, "validate_document", lambda p, **kw: False)
+
+        with pytest.raises(PermissionError):
+            pack_document(unpacked_dir, dest, validate=True)
+
     def test_new_destination_respects_umask(self, unpacked_dir, temp_dir):
         """A brand-new file gets the mode a plain open() would have produced, not 0600."""
         dest = temp_dir / "fresh.docx"
@@ -213,23 +230,23 @@ class TestAtomicInodeState:
         assert stat.S_IMODE(dest.stat().st_mode) == 0o644
 
     @pytest.mark.skipif(shutil.which("setfacl") is None, reason="setfacl not available")
-    def test_saves_into_a_directory_with_a_restrictive_default_acl(self, unpacked_dir, simple_docx, temp_dir):
+    def test_saves_into_a_directory_with_a_restrictive_default_acl(self, unpacked_dir, temp_dir):
         """A default ACL can leave a newly created file not writable by its owner.
 
         Reopening the temp file by name to write or fsync it would then fail, breaking
         a save that worked before this feature existed. Writing through the fd it was
-        created with (opened O_RDWR before the mode applied) is what keeps this working.
+        created with (opened O_RDWR, before the mode applied) is what keeps this working.
+
+        The destination must be *fresh*: for an existing one the temp file takes the
+        destination's mode up front, which would mask the bug.
         """
         acl_dir = temp_dir / "acl"
         acl_dir.mkdir()
         subprocess.run(["setfacl", "-d", "-m", "u::r--", str(acl_dir)], check=True)
-        dest = acl_dir / "doc.docx"
-        shutil.copy(simple_docx, dest)
-        original_bytes = dest.read_bytes()
+        dest = acl_dir / "fresh.docx"
 
         pack_document(unpacked_dir, dest)
 
-        assert dest.read_bytes() != original_bytes
         with zipfile.ZipFile(dest) as zf:
             assert zf.testzip() is None
 

--- a/tests/test_atomic_save.py
+++ b/tests/test_atomic_save.py
@@ -23,6 +23,7 @@ from pathlib import Path
 
 import pytest
 
+from docx_editor import Document
 from docx_editor.ooxml import pack, unpack_document
 from docx_editor.ooxml.pack import pack_document
 
@@ -182,20 +183,23 @@ class TestAtomicInodeState:
 
         assert stat.S_IMODE(dest.stat().st_mode) == 0o664
 
-    def test_read_only_destination_is_saved_and_keeps_its_mode(self, unpacked_dir, simple_docx, temp_dir):
-        """A 0444 destination must still save: the fsync must happen before the chmod.
+    def test_read_only_destination_is_refused(self, unpacked_dir, simple_docx, temp_dir):
+        """A write-protected document must not be silently overwritten.
 
-        Chmod-ing the temp file to 0444 first makes reopening it to fsync fail.
+        rename(2) only needs write permission on the *directory*, so an atomic promotion
+        would happily replace a 0444 file — something the pre-atomic in-place write
+        could never do, and that Windows still refuses.
         """
         dest = temp_dir / "readonly.docx"
         shutil.copy(simple_docx, dest)
         original_bytes = dest.read_bytes()
         dest.chmod(0o444)
 
-        pack_document(unpacked_dir, dest)
+        with pytest.raises(PermissionError):
+            pack_document(unpacked_dir, dest)
 
-        assert stat.S_IMODE(dest.stat().st_mode) == 0o444
-        assert dest.read_bytes() != original_bytes  # it really was written
+        assert dest.read_bytes() == original_bytes
+        assert _temp_litter(dest) == []
 
     def test_new_destination_respects_umask(self, unpacked_dir, temp_dir):
         """A brand-new file gets the mode a plain open() would have produced, not 0600."""
@@ -210,10 +214,11 @@ class TestAtomicInodeState:
 
     @pytest.mark.skipif(shutil.which("setfacl") is None, reason="setfacl not available")
     def test_saves_into_a_directory_with_a_restrictive_default_acl(self, unpacked_dir, simple_docx, temp_dir):
-        """A default ACL can mask a newly created file down to 0400.
+        """A default ACL can leave a newly created file not writable by its owner.
 
         Reopening the temp file by name to write or fsync it would then fail, breaking
-        a save that worked before this feature existed.
+        a save that worked before this feature existed. Writing through the fd it was
+        created with (opened O_RDWR before the mode applied) is what keeps this working.
         """
         acl_dir = temp_dir / "acl"
         acl_dir.mkdir()
@@ -243,3 +248,19 @@ class TestAtomicInodeState:
         with zipfile.ZipFile(real) as zf:
             assert zf.testzip() is None
         assert _temp_litter(real) == []
+
+    def test_saving_through_a_symlink_keeps_the_workspace_in_sync(self, clean_workspace, temp_dir):
+        """Saving via another name for the source still writes the source.
+
+        So the workspace's recorded mtime has to be refreshed, or the next open() sees a
+        workspace that looks stale and refuses.
+        """
+        link = temp_dir / "alias.docx"
+        link.symlink_to(clean_workspace)
+
+        doc = Document.open(clean_workspace)
+        doc.save(link)  # a different spelling of the same file
+        doc.close()
+
+        reopened = Document.open(clean_workspace)  # must not raise WorkspaceSyncError
+        reopened.close()

--- a/tests/test_atomic_save.py
+++ b/tests/test_atomic_save.py
@@ -8,9 +8,15 @@ directory and promote it with a single ``os.replace``. This guards two propertie
     ran ``output_file.unlink()`` on the *original* during a save-in-place.
   * A successful pack is a single rename, so the destination is never observed
     half-written — critical inside cloud-synced folders (OneDrive/Dropbox/...).
+
+Because ``os.replace`` swaps in the temp file's *inode*, anything riding on the
+destination's inode must be carried over: these tests also pin the destination's
+permissions and the handling of a symlinked destination.
 """
 
+import os
 import shutil
+import stat
 import zipfile
 from pathlib import Path
 
@@ -34,12 +40,23 @@ def _temp_litter(dest: Path) -> list[Path]:
 
 
 def test_failure_mid_pack_preserves_original(unpacked_dir, simple_docx, temp_dir, monkeypatch):
-    """A write error mid-pack leaves the existing destination byte-for-byte intact."""
+    """A write error mid-archive leaves the existing destination byte-for-byte intact."""
     dest = temp_dir / "original.docx"
     shutil.copy(simple_docx, dest)
     original_bytes = dest.read_bytes()
 
-    def boom(*args, **kwargs):
+    # Fail on the *second* member so the archive is genuinely half-written, and
+    # record that a temp file existed at that moment — proving the failure happened
+    # after promotion started, not before the temp file was ever created (which
+    # would make this test pass vacuously).
+    state = {"calls": 0, "temp_existed_mid_write": False}
+    real_copyfileobj = shutil.copyfileobj
+
+    def boom(src, dst, *args, **kwargs):
+        state["calls"] += 1
+        if state["calls"] < 2:
+            return real_copyfileobj(src, dst, *args, **kwargs)
+        state["temp_existed_mid_write"] = bool(_temp_litter(dest))
         raise OSError("simulated write failure")
 
     monkeypatch.setattr(pack.shutil, "copyfileobj", boom)
@@ -47,6 +64,7 @@ def test_failure_mid_pack_preserves_original(unpacked_dir, simple_docx, temp_dir
     with pytest.raises(OSError):
         pack_document(unpacked_dir, dest)
 
+    assert state["temp_existed_mid_write"], "failure did not occur mid-archive"
     assert dest.read_bytes() == original_bytes
     assert _temp_litter(dest) == []
 
@@ -57,7 +75,7 @@ def test_validation_failure_preserves_original(unpacked_dir, simple_docx, temp_d
     shutil.copy(simple_docx, dest)
     original_bytes = dest.read_bytes()
 
-    monkeypatch.setattr(pack, "validate_document", lambda p: False)
+    monkeypatch.setattr(pack, "validate_document", lambda p, **kw: False)
 
     result = pack_document(unpacked_dir, dest, validate=True)
 
@@ -66,9 +84,29 @@ def test_validation_failure_preserves_original(unpacked_dir, simple_docx, temp_d
     assert _temp_litter(dest) == []
 
 
+def test_validation_receives_real_extension(unpacked_dir, temp_dir, monkeypatch):
+    """The temp file is named .tmp, so the real suffix must be passed to soffice explicitly.
+
+    Otherwise validate_document() picks its export filter from ".tmp" and falls to
+    the default (Writer) filter — wrong for .pptx/.xlsx.
+    """
+    dest = temp_dir / "out.docx"
+    seen = {}
+
+    def spy_validate(path, suffix=None):
+        seen["suffix"] = suffix
+        return True
+
+    monkeypatch.setattr(pack, "validate_document", spy_validate)
+
+    assert pack_document(unpacked_dir, dest, validate=True) is True
+    assert seen["suffix"] == ".docx"
+
+
 def test_success_is_single_replace_promotion(unpacked_dir, temp_dir, monkeypatch):
     """A successful pack promotes one temp file — in the destination's own dir — via os.replace."""
     dest = temp_dir / "out.docx"
+    resolved = Path(os.path.realpath(dest))
 
     real_replace = pack.os.replace
     calls: list[tuple[Path, Path]] = []
@@ -86,6 +124,59 @@ def test_success_is_single_replace_promotion(unpacked_dir, temp_dir, monkeypatch
         assert zf.testzip() is None
     assert len(calls) == 1
     src, dst = calls[0]
-    assert src.parent == dest.parent  # same volume ⇒ atomic replace
-    assert dst == dest
+    assert src.parent == resolved.parent  # same volume ⇒ atomic replace
+    assert dst == resolved
     assert _temp_litter(dest) == []
+
+
+def test_existing_destination_keeps_its_permissions(unpacked_dir, simple_docx, temp_dir):
+    """os.replace swaps the inode — the destination's mode must survive the save.
+
+    Without this, mkstemp's 0600 would silently strip group/world access from every
+    saved document.
+    """
+    dest = temp_dir / "shared.docx"
+    shutil.copy(simple_docx, dest)
+    dest.chmod(0o664)
+
+    pack_document(unpacked_dir, dest)
+
+    assert stat.S_IMODE(dest.stat().st_mode) == 0o664
+
+
+def test_new_destination_respects_umask(unpacked_dir, temp_dir):
+    """A brand-new file gets the mode a plain open() would have produced, not 0600."""
+    dest = temp_dir / "fresh.docx"
+    old_umask = os.umask(0o022)
+    try:
+        pack_document(unpacked_dir, dest)
+    finally:
+        os.umask(old_umask)
+
+    assert stat.S_IMODE(dest.stat().st_mode) == 0o644
+
+
+def test_symlinked_destination_is_followed(unpacked_dir, simple_docx, temp_dir):
+    """Saving to a symlink must update the file it points at, not replace the link."""
+    real = temp_dir / "real.docx"
+    shutil.copy(simple_docx, real)
+    original_bytes = real.read_bytes()
+    link = temp_dir / "link.docx"
+    link.symlink_to(real)
+
+    pack_document(unpacked_dir, link)
+
+    assert link.is_symlink(), "the symlink itself was replaced"
+    assert real.read_bytes() != original_bytes, "the real document was never updated"
+    with zipfile.ZipFile(real) as zf:
+        assert zf.testzip() is None
+    assert _temp_litter(real) == []
+
+
+def test_long_destination_filename(unpacked_dir, temp_dir):
+    """A near-max-length filename must still save (the temp name is derived from it)."""
+    dest = temp_dir / ("a" * 245 + ".docx")  # 250 chars, legal on ext4/APFS
+    pack_document(unpacked_dir, dest)
+
+    with zipfile.ZipFile(dest) as zf:
+        assert zf.testzip() is None

--- a/tests/test_atomic_save.py
+++ b/tests/test_atomic_save.py
@@ -17,6 +17,7 @@ destination's permissions and the handling of a symlinked destination.
 import os
 import shutil
 import stat
+import subprocess
 import zipfile
 from pathlib import Path
 
@@ -155,6 +156,18 @@ class TestAtomicPromotion:
         with zipfile.ZipFile(dest) as zf:
             assert zf.testzip() is None
 
+    def test_undecodable_destination_filename(self, unpacked_dir, temp_dir):
+        """Linux filenames are bytes; an undecodable one arrives as surrogates.
+
+        Deriving the temp name with str.encode() (strict UTF-8) would reject those and
+        make the document unsaveable.
+        """
+        dest = temp_dir / os.fsdecode(b"caf\xe9.docx")
+        pack_document(unpacked_dir, dest)
+
+        with zipfile.ZipFile(dest) as zf:
+            assert zf.testzip() is None
+
 
 class TestAtomicInodeState:
     """os.replace swaps the inode — what rides on it must be carried over."""
@@ -194,6 +207,26 @@ class TestAtomicInodeState:
             os.umask(old_umask)
 
         assert stat.S_IMODE(dest.stat().st_mode) == 0o644
+
+    @pytest.mark.skipif(shutil.which("setfacl") is None, reason="setfacl not available")
+    def test_saves_into_a_directory_with_a_restrictive_default_acl(self, unpacked_dir, simple_docx, temp_dir):
+        """A default ACL can mask a newly created file down to 0400.
+
+        Reopening the temp file by name to write or fsync it would then fail, breaking
+        a save that worked before this feature existed.
+        """
+        acl_dir = temp_dir / "acl"
+        acl_dir.mkdir()
+        subprocess.run(["setfacl", "-d", "-m", "u::r--", str(acl_dir)], check=True)
+        dest = acl_dir / "doc.docx"
+        shutil.copy(simple_docx, dest)
+        original_bytes = dest.read_bytes()
+
+        pack_document(unpacked_dir, dest)
+
+        assert dest.read_bytes() != original_bytes
+        with zipfile.ZipFile(dest) as zf:
+            assert zf.testzip() is None
 
     def test_symlinked_destination_is_followed(self, unpacked_dir, simple_docx, temp_dir):
         """Saving to a symlink must update the file it points at, not replace the link."""

--- a/tests/test_open_document_guard.py
+++ b/tests/test_open_document_guard.py
@@ -2,9 +2,12 @@
 
 Word writes a ``~$`` owner (lock) file next to any document it has open. Saving
 over that live file races Word's own writes and can corrupt the document, so
-``Document.save()`` / ``Workspace.save()`` refuse unless ``force=True``. A
-PermissionError from the OS (Word holding the file on Windows) maps to the same
-``DocumentOpenError``.
+``Document.save()`` / ``Workspace.save()`` refuse unless ``force=True``.
+
+A PermissionError from the final replace (Word holding the file on Windows) maps
+to the same ``DocumentOpenError`` — but *only* that step. A PermissionError from
+anywhere earlier is a genuine filesystem error and must not be mislabeled as
+"the document is open".
 """
 
 import pytest
@@ -23,6 +26,12 @@ def test_owner_file_candidates_forms(tmp_path):
     assert all(c.parent == tmp_path for c in candidates)
 
 
+def test_owner_file_candidates_short_stem(tmp_path):
+    """A short stem keeps the full name and yields no junk candidate like '~$.docx'."""
+    candidates = owner_file_candidates(tmp_path / "ab.docx")
+    assert [c.name for c in candidates] == ["~$ab.docx"]
+
+
 @pytest.mark.parametrize("stub_index", [0, 1])
 def test_guard_blocks_when_document_open(clean_workspace, stub_index):
     """A ~$ owner file next to the destination makes save() raise, leaving it untouched."""
@@ -34,9 +43,11 @@ def test_guard_blocks_when_document_open(clean_workspace, stub_index):
     ref = find_ref(doc, "fox")
     doc.replace("fox", "cat", paragraph=ref)
 
-    with pytest.raises(DocumentOpenError):
+    with pytest.raises(DocumentOpenError) as exc:
         doc.save()
 
+    assert exc.value.owner_file == stub
+    assert exc.value.path == clean_workspace
     assert clean_workspace.read_bytes() == original_bytes  # destination untouched
     doc.close()
 
@@ -81,8 +92,9 @@ def test_saving_to_fresh_path_ignores_source_stub(clean_workspace, temp_dir):
     doc.close()
 
 
-def test_permission_error_maps_to_document_open_error(clean_workspace, monkeypatch):
-    """A PermissionError during packing (Word holding the file) maps to DocumentOpenError."""
+def test_permission_error_on_replace_maps_to_document_open_error(clean_workspace, monkeypatch):
+    """A PermissionError from the final replace (Word holding the file) maps to DocumentOpenError."""
+    original_bytes = clean_workspace.read_bytes()
 
     def deny(*args, **kwargs):
         raise PermissionError("Word has the file open")
@@ -91,5 +103,29 @@ def test_permission_error_maps_to_document_open_error(clean_workspace, monkeypat
 
     doc = Document.open(clean_workspace)
     with pytest.raises(DocumentOpenError):
+        doc.save()
+
+    # The failed promotion must leave the destination and its directory clean.
+    assert clean_workspace.read_bytes() == original_bytes
+    assert list(clean_workspace.parent.glob(f".{clean_workspace.name}.*")) == []
+    doc.close()
+
+
+def test_permission_error_before_replace_is_not_mislabeled(clean_workspace, monkeypatch):
+    """A PermissionError from anywhere but the replace stays a PermissionError.
+
+    Creating the temp file needs *directory* write permission, which the pre-atomic
+    in-place write did not. Reporting that as "close the document in Word" would
+    send the caller down a dead end — SKILL.md tells agents to stop and blame Word
+    on DocumentOpenError.
+    """
+
+    def deny(*args, **kwargs):
+        raise PermissionError("cannot create temp file in read-only directory")
+
+    monkeypatch.setattr(pack.tempfile, "mkstemp", deny)
+
+    doc = Document.open(clean_workspace)
+    with pytest.raises(PermissionError):
         doc.save()
     doc.close()

--- a/tests/test_open_document_guard.py
+++ b/tests/test_open_document_guard.py
@@ -59,7 +59,7 @@ class TestOpenDocumentGuard:
         assert clean_workspace.read_bytes() == original_bytes  # destination untouched
         doc.close()
 
-    def test_guard_sees_stub_beside_a_symlinked_destination(self, clean_workspace, temp_dir):
+    def test_guard_sees_stub_beside_an_explicit_symlink_destination(self, clean_workspace, temp_dir):
         """Word writes its stub next to the name the user opened — the symlink.
 
         The save resolves the symlink to promote into the real file, so the guard has
@@ -74,6 +74,41 @@ class TestOpenDocumentGuard:
         doc = Document.open(clean_workspace)
         with pytest.raises(DocumentOpenError):
             doc.save(link)
+        doc.close()
+
+    def test_guard_sees_stub_when_the_opened_path_is_a_symlink(self, clean_workspace, temp_dir):
+        """The realistic case: the user *opens* the symlink Word has open, then saves in place.
+
+        Workspace resolves source_path, so the destination is already the real file by
+        save() time and the stub beside the symlink is invisible unless the originally
+        opened name is remembered.
+        """
+        link_dir = temp_dir / "links"
+        link_dir.mkdir()
+        link = link_dir / "link.docx"
+        link.symlink_to(clean_workspace)
+        (link_dir / "~$link.docx").write_bytes(b"")  # stub beside the symlink only
+        original_bytes = clean_workspace.read_bytes()
+
+        doc = Document.open(link)  # opened *through* the symlink
+        ref = find_ref(doc, "fox")
+        doc.replace("fox", "cat", paragraph=ref)
+
+        with pytest.raises(DocumentOpenError):
+            doc.save()
+
+        assert clean_workspace.read_bytes() == original_bytes
+        doc.close()
+
+    def test_stale_stub_does_not_block_a_new_destination(self, clean_workspace, temp_dir):
+        """A stub beside a name with no document behind it guards nothing."""
+        fresh = temp_dir / "brandnew.docx"
+        (temp_dir / "~$brandnew.docx").write_bytes(b"")  # stale stub, no such document
+
+        doc = Document.open(clean_workspace)
+        saved = doc.save(fresh)
+        assert saved == fresh
+        assert fresh.exists()
         doc.close()
 
     def test_force_overrides_guard(self, clean_workspace):
@@ -166,7 +201,7 @@ class TestPermissionErrorMapping:
         def deny(*args, **kwargs):
             raise PermissionError("cannot create temp file in read-only directory")
 
-        monkeypatch.setattr(pack.tempfile, "mkstemp", deny)
+        monkeypatch.setattr(pack, "_create_temp", deny)
 
         doc = Document.open(clean_workspace)
         with pytest.raises(PermissionError):

--- a/tests/test_open_document_guard.py
+++ b/tests/test_open_document_guard.py
@@ -1,0 +1,95 @@
+"""Tests for the open-document guard.
+
+Word writes a ``~$`` owner (lock) file next to any document it has open. Saving
+over that live file races Word's own writes and can corrupt the document, so
+``Document.save()`` / ``Workspace.save()`` refuse unless ``force=True``. A
+PermissionError from the OS (Word holding the file on Windows) maps to the same
+``DocumentOpenError``.
+"""
+
+import pytest
+from conftest import find_ref
+
+from docx_editor import Document, DocumentOpenError
+from docx_editor.ooxml import pack
+from docx_editor.workspace import owner_file_candidates
+
+
+def test_owner_file_candidates_forms(tmp_path):
+    """Both the full-name and two-char-truncated ~$ forms are produced."""
+    candidates = owner_file_candidates(tmp_path / "Report.docx")
+    names = {c.name for c in candidates}
+    assert names == {"~$Report.docx", "~$port.docx"}
+    assert all(c.parent == tmp_path for c in candidates)
+
+
+@pytest.mark.parametrize("stub_index", [0, 1])
+def test_guard_blocks_when_document_open(clean_workspace, stub_index):
+    """A ~$ owner file next to the destination makes save() raise, leaving it untouched."""
+    original_bytes = clean_workspace.read_bytes()
+    stub = owner_file_candidates(clean_workspace)[stub_index]
+    stub.write_bytes(b"")  # Word's owner file is opaque; presence is what matters.
+
+    doc = Document.open(clean_workspace)
+    ref = find_ref(doc, "fox")
+    doc.replace("fox", "cat", paragraph=ref)
+
+    with pytest.raises(DocumentOpenError):
+        doc.save()
+
+    assert clean_workspace.read_bytes() == original_bytes  # destination untouched
+    doc.close()
+
+
+def test_force_overrides_guard(clean_workspace):
+    """force=True saves through the guard and the edit survives a reopen."""
+    stub = owner_file_candidates(clean_workspace)[0]
+    stub.write_bytes(b"")
+
+    doc = Document.open(clean_workspace)
+    ref = find_ref(doc, "fox")
+    doc.replace("fox", "cat", paragraph=ref)
+    doc.save(force=True)
+    doc.close()
+
+    reopened = Document.open(clean_workspace)
+    text = reopened.get_visible_text()
+    assert "cat" in text
+    assert "fox" not in text
+    reopened.close()
+
+
+def test_unrelated_owner_file_does_not_block(clean_workspace):
+    """A ~$ stub for a *different* document in the same folder is not a false positive."""
+    (clean_workspace.parent / "~$unrelated.docx").write_bytes(b"")
+
+    doc = Document.open(clean_workspace)
+    saved = doc.save()
+    assert saved == clean_workspace
+    doc.close()
+
+
+def test_saving_to_fresh_path_ignores_source_stub(clean_workspace, temp_dir):
+    """A stub on the open source must not block saving a copy to a fresh destination."""
+    owner_file_candidates(clean_workspace)[0].write_bytes(b"")  # source is "open"
+    fresh = temp_dir / "copy.docx"
+
+    doc = Document.open(clean_workspace)
+    saved = doc.save(fresh)
+    assert saved == fresh
+    assert fresh.exists()
+    doc.close()
+
+
+def test_permission_error_maps_to_document_open_error(clean_workspace, monkeypatch):
+    """A PermissionError during packing (Word holding the file) maps to DocumentOpenError."""
+
+    def deny(*args, **kwargs):
+        raise PermissionError("Word has the file open")
+
+    monkeypatch.setattr(pack.os, "replace", deny)
+
+    doc = Document.open(clean_workspace)
+    with pytest.raises(DocumentOpenError):
+        doc.save()
+    doc.close()

--- a/tests/test_open_document_guard.py
+++ b/tests/test_open_document_guard.py
@@ -171,6 +171,27 @@ class TestPermissionErrorMapping:
         assert list(clean_workspace.parent.glob(f".{clean_workspace.name}.*")) == []
         doc.close()
 
+    def test_replace_denial_on_a_fresh_destination_is_not_an_open_document(
+        self, clean_workspace, temp_dir, monkeypatch
+    ):
+        """A destination that does not exist yet cannot be open in Word.
+
+        Reporting a read-only-directory failure as DocumentOpenError would tell the
+        agent to go ask the user to close a document nobody has open.
+        """
+        monkeypatch.setattr(pack.sys, "platform", "win32")
+
+        def deny(*args, **kwargs):
+            raise PermissionError("directory is read-only")
+
+        monkeypatch.setattr(pack.os, "replace", deny)
+
+        doc = Document.open(clean_workspace)
+        with pytest.raises(PermissionError) as exc:
+            doc.save(temp_dir / "brandnew.docx")
+        assert not isinstance(exc.value, DocumentOpenError)
+        doc.close()
+
     def test_replace_denial_stays_permission_error_on_posix(self, clean_workspace, monkeypatch):
         """On POSIX a denied rename never means "open document" — don't mislabel it.
 

--- a/tests/test_open_document_guard.py
+++ b/tests/test_open_document_guard.py
@@ -4,11 +4,14 @@ Word writes a ``~$`` owner (lock) file next to any document it has open. Saving
 over that live file races Word's own writes and can corrupt the document, so
 ``Document.save()`` / ``Workspace.save()`` refuse unless ``force=True``.
 
-A PermissionError from the final replace (Word holding the file on Windows) maps
-to the same ``DocumentOpenError`` — but *only* that step. A PermissionError from
-anywhere earlier is a genuine filesystem error and must not be mislabeled as
-"the document is open".
+A PermissionError from the final replace maps to the same ``DocumentOpenError``,
+but only on Windows — that is the one platform where a locked destination surfaces
+that way. On POSIX, rename(2) over an open file always succeeds, so a denial there
+means something else entirely and must not be reported as "the document is open".
 """
+
+import os
+from pathlib import Path
 
 import pytest
 from conftest import find_ref
@@ -18,114 +21,154 @@ from docx_editor.ooxml import pack
 from docx_editor.workspace import owner_file_candidates
 
 
-def test_owner_file_candidates_forms(tmp_path):
-    """Both the full-name and two-char-truncated ~$ forms are produced."""
-    candidates = owner_file_candidates(tmp_path / "Report.docx")
-    names = {c.name for c in candidates}
-    assert names == {"~$Report.docx", "~$port.docx"}
-    assert all(c.parent == tmp_path for c in candidates)
+class TestOwnerFileCandidates:
+    """The ~$ names Word may have written for a given document."""
+
+    def test_both_forms_for_a_normal_name(self, tmp_path):
+        """Both the full-name and two-char-truncated ~$ forms are produced."""
+        candidates = owner_file_candidates(tmp_path / "Report.docx")
+        names = {c.name for c in candidates}
+        assert names == {"~$Report.docx", "~$port.docx"}
+        assert all(c.parent == tmp_path for c in candidates)
+
+    def test_short_stem_yields_no_junk_candidate(self, tmp_path):
+        """A short stem keeps the full name and produces no junk like '~$.docx'."""
+        candidates = owner_file_candidates(tmp_path / "ab.docx")
+        assert [c.name for c in candidates] == ["~$ab.docx"]
 
 
-def test_owner_file_candidates_short_stem(tmp_path):
-    """A short stem keeps the full name and yields no junk candidate like '~$.docx'."""
-    candidates = owner_file_candidates(tmp_path / "ab.docx")
-    assert [c.name for c in candidates] == ["~$ab.docx"]
+class TestOpenDocumentGuard:
+    """save() refuses to overwrite a document that looks open in Word."""
+
+    @pytest.mark.parametrize("stub_index", [0, 1])
+    def test_guard_blocks_when_document_open(self, clean_workspace, stub_index):
+        """A ~$ owner file next to the destination makes save() raise, leaving it untouched."""
+        original_bytes = clean_workspace.read_bytes()
+        stub = owner_file_candidates(clean_workspace)[stub_index]
+        stub.write_bytes(b"")  # Word's owner file is opaque; presence is what matters.
+
+        doc = Document.open(clean_workspace)
+        ref = find_ref(doc, "fox")
+        doc.replace("fox", "cat", paragraph=ref)
+
+        with pytest.raises(DocumentOpenError) as exc:
+            doc.save()
+
+        assert exc.value.owner_file == stub
+        assert exc.value.path == Path(os.path.realpath(clean_workspace))
+        assert clean_workspace.read_bytes() == original_bytes  # destination untouched
+        doc.close()
+
+    def test_guard_sees_stub_beside_a_symlinked_destination(self, clean_workspace, temp_dir):
+        """Word writes its stub next to the name the user opened — the symlink.
+
+        The save resolves the symlink to promote into the real file, so the guard has
+        to check beside *both* names or it misses a genuinely open document.
+        """
+        link_dir = temp_dir / "links"
+        link_dir.mkdir()
+        link = link_dir / "link.docx"
+        link.symlink_to(clean_workspace)
+        (link_dir / "~$link.docx").write_bytes(b"")  # stub beside the symlink only
+
+        doc = Document.open(clean_workspace)
+        with pytest.raises(DocumentOpenError):
+            doc.save(link)
+        doc.close()
+
+    def test_force_overrides_guard(self, clean_workspace):
+        """force=True saves through the guard and the edit survives a reopen."""
+        stub = owner_file_candidates(clean_workspace)[0]
+        stub.write_bytes(b"")
+
+        doc = Document.open(clean_workspace)
+        ref = find_ref(doc, "fox")
+        doc.replace("fox", "cat", paragraph=ref)
+        doc.save(force=True)
+        doc.close()
+
+        reopened = Document.open(clean_workspace)
+        text = reopened.get_visible_text()
+        assert "cat" in text
+        assert "fox" not in text
+        reopened.close()
+
+    def test_unrelated_owner_file_does_not_block(self, clean_workspace):
+        """A ~$ stub for a *different* document in the same folder is not a false positive."""
+        (clean_workspace.parent / "~$unrelated.docx").write_bytes(b"")
+
+        doc = Document.open(clean_workspace)
+        saved = doc.save()
+        assert saved == clean_workspace
+        doc.close()
+
+    def test_saving_to_fresh_path_ignores_source_stub(self, clean_workspace, temp_dir):
+        """A stub on the open source must not block saving a copy to a fresh destination."""
+        owner_file_candidates(clean_workspace)[0].write_bytes(b"")  # source is "open"
+        fresh = temp_dir / "copy.docx"
+
+        doc = Document.open(clean_workspace)
+        saved = doc.save(fresh)
+        assert saved == fresh
+        assert fresh.exists()
+        doc.close()
 
 
-@pytest.mark.parametrize("stub_index", [0, 1])
-def test_guard_blocks_when_document_open(clean_workspace, stub_index):
-    """A ~$ owner file next to the destination makes save() raise, leaving it untouched."""
-    original_bytes = clean_workspace.read_bytes()
-    stub = owner_file_candidates(clean_workspace)[stub_index]
-    stub.write_bytes(b"")  # Word's owner file is opaque; presence is what matters.
+class TestPermissionErrorMapping:
+    """Only a denied *replace*, and only on Windows, means "the document is open"."""
 
-    doc = Document.open(clean_workspace)
-    ref = find_ref(doc, "fox")
-    doc.replace("fox", "cat", paragraph=ref)
+    def test_replace_denial_maps_to_document_open_error_on_windows(self, clean_workspace, monkeypatch):
+        """On Windows, Word holding the destination surfaces as a PermissionError here."""
+        original_bytes = clean_workspace.read_bytes()
+        monkeypatch.setattr(pack.sys, "platform", "win32")
 
-    with pytest.raises(DocumentOpenError) as exc:
-        doc.save()
+        def deny(*args, **kwargs):
+            raise PermissionError("Word has the file open")
 
-    assert exc.value.owner_file == stub
-    assert exc.value.path == clean_workspace
-    assert clean_workspace.read_bytes() == original_bytes  # destination untouched
-    doc.close()
+        monkeypatch.setattr(pack.os, "replace", deny)
 
+        doc = Document.open(clean_workspace)
+        with pytest.raises(DocumentOpenError):
+            doc.save()
 
-def test_force_overrides_guard(clean_workspace):
-    """force=True saves through the guard and the edit survives a reopen."""
-    stub = owner_file_candidates(clean_workspace)[0]
-    stub.write_bytes(b"")
+        # The failed promotion must leave the destination and its directory clean.
+        assert clean_workspace.read_bytes() == original_bytes
+        assert list(clean_workspace.parent.glob(f".{clean_workspace.name}.*")) == []
+        doc.close()
 
-    doc = Document.open(clean_workspace)
-    ref = find_ref(doc, "fox")
-    doc.replace("fox", "cat", paragraph=ref)
-    doc.save(force=True)
-    doc.close()
+    def test_replace_denial_stays_permission_error_on_posix(self, clean_workspace, monkeypatch):
+        """On POSIX a denied rename never means "open document" — don't mislabel it.
 
-    reopened = Document.open(clean_workspace)
-    text = reopened.get_visible_text()
-    assert "cat" in text
-    assert "fox" not in text
-    reopened.close()
+        rename(2) over a file another process holds open always succeeds, so a denial
+        means a sticky-bit directory, an immutable file, or an SELinux denial.
+        """
+        monkeypatch.setattr(pack.sys, "platform", "linux")
 
+        def deny(*args, **kwargs):
+            raise PermissionError("sticky-bit directory")
 
-def test_unrelated_owner_file_does_not_block(clean_workspace):
-    """A ~$ stub for a *different* document in the same folder is not a false positive."""
-    (clean_workspace.parent / "~$unrelated.docx").write_bytes(b"")
+        monkeypatch.setattr(pack.os, "replace", deny)
 
-    doc = Document.open(clean_workspace)
-    saved = doc.save()
-    assert saved == clean_workspace
-    doc.close()
+        doc = Document.open(clean_workspace)
+        with pytest.raises(PermissionError):
+            doc.save()
+        doc.close()
 
+    def test_permission_error_before_replace_is_not_mislabeled(self, clean_workspace, monkeypatch):
+        """A PermissionError from anywhere but the replace stays a PermissionError.
 
-def test_saving_to_fresh_path_ignores_source_stub(clean_workspace, temp_dir):
-    """A stub on the open source must not block saving a copy to a fresh destination."""
-    owner_file_candidates(clean_workspace)[0].write_bytes(b"")  # source is "open"
-    fresh = temp_dir / "copy.docx"
+        Creating the temp file needs *directory* write permission, which the pre-atomic
+        in-place write did not. Reporting that as "close the document in Word" would
+        send the caller down a dead end — SKILL.md tells agents to stop and blame Word
+        on DocumentOpenError.
+        """
 
-    doc = Document.open(clean_workspace)
-    saved = doc.save(fresh)
-    assert saved == fresh
-    assert fresh.exists()
-    doc.close()
+        def deny(*args, **kwargs):
+            raise PermissionError("cannot create temp file in read-only directory")
 
+        monkeypatch.setattr(pack.tempfile, "mkstemp", deny)
 
-def test_permission_error_on_replace_maps_to_document_open_error(clean_workspace, monkeypatch):
-    """A PermissionError from the final replace (Word holding the file) maps to DocumentOpenError."""
-    original_bytes = clean_workspace.read_bytes()
-
-    def deny(*args, **kwargs):
-        raise PermissionError("Word has the file open")
-
-    monkeypatch.setattr(pack.os, "replace", deny)
-
-    doc = Document.open(clean_workspace)
-    with pytest.raises(DocumentOpenError):
-        doc.save()
-
-    # The failed promotion must leave the destination and its directory clean.
-    assert clean_workspace.read_bytes() == original_bytes
-    assert list(clean_workspace.parent.glob(f".{clean_workspace.name}.*")) == []
-    doc.close()
-
-
-def test_permission_error_before_replace_is_not_mislabeled(clean_workspace, monkeypatch):
-    """A PermissionError from anywhere but the replace stays a PermissionError.
-
-    Creating the temp file needs *directory* write permission, which the pre-atomic
-    in-place write did not. Reporting that as "close the document in Word" would
-    send the caller down a dead end — SKILL.md tells agents to stop and blame Word
-    on DocumentOpenError.
-    """
-
-    def deny(*args, **kwargs):
-        raise PermissionError("cannot create temp file in read-only directory")
-
-    monkeypatch.setattr(pack.tempfile, "mkstemp", deny)
-
-    doc = Document.open(clean_workspace)
-    with pytest.raises(PermissionError):
-        doc.save()
-    doc.close()
+        doc = Document.open(clean_workspace)
+        with pytest.raises(PermissionError):
+            doc.save()
+        doc.close()


### PR DESCRIPTION
Makes `Document.save()` safe to use inside cloud-synced folders and while Word has the document open. Two independent changes, stdlib only, no new dependencies.

## 1. Fix the data-loss bug in `validate=True`

`pack_document()` wrote the ZIP directly onto the destination, then validated it — and on a failed validation ran `output_file.unlink()`. During a save-in-place, `output_file` *is* the original, so a failed validation destroyed the user's document.

Validation now runs against the temp file. A failure returns `False` and leaves the destination exactly as it was.

## 2. Atomic save

The archive is built in a temp file in the destination's own directory and promoted with a single `os.replace()`, flushed to disk. The destination is never observed half-written, so a sync client cannot upload a torn file, and any failure leaves the original intact.

Because `os.replace()` swaps the inode, state riding on it has to be carried over deliberately:

- The destination's **permissions** are preserved (without this, every save reset the file to `0600`, silently stripping group/world access from shared documents).
- A **symlinked destination is followed** to the file it points at, rather than being replaced — which would strand the real document while reporting success.
- A **write-protected document is refused** with `PermissionError` rather than silently overwritten. Rename only needs *directory* write permission, so the promotion would otherwise defeat the user's write protection — something the old in-place write could never do, and that Windows still refuses.

Not preserved (inherent to atomic saving): ownership, POSIX ACLs, xattrs, and hardlinks. Documented in the README.

The archive is written through the temp file's own descriptor rather than reopened by name, so a directory with a restrictive default POSIX ACL — which can leave a newly created file unwritable even by its owner — does not break a save that worked before.

Packed output is **byte-identical** to the previous implementation; the deterministic-ZIP contract (sorted names, 1980 timestamps, pinned metadata) is untouched.

## 3. Open-document guard

Word writes a `~$` owner file next to any document it has open. Saving over that live file races Word's own writes, so `save()` now raises the new `DocumentOpenError` instead, carrying `.path` and `.owner_file`.

- Guards the **destination only** — saving a copy to a fresh path while the source is open still works.
- Checks beside every name the destination is known by, including the possibly-symlinked name the caller originally opened. Word writes its stub beside the name *it* was told to open, which is not necessarily the file we are about to write.
- On Windows, a `PermissionError` from the final replace means the same thing and maps to `DocumentOpenError`. On POSIX it cannot — `rename(2)` over an open file always succeeds — so a denial there stays a `PermissionError` rather than being mislabeled "close the document".
- `force=True` skips the guard, for a confirmed-stale lock left by a crashed session.

**Known limitation:** the guard sees only *local* locks. Remote co-authoring (OneDrive/SharePoint, Word for the web) leaves no local stub and cannot be detected from the filesystem; rely on the cloud provider's version history there.

## Behavior changes worth calling out

- A read-only document is now refused instead of overwritten (restores pre-atomic behavior; aligns POSIX with Windows).
- Saving needs write permission on the **containing directory**, not just the document, because the temp file is created next to the destination. A directory-permission problem surfaces as a plain `PermissionError`, never as `DocumentOpenError`.

## Testing

647 passed, 6 skipped (28 new tests). `ruff check` and `ruff format` clean.

The new tests cover, among others: a failure mid-archive leaving the original byte-for-byte intact; a failed validation preserving the original; permission preservation and umask compliance; a read-only destination refused; a symlinked destination followed; the `~$` stub found beside an *opened* symlink; a directory with a restrictive default ACL; near-`NAME_MAX` and undecodable (non-UTF-8) filenames; and that a `PermissionError` raised anywhere but the final replace is not mislabeled as an open document.

Output bytes were verified identical to the pre-change implementation across every test fixture.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safe atomic saving for documents, helping prevent partial or corrupted files in synced folders.
  * Added detection of Word lock files to prevent overwriting documents currently open in Word.
  * Added `force=True` to override confirmed stale lock files.
  * Added a public `DocumentOpenError` for open-document save conflicts.

* **Documentation**
  * Documented atomic saves, permissions, lock detection, and remote co-authoring limitations.
  * Added guidance for handling open-document save errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->