### PR TITLE
fix: fall back to w:t when w:del lacks w:delText in revision parsing

### DIFF
--- a/docx_editor/track_changes.py
+++ b/docx_editor/track_changes.py
@@ -1645,7 +1645,9 @@ class RevisionManager:
         else:
             text_elems = elem.getElementsByTagName("w:delText")
             if not text_elems:
-                # Nonconforming producers may leave plain w:t inside w:del
+                # Deliberate interop fallback: nonconforming producers may
+                # leave plain w:t inside w:del. Fires only when the w:del has
+                # no w:delText at all; mixed content reads only w:delText.
                 text_elems = elem.getElementsByTagName("w:t")
 
         text_parts = [self._get_node_text(t_elem) for t_elem in text_elems]

--- a/docx_editor/track_changes.py
+++ b/docx_editor/track_changes.py
@@ -1644,6 +1644,9 @@ class RevisionManager:
             text_elems = elem.getElementsByTagName("w:t")
         else:
             text_elems = elem.getElementsByTagName("w:delText")
+            if not text_elems:
+                # Nonconforming producers may leave plain w:t inside w:del
+                text_elems = elem.getElementsByTagName("w:t")
 
         text_parts = [self._get_node_text(t_elem) for t_elem in text_elems]
 

--- a/tests/test_track_changes.py
+++ b/tests/test_track_changes.py
@@ -1647,6 +1647,59 @@ class TestRestoreDeletionAttributeCopying:
         assert not r_elems[0].hasAttribute("w:rsidDel")
 
 
+class TestParseRevisionDelTextFallback:
+    """Tests for w:delText -> w:t fallback when reading deletion text."""
+
+    def test_deletion_with_plain_wt_falls_back(self):
+        """Test that deletion text falls back to w:t when w:delText is absent."""
+        import defusedxml.minidom
+
+        # Nonconforming producers may leave plain w:t inside w:del
+        xml = """<?xml version="1.0"?>
+        <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+            <w:del w:id="1" w:author="Foreign">
+                <w:r>
+                    <w:t>lost text</w:t>
+                </w:r>
+            </w:del>
+        </w:document>"""
+
+        mock_editor = MagicMock()
+        mock_editor.dom = defusedxml.minidom.parseString(xml)
+
+        manager = RevisionManager(mock_editor)
+
+        revisions = manager.list_revisions()
+        assert len(revisions) == 1
+        assert revisions[0].type == "deletion"
+        assert revisions[0].text == "lost text"
+
+    def test_deletion_with_deltext_unchanged(self):
+        """Test that the fallback does not fire when w:delText exists."""
+        import defusedxml.minidom
+
+        xml = """<?xml version="1.0"?>
+        <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+            <w:del w:id="1" w:author="Test">
+                <w:r>
+                    <w:delText>proper</w:delText>
+                </w:r>
+                <w:r>
+                    <w:t>stray</w:t>
+                </w:r>
+            </w:del>
+        </w:document>"""
+
+        mock_editor = MagicMock()
+        mock_editor.dom = defusedxml.minidom.parseString(xml)
+
+        manager = RevisionManager(mock_editor)
+
+        revisions = manager.list_revisions()
+        assert len(revisions) == 1
+        assert revisions[0].text == "proper"
+
+
 def _split_wt_text_nodes(doc, target_text, tag="w:t"):
     """Reach into the DOM and split an element's TEXT_NODE into multiple siblings.
 


### PR DESCRIPTION
## Summary

Per the OOXML spec, deleted run content inside `w:del` uses `w:delText`, but nonconforming producers sometimes leave plain `w:t` there. Such deletions previously appeared in `list_revisions()` with `text=""`, hiding what was deleted.

`RevisionManager._parse_revision` now falls back to reading `w:t` elements when a `w:del` contains no `w:delText`. The fallback fires only on an empty `w:delText` node list, so conforming documents behave bit-identically. Mixed content (`w:delText` present alongside a stray `w:t`) still reads only `w:delText`.

Accept/reject behavior is unchanged, and this is consistent with `build_text_map()`, which already excludes `w:t` inside `w:del` from visible text.

## Testing

- New `TestParseRevisionDelTextFallback` tests: fallback path (`w:del` with only `w:t`) and conforming-path regression guard (`w:delText` + stray `w:t` reads only `w:delText`)
- Full suite: 621 passed, 6 skipped
- `ruff check` and `ruff format --check` clean