### PR TITLE
feat: add get_original_text() pre-revision document view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -213,3 +213,9 @@ __marimo__/
 
 .worktree/
 .worktrees/
+
+# Local agent tooling
+.agtx/
+.claude/commands/agtx/
+.claude/commands/openspec/
+.mcp.json

--- a/docs/api.md
+++ b/docs/api.md
@@ -139,6 +139,18 @@ Get flattened visible document text. Inserted text is included and deleted text 
 text = doc.get_visible_text()
 ```
 
+#### `get_original_text()`
+
+Get flattened original (pre-revision) document text. Deleted text is included and inserted text is excluded — the inverse of `get_visible_text()`. Equals what `get_visible_text()` would return after `reject_all()`, without modifying the document. Read-only: paragraph references and editing operations keep working on the visible view.
+
+**Returns:** Original text with paragraphs separated by newlines (str)
+
+**Example:**
+
+```python
+text = doc.get_original_text()
+```
+
 #### `find_text(text, occurrence=0)`
 
 Find text in the document, including text spanning XML element boundaries.

--- a/docs/api.md
+++ b/docs/api.md
@@ -141,7 +141,7 @@ text = doc.get_visible_text()
 
 #### `get_original_text()`
 
-Get flattened original (pre-revision) document text. Deleted text is included and inserted text is excluded — the inverse of `get_visible_text()`. Equals what `get_visible_text()` would return after `reject_all()`, without modifying the document. Read-only: paragraph references and editing operations keep working on the visible view.
+Get flattened original (pre-revision) document text. Deleted text is included and inserted text is excluded — the inverse of `get_visible_text()`. For intra-paragraph revisions this equals what `get_visible_text()` would return after `reject_all()`, without modifying the document (paragraph-level revisions such as inserted paragraph marks only affect line boundaries). Read-only: paragraph references and editing operations keep working on the visible view.
 
 **Returns:** Original text with paragraphs separated by newlines (str)
 

--- a/docx_editor/document.py
+++ b/docx_editor/document.py
@@ -418,6 +418,29 @@ class Document:
             parts.append(tm.text)
         return "\n".join(parts)
 
+    def get_original_text(self) -> str:
+        """Get the original (pre-revision) text of the document.
+
+        Returns flattened text with paragraphs separated by newlines.
+        Deleted text is included, inserted text is excluded — the inverse
+        of get_visible_text().
+
+        For intra-paragraph revisions this equals what get_visible_text()
+        would return after reject_all(), without modifying the document.
+        Read-only: paragraph references, hashes, and all editing operations
+        keep working on the accepted (visible) view.
+
+        Returns:
+            The original text content
+        """
+        self._ensure_open()
+        paragraphs = self._document_editor.dom.getElementsByTagName("w:p")
+        parts = []
+        for p in paragraphs:
+            tm = build_text_map(p, view="original")
+            parts.append(tm.text)
+        return "\n".join(parts)
+
     def replace(self, find: str, replace_with: str, *, paragraph: str, occurrence: int = 0) -> str:
         """Replace text with tracked changes.
 

--- a/docx_editor/xml_editor.py
+++ b/docx_editor/xml_editor.py
@@ -353,38 +353,69 @@ def get_text_node_data(elem) -> str:
     return "".join(c.data for c in elem.childNodes if c.nodeType == c.TEXT_NODE)
 
 
-def build_text_map(paragraph) -> TextMap:
+def build_text_map(paragraph, view: str = "accepted") -> TextMap:
     """Build a text map for a paragraph element.
 
-    Walks all <w:t> elements in the paragraph, concatenating visible text
-    (excluding <w:delText>) and recording the source node and offset for
-    each character position.
+    Two views are supported:
 
-    Text inside <w:ins> is included (it's visible) with is_inside_ins=True.
-    Text inside <w:del>/<w:delText> is excluded from visible text.
+    - ``"accepted"`` (default): the visible text — text inside <w:ins> is
+      included (with is_inside_ins=True), text inside <w:del>/<w:delText>
+      is excluded. Paragraph hashes and all editing operations use this view.
+    - ``"original"``: the pre-revision text — <w:ins> subtrees are excluded,
+      <w:delText> is included (with is_inside_del=True).
+
+    Records the source node and offset for each character position.
     """
+    if view not in ("accepted", "original"):
+        raise ValueError(f"Unknown view: {view!r} (expected 'accepted' or 'original')")
+
     text_chars: list[str] = []
     positions: list[TextPosition] = []
 
-    for node in paragraph.getElementsByTagName("w:t"):
-        # Skip w:t inside w:del (deleted text uses w:delText, but be safe)
-        if _is_inside_element(node, "w:del"):
-            continue
+    if view == "accepted":
+        for node in paragraph.getElementsByTagName("w:t"):
+            # Skip w:t inside w:del (deleted text uses w:delText, but be safe)
+            if _is_inside_element(node, "w:del"):
+                continue
 
-        inside_ins = _is_inside_element(node, "w:ins")
-        node_text = get_text_node_data(node)
+            inside_ins = _is_inside_element(node, "w:ins")
+            node_text = get_text_node_data(node)
 
-        for i, char in enumerate(node_text):
-            text_chars.append(char)
-            positions.append(
-                TextPosition(
-                    node=node,
-                    offset_in_node=i,
-                    is_inside_ins=inside_ins,
-                    is_inside_del=False,
+            for i, char in enumerate(node_text):
+                text_chars.append(char)
+                positions.append(
+                    TextPosition(
+                        node=node,
+                        offset_in_node=i,
+                        is_inside_ins=inside_ins,
+                        is_inside_del=False,
+                    )
                 )
-            )
 
+        return TextMap(text="".join(text_chars), positions=positions)
+
+    def _collect_original(node, inside_del: bool) -> None:
+        for child in node.childNodes:
+            if child.nodeType != child.ELEMENT_NODE:
+                continue
+            if child.tagName == "w:ins":
+                continue
+            if child.tagName in ("w:t", "w:delText"):
+                node_text = get_text_node_data(child)
+                for i, char in enumerate(node_text):
+                    text_chars.append(char)
+                    positions.append(
+                        TextPosition(
+                            node=child,
+                            offset_in_node=i,
+                            is_inside_ins=False,
+                            is_inside_del=inside_del,
+                        )
+                    )
+            else:
+                _collect_original(child, inside_del or child.tagName == "w:del")
+
+    _collect_original(paragraph, False)
     return TextMap(text="".join(text_chars), positions=positions)
 
 

--- a/docx_editor/xml_editor.py
+++ b/docx_editor/xml_editor.py
@@ -12,6 +12,7 @@ import zlib
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Literal
 from xml.dom.minidom import Element
 
 import defusedxml.minidom
@@ -353,7 +354,7 @@ def get_text_node_data(elem) -> str:
     return "".join(c.data for c in elem.childNodes if c.nodeType == c.TEXT_NODE)
 
 
-def build_text_map(paragraph, view: str = "accepted") -> TextMap:
+def build_text_map(paragraph, view: Literal["accepted", "original"] = "accepted") -> TextMap:
     """Build a text map for a paragraph element.
 
     Two views are supported:
@@ -361,8 +362,9 @@ def build_text_map(paragraph, view: str = "accepted") -> TextMap:
     - ``"accepted"`` (default): the visible text — text inside <w:ins> is
       included (with is_inside_ins=True), text inside <w:del>/<w:delText>
       is excluded. Paragraph hashes and all editing operations use this view.
-    - ``"original"``: the pre-revision text — <w:ins> subtrees are excluded,
-      <w:delText> is included (with is_inside_del=True).
+    - ``"original"``: the pre-revision text — <w:ins> and <w:moveTo> subtrees
+      are excluded, <w:delText> is included, and text inside <w:del> or
+      <w:moveFrom> is flagged with is_inside_del=True.
 
     Records the source node and offset for each character position.
     """
@@ -394,11 +396,11 @@ def build_text_map(paragraph, view: str = "accepted") -> TextMap:
 
         return TextMap(text="".join(text_chars), positions=positions)
 
-    def _collect_original(node, inside_del: bool) -> None:
+    def collect_original(node, inside_del: bool) -> None:
         for child in node.childNodes:
             if child.nodeType != child.ELEMENT_NODE:
                 continue
-            if child.tagName == "w:ins":
+            if child.tagName in ("w:ins", "w:moveTo"):
                 continue
             if child.tagName in ("w:t", "w:delText"):
                 node_text = get_text_node_data(child)
@@ -413,9 +415,9 @@ def build_text_map(paragraph, view: str = "accepted") -> TextMap:
                         )
                     )
             else:
-                _collect_original(child, inside_del or child.tagName == "w:del")
+                collect_original(child, inside_del or child.tagName in ("w:del", "w:moveFrom"))
 
-    _collect_original(paragraph, False)
+    collect_original(paragraph, False)
     return TextMap(text="".join(text_chars), positions=positions)
 
 

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -507,6 +507,54 @@ class TestDocumentGetVisibleText:
             doc.get_visible_text()
 
 
+class TestDocumentGetOriginalText:
+    """Tests for get_original_text()."""
+
+    def test_recovers_pre_revision_text(self, clean_workspace):
+        """Original text equals the pre-edit baseline; visible is the inverse."""
+        doc = Document.open(clean_workspace)
+        baseline = doc.get_visible_text()
+        doc.insert_after("fox", " INSERTED", paragraph=find_ref(doc, "fox"))
+        doc.delete("dog", paragraph=find_ref(doc, "dog"))
+        assert doc.get_original_text() == baseline
+        visible = doc.get_visible_text()
+        assert "INSERTED" in visible
+        assert "dog" not in visible
+        doc.close()
+
+    def test_matches_visible_text_after_reject_all(self, clean_workspace):
+        """Acceptance criterion: original view == post-reject_all visible text."""
+        doc = Document.open(clean_workspace)
+        doc.replace("fox", "cat", paragraph=find_ref(doc, "fox"))
+        original = doc.get_original_text()
+        doc.reject_all()
+        assert doc.get_visible_text() == original
+        doc.close()
+
+    def test_no_revisions_equals_visible(self, clean_workspace):
+        """Without tracked changes both views are identical."""
+        doc = Document.open(clean_workspace)
+        assert doc.get_original_text() == doc.get_visible_text()
+        doc.close()
+
+    def test_read_only_refs_stay_valid(self, clean_workspace):
+        """Reading the original view does not invalidate paragraph refs."""
+        doc = Document.open(clean_workspace)
+        ref = find_ref(doc, "fox")
+        doc.get_original_text()
+        new_ref = doc.replace("fox", "cat", paragraph=ref)
+        assert new_ref != ref
+        assert "cat" in doc.get_visible_text()
+        doc.close()
+
+    def test_get_original_text_after_close_raises(self, clean_workspace):
+        """Should raise ValueError after document is closed."""
+        doc = Document.open(clean_workspace)
+        doc.close()
+        with pytest.raises(ValueError, match="closed"):
+            doc.get_original_text()
+
+
 class TestDocumentFindText:
     """Tests for find_text()."""
 

--- a/tests/test_text_map.py
+++ b/tests/test_text_map.py
@@ -139,10 +139,11 @@ class TestBuildTextMapOriginalView:
         """Deleted chars reference w:delText with correct offsets and flags."""
         p = _parse_paragraph(MIXED_INS_DEL_XML)
         tm = build_text_map(p, view="original")
+        del_text_node = p.getElementsByTagName("w:delText")[0]
         # "Hello old world": positions 6-9 are "old " from w:delText
         for i, pos in enumerate(tm.positions[6:10]):
             assert pos.is_inside_del
-            assert pos.node.tagName == "w:delText"
+            assert pos.node is del_text_node
             assert pos.offset_in_node == i
         # Surrounding text is not marked deleted
         assert all(not pos.is_inside_del for pos in tm.positions[:6])
@@ -173,11 +174,33 @@ class TestBuildTextMapOriginalView:
         assert tm.positions[0].node is not tm.positions[6].node
         assert all(pos.is_inside_del for pos in tm.positions)
 
+    def test_move_revisions_counted_once(self):
+        """Moved text appears once in the original view, at its source.
+
+        w:moveTo (destination) is skipped like w:ins; w:moveFrom (source)
+        is treated like w:del.
+        """
+        p = _parse_paragraph(
+            "<w:p>"
+            '<w:moveFrom w:id="1" w:author="Test" w:date="2024-01-01T00:00:00Z">'
+            "<w:r><w:delText>moved </w:delText></w:r>"
+            "</w:moveFrom>"
+            "<w:r><w:t>middle </w:t></w:r>"
+            '<w:moveTo w:id="2" w:author="Test" w:date="2024-01-01T00:00:00Z">'
+            "<w:r><w:t>moved </w:t></w:r>"
+            "</w:moveTo>"
+            "</w:p>"
+        )
+        tm = build_text_map(p, view="original")
+        assert tm.text == "moved middle "
+        assert all(pos.is_inside_del for pos in tm.positions[:6])
+        assert all(not pos.is_inside_del for pos in tm.positions[6:])
+
     def test_invalid_view_raises(self):
         """Unknown view names are rejected."""
         p = _parse_paragraph("<w:p><w:r><w:t>Hello</w:t></w:r></w:p>")
         with pytest.raises(ValueError, match="bogus"):
-            build_text_map(p, view="bogus")
+            build_text_map(p, view="bogus")  # type: ignore[arg-type]
 
     def test_w_t_inside_del_defensive(self):
         """w:t inside w:del (invalid OOXML) is excluded from accepted,

--- a/tests/test_text_map.py
+++ b/tests/test_text_map.py
@@ -1,5 +1,6 @@
 """Tests for text map building (Phase 1: Core Infrastructure)."""
 
+import pytest
 from conftest import parse_paragraph as _parse_paragraph
 
 from docx_editor.xml_editor import build_text_map, find_in_text_map
@@ -108,6 +109,92 @@ class TestBuildTextMapTrackedChanges:
         assert tm.positions[9].is_inside_ins
         # "world" - regular
         assert not tm.positions[10].is_inside_ins
+
+
+MIXED_INS_DEL_XML = (
+    "<w:p>"
+    "<w:r><w:t>Hello </w:t></w:r>"
+    '<w:del w:id="1" w:author="Test" w:date="2024-01-01T00:00:00Z">'
+    "<w:r><w:delText>old </w:delText></w:r>"
+    "</w:del>"
+    '<w:ins w:id="2" w:author="Test" w:date="2024-01-01T00:00:00Z">'
+    "<w:r><w:t>new </w:t></w:r>"
+    "</w:ins>"
+    "<w:r><w:t>world</w:t></w:r>"
+    "</w:p>"
+)
+
+
+class TestBuildTextMapOriginalView:
+    """Tests for build_text_map(view="original")."""
+
+    def test_mixed_paragraph_original_vs_accepted(self):
+        """Original view includes deletions and excludes insertions."""
+        p = _parse_paragraph(MIXED_INS_DEL_XML)
+        assert build_text_map(p, view="original").text == "Hello old world"
+        assert build_text_map(p, view="accepted").text == "Hello new world"
+        assert build_text_map(p).text == "Hello new world"
+
+    def test_original_position_metadata(self):
+        """Deleted chars reference w:delText with correct offsets and flags."""
+        p = _parse_paragraph(MIXED_INS_DEL_XML)
+        tm = build_text_map(p, view="original")
+        # "Hello old world": positions 6-9 are "old " from w:delText
+        for i, pos in enumerate(tm.positions[6:10]):
+            assert pos.is_inside_del
+            assert pos.node.tagName == "w:delText"
+            assert pos.offset_in_node == i
+        # Surrounding text is not marked deleted
+        assert all(not pos.is_inside_del for pos in tm.positions[:6])
+        assert all(not pos.is_inside_del for pos in tm.positions[10:])
+        # w:ins subtrees are skipped, so nothing is inside ins
+        assert all(not pos.is_inside_ins for pos in tm.positions)
+
+    def test_plain_paragraph_views_identical(self):
+        """Without revisions, original and accepted views match."""
+        p = _parse_paragraph("<w:p><w:r><w:t>Hello world</w:t></w:r></w:p>")
+        original = build_text_map(p, view="original")
+        accepted = build_text_map(p, view="accepted")
+        assert original.text == accepted.text == "Hello world"
+        assert len(original.positions) == len(accepted.positions)
+
+    def test_deleted_text_split_across_runs(self):
+        """Multiple w:delText runs concatenate in document order."""
+        p = _parse_paragraph(
+            "<w:p>"
+            '<w:del w:id="1" w:author="Test" w:date="2024-01-01T00:00:00Z">'
+            "<w:r><w:delText>Hello </w:delText></w:r>"
+            "<w:r><w:delText>world</w:delText></w:r>"
+            "</w:del>"
+            "</w:p>"
+        )
+        tm = build_text_map(p, view="original")
+        assert tm.text == "Hello world"
+        assert tm.positions[0].node is not tm.positions[6].node
+        assert all(pos.is_inside_del for pos in tm.positions)
+
+    def test_invalid_view_raises(self):
+        """Unknown view names are rejected."""
+        p = _parse_paragraph("<w:p><w:r><w:t>Hello</w:t></w:r></w:p>")
+        with pytest.raises(ValueError, match="bogus"):
+            build_text_map(p, view="bogus")
+
+    def test_w_t_inside_del_defensive(self):
+        """w:t inside w:del (invalid OOXML) is excluded from accepted,
+        included in original with is_inside_del=True."""
+        p = _parse_paragraph(
+            "<w:p>"
+            "<w:r><w:t>Hello </w:t></w:r>"
+            '<w:del w:id="1" w:author="Test" w:date="2024-01-01T00:00:00Z">'
+            "<w:r><w:t>old </w:t></w:r>"
+            "</w:del>"
+            "<w:r><w:t>world</w:t></w:r>"
+            "</w:p>"
+        )
+        assert build_text_map(p).text == "Hello world"
+        tm = build_text_map(p, view="original")
+        assert tm.text == "Hello old world"
+        assert all(pos.is_inside_del for pos in tm.positions[6:10])
 
 
 class TestTextMapFind:


### PR DESCRIPTION
## Summary

Adds a read-only view of the document's original (pre-revision) text, the inverse of `get_visible_text()`: deleted text is included, inserted text is excluded.

- `build_text_map()` gains a `view: Literal["accepted", "original"]` parameter. The default `"accepted"` path is unchanged — paragraph hashes, editing operations, and comment anchoring are unaffected (all existing call sites use the default).
- The `"original"` view walks the paragraph recursively in document order: `w:ins` and `w:moveTo` subtrees are skipped, `w:delText` is collected, and text inside `w:del`/`w:moveFrom` is flagged `is_inside_del=True` (so move-tracked documents count moved text once, at its source).
- New `Document.get_original_text()` accessor mirrors `get_visible_text()`; documented in `docs/api.md`.

For intra-paragraph revisions, `get_original_text()` equals what `get_visible_text()` would return after `reject_all()` — without modifying the document. Paragraph-level revisions (e.g. inserted paragraph marks) only affect line boundaries; content never leaks between views.

Also adds local agent tooling files to `.gitignore`.

## Testing

- 7 new unit tests (mixed ins/del, position metadata, split `w:delText` runs, move revisions, invalid view, defensive `w:t`-inside-`w:del`, plain-paragraph identity)
- 5 new integration tests, including the `reject_all()` equivalence criterion and closed-document error
- Full suite: 633 passed, 6 skipped; `ruff check`, `ruff format --check`, and `ty check` all clean
- Reviewed via multi-reviewer loop (3 independent reviewers + codex + red-team triage); all confirmed findings fixed in `fix:` commit