### PR TITLE
fix: iterate accept_all/reject_all to fixed point for nested revisions

### DIFF
--- a/docx_editor/track_changes.py
+++ b/docx_editor/track_changes.py
@@ -1721,10 +1721,12 @@ class RevisionManager:
     def accept_all(self, author: str | None = None) -> int:
         """Accept all revisions, optionally filtered by author.
 
-        Repeated passes are made until no listed revision can be processed, so
-        nested revisions in Word-authored files (e.g. a w:del inside a w:ins)
-        are fully resolved; with an author filter, other authors' revisions are
-        left untouched.
+        Repeats passes until no listed revision can be processed, fully
+        resolving nested revisions in Word-authored files (e.g. a w:del inside
+        a w:ins) and terminating even when an author filter leaves other
+        authors' revisions in the document. Revisions are matched by w:id, so
+        if Word emits duplicate ids across authors, a filtered call may also
+        process a same-id revision by another author.
 
         Args:
             author: If provided, only accept revisions by this author
@@ -1746,10 +1748,12 @@ class RevisionManager:
     def reject_all(self, author: str | None = None) -> int:
         """Reject all revisions, optionally filtered by author.
 
-        Repeated passes are made until no listed revision can be processed, so
-        nested revisions in Word-authored files (e.g. a w:del inside a w:ins)
-        are fully resolved; with an author filter, other authors' revisions are
-        left untouched.
+        Repeats passes until no listed revision can be processed, fully
+        resolving nested revisions in Word-authored files (e.g. a w:del inside
+        a w:ins) and terminating even when an author filter leaves other
+        authors' revisions in the document. Revisions are matched by w:id, so
+        if Word emits duplicate ids across authors, a filtered call may also
+        process a same-id revision by another author.
 
         Args:
             author: If provided, only reject revisions by this author

--- a/docx_editor/track_changes.py
+++ b/docx_editor/track_changes.py
@@ -1721,6 +1721,11 @@ class RevisionManager:
     def accept_all(self, author: str | None = None) -> int:
         """Accept all revisions, optionally filtered by author.
 
+        Repeated passes are made until no listed revision can be processed, so
+        nested revisions in Word-authored files (e.g. a w:del inside a w:ins)
+        are fully resolved; with an author filter, other authors' revisions are
+        left untouched.
+
         Args:
             author: If provided, only accept revisions by this author
 
@@ -1728,15 +1733,23 @@ class RevisionManager:
             Number of revisions accepted
         """
         count = 0
-        revisions = self.list_revisions(author=author)
-        # Process in reverse order by ID to avoid index issues
-        for rev in sorted(revisions, key=lambda r: r.id, reverse=True):
-            if self.accept_revision(rev.id):
-                count += 1
-        return count
+        while True:
+            progressed = False
+            # Process in reverse order by ID to avoid index issues
+            for rev in sorted(self.list_revisions(author=author), key=lambda r: r.id, reverse=True):
+                if self.accept_revision(rev.id):
+                    count += 1
+                    progressed = True
+            if not progressed:
+                return count
 
     def reject_all(self, author: str | None = None) -> int:
         """Reject all revisions, optionally filtered by author.
+
+        Repeated passes are made until no listed revision can be processed, so
+        nested revisions in Word-authored files (e.g. a w:del inside a w:ins)
+        are fully resolved; with an author filter, other authors' revisions are
+        left untouched.
 
         Args:
             author: If provided, only reject revisions by this author
@@ -1745,12 +1758,15 @@ class RevisionManager:
             Number of revisions rejected
         """
         count = 0
-        revisions = self.list_revisions(author=author)
-        # Process in reverse order by ID to avoid index issues
-        for rev in sorted(revisions, key=lambda r: r.id, reverse=True):
-            if self.reject_revision(rev.id):
-                count += 1
-        return count
+        while True:
+            progressed = False
+            # Process in reverse order by ID to avoid index issues
+            for rev in sorted(self.list_revisions(author=author), key=lambda r: r.id, reverse=True):
+                if self.reject_revision(rev.id):
+                    count += 1
+                    progressed = True
+            if not progressed:
+                return count
 
     def _unwrap_element(self, elem) -> None:
         """Remove an element's wrapper, keeping its children in place."""

--- a/tests/test_track_changes.py
+++ b/tests/test_track_changes.py
@@ -1586,62 +1586,175 @@ class TestAcceptRejectLoops:
         assert count == 2
 
 
+def _make_revision_manager(body_xml):
+    """Build a RevisionManager over a real minidom DOM from a body snippet."""
+    import defusedxml.minidom
+
+    xml = (
+        '<?xml version="1.0"?>'
+        '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">'
+        f"{body_xml}"
+        "</w:document>"
+    )
+    mock_editor = MagicMock()
+    mock_editor.dom = defusedxml.minidom.parseString(xml)
+    return RevisionManager(mock_editor)
+
+
+class TestNestedForeignRevisions:
+    """Tests for accept_all/reject_all on nested revisions from Word-authored files.
+
+    Word produces nested markup when one reviewer edits another's tracked
+    change, e.g. a w:del inside a w:ins. The fixed-point loop in
+    accept_all/reject_all must fully resolve such nesting and still terminate
+    when an author filter legitimately leaves other authors' revisions behind.
+    """
+
+    NESTED_DEL_INSIDE_INS = """
+        <w:ins w:id="5" w:author="A" w:date="2026-01-01T00:00:00Z">
+            <w:r><w:t>kept</w:t></w:r>
+            <w:del w:id="3" w:author="B" w:date="2026-01-02T00:00:00Z">
+                <w:r><w:delText>gone</w:delText></w:r>
+            </w:del>
+        </w:ins>"""
+
+    def test_accept_all_nested_del_inside_ins(self):
+        """accept_all resolves a w:del nested inside a w:ins completely."""
+        manager = _make_revision_manager(self.NESTED_DEL_INSIDE_INS)
+        dom = manager.editor.dom
+
+        count = manager.accept_all()
+
+        assert count == 2
+        assert manager.list_revisions() == []
+        assert dom.getElementsByTagName("w:delText") == []
+        texts = [t.firstChild.data for t in dom.getElementsByTagName("w:t")]
+        assert texts == ["kept"]
+
+    def test_reject_all_nested_outer_processed_first(self):
+        """Rejecting the outer w:ins discards the nested w:del with it."""
+        manager = _make_revision_manager(self.NESTED_DEL_INSIDE_INS)
+        dom = manager.editor.dom
+
+        # Outer ins id=5 > nested del id=3: reverse-id order hits the outer
+        # first, so the nested deletion vanishes with it and is never itself
+        # rejected — only one per-id rejection executes.
+        count = manager.reject_all()
+
+        assert count == 1
+        assert manager.list_revisions() == []
+        assert dom.getElementsByTagName("w:t") == []
+        assert dom.getElementsByTagName("w:delText") == []
+
+    def test_reject_all_nested_inner_processed_first(self):
+        """Rejecting the nested w:del first still converges to the same document."""
+        body = """
+        <w:ins w:id="3" w:author="A" w:date="2026-01-01T00:00:00Z">
+            <w:r><w:t>kept</w:t></w:r>
+            <w:del w:id="5" w:author="B" w:date="2026-01-02T00:00:00Z">
+                <w:r><w:delText>gone</w:delText></w:r>
+            </w:del>
+        </w:ins>"""
+        manager = _make_revision_manager(body)
+        dom = manager.editor.dom
+
+        # Nested del id=5 > outer ins id=3: the deletion is rejected first
+        # (restoring its text inside the insertion), then rejecting the outer
+        # insertion removes everything.
+        count = manager.reject_all()
+
+        assert count == 2
+        assert manager.list_revisions() == []
+        assert dom.getElementsByTagName("w:t") == []
+        assert dom.getElementsByTagName("w:delText") == []
+
+    def test_accept_all_author_filter_duplicate_ids_converges(self):
+        """accept_all(author=...) converges when w:id values collide across authors."""
+        # Word does not guarantee unique w:id across w:ins/w:del. The per-id
+        # lookup checks w:ins first, so accepting B's deletion by id hits A's
+        # insertion instead; only re-listing until no progress resolves B.
+        body = """
+        <w:ins w:id="7" w:author="A" w:date="2026-01-01T00:00:00Z">
+            <w:r><w:t>alpha</w:t></w:r>
+        </w:ins>
+        <w:del w:id="7" w:author="B" w:date="2026-01-02T00:00:00Z">
+            <w:r><w:delText>beta</w:delText></w:r>
+        </w:del>"""
+        manager = _make_revision_manager(body)
+
+        manager.accept_all(author="B")
+
+        assert manager.list_revisions(author="B") == []
+
+    def test_accept_all_author_filter_terminates_with_foreign_revisions(self):
+        """accept_all(author=...) returns promptly while other authors' revisions remain."""
+        manager = _make_revision_manager(self.NESTED_DEL_INSIDE_INS)
+
+        count = manager.accept_all(author="B")
+
+        assert count == 1
+        assert manager.list_revisions(author="B") == []
+        remaining = manager.list_revisions(author="A")
+        assert len(remaining) == 1
+        assert remaining[0].type == "insertion"
+
+    def test_reject_all_author_filter_terminates_with_foreign_revisions(self):
+        """reject_all(author=...) returns promptly while other authors' revisions remain."""
+        manager = _make_revision_manager(self.NESTED_DEL_INSIDE_INS)
+        dom = manager.editor.dom
+
+        count = manager.reject_all(author="B")
+
+        assert count == 1
+        assert manager.list_revisions(author="B") == []
+        remaining = manager.list_revisions(author="A")
+        assert len(remaining) == 1
+        assert remaining[0].type == "insertion"
+        # B's rejected deletion restored its text inside A's insertion.
+        texts = [t.firstChild.data for t in dom.getElementsByTagName("w:t")]
+        assert texts == ["kept", "gone"]
+
+
 class TestRestoreDeletionAttributeCopying:
     """Tests for _restore_deletion attribute copying edge cases."""
 
     def test_restore_deletion_copies_deltext_attributes(self):
         """Test that _restore_deletion copies attributes from w:delText to w:t."""
-        import defusedxml.minidom
-
-        # Create a minimal document with w:del containing w:delText with attributes
-        xml = """<?xml version="1.0"?>
-        <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        manager = _make_revision_manager(
+            """
             <w:del w:id="1" w:author="Test">
                 <w:r>
                     <w:delText xml:space="preserve">test text</w:delText>
                 </w:r>
-            </w:del>
-        </w:document>"""
+            </w:del>"""
+        )
+        dom = manager.editor.dom
 
-        mock_editor = MagicMock()
-        mock_editor.dom = defusedxml.minidom.parseString(xml)
-
-        manager = RevisionManager(mock_editor)
-
-        # Get the w:del element
-        del_elem = mock_editor.dom.getElementsByTagName("w:del")[0]
-
-        # Restore the deletion
+        del_elem = dom.getElementsByTagName("w:del")[0]
         manager._restore_deletion(del_elem)
 
         # Verify w:t was created with xml:space attribute
-        t_elems = mock_editor.dom.getElementsByTagName("w:t")
+        t_elems = dom.getElementsByTagName("w:t")
         assert len(t_elems) == 1
         assert t_elems[0].getAttribute("xml:space") == "preserve"
 
     def test_restore_deletion_converts_rsiddel_to_rsidr(self):
         """Test that _restore_deletion converts w:rsidDel to w:rsidR on runs."""
-        import defusedxml.minidom
-
-        xml = """<?xml version="1.0"?>
-        <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        manager = _make_revision_manager(
+            """
             <w:del w:id="1" w:author="Test">
                 <w:r w:rsidDel="00112233">
                     <w:delText>text</w:delText>
                 </w:r>
-            </w:del>
-        </w:document>"""
+            </w:del>"""
+        )
+        dom = manager.editor.dom
 
-        mock_editor = MagicMock()
-        mock_editor.dom = defusedxml.minidom.parseString(xml)
-
-        manager = RevisionManager(mock_editor)
-
-        del_elem = mock_editor.dom.getElementsByTagName("w:del")[0]
+        del_elem = dom.getElementsByTagName("w:del")[0]
         manager._restore_deletion(del_elem)
 
         # Verify w:rsidDel was converted to w:rsidR
-        r_elems = mock_editor.dom.getElementsByTagName("w:r")
+        r_elems = dom.getElementsByTagName("w:r")
         assert len(r_elems) == 1
         assert r_elems[0].getAttribute("w:rsidR") == "00112233"
         assert not r_elems[0].hasAttribute("w:rsidDel")

--- a/tests/test_track_changes.py
+++ b/tests/test_track_changes.py
@@ -1681,10 +1681,17 @@ class TestNestedForeignRevisions:
             <w:r><w:delText>beta</w:delText></w:r>
         </w:del>"""
         manager = _make_revision_manager(body)
+        dom = manager.editor.dom
 
-        manager.accept_all(author="B")
+        count = manager.accept_all(author="B")
 
-        assert manager.list_revisions(author="B") == []
+        # Documented side effect of id-based matching: pass 1 accepts A's
+        # same-id insertion (collateral), pass 2 accepts B's deletion.
+        assert count == 2
+        assert manager.list_revisions() == []
+        texts = [t.firstChild.data for t in dom.getElementsByTagName("w:t")]
+        assert texts == ["alpha"]
+        assert dom.getElementsByTagName("w:delText") == []
 
     def test_accept_all_author_filter_terminates_with_foreign_revisions(self):
         """Test that accept_all(author=...) terminates while other authors' revisions remain."""

--- a/tests/test_track_changes.py
+++ b/tests/test_track_changes.py
@@ -1619,7 +1619,7 @@ class TestNestedForeignRevisions:
         </w:ins>"""
 
     def test_accept_all_nested_del_inside_ins(self):
-        """accept_all resolves a w:del nested inside a w:ins completely."""
+        """Test that accept_all resolves a w:del nested inside a w:ins completely."""
         manager = _make_revision_manager(self.NESTED_DEL_INSIDE_INS)
         dom = manager.editor.dom
 
@@ -1632,7 +1632,7 @@ class TestNestedForeignRevisions:
         assert texts == ["kept"]
 
     def test_reject_all_nested_outer_processed_first(self):
-        """Rejecting the outer w:ins discards the nested w:del with it."""
+        """Test that rejecting the outer w:ins discards the nested w:del with it."""
         manager = _make_revision_manager(self.NESTED_DEL_INSIDE_INS)
         dom = manager.editor.dom
 
@@ -1647,7 +1647,7 @@ class TestNestedForeignRevisions:
         assert dom.getElementsByTagName("w:delText") == []
 
     def test_reject_all_nested_inner_processed_first(self):
-        """Rejecting the nested w:del first still converges to the same document."""
+        """Test that rejecting the nested w:del first still converges to the same document."""
         body = """
         <w:ins w:id="3" w:author="A" w:date="2026-01-01T00:00:00Z">
             <w:r><w:t>kept</w:t></w:r>
@@ -1669,7 +1669,7 @@ class TestNestedForeignRevisions:
         assert dom.getElementsByTagName("w:delText") == []
 
     def test_accept_all_author_filter_duplicate_ids_converges(self):
-        """accept_all(author=...) converges when w:id values collide across authors."""
+        """Test that accept_all(author=...) converges when w:id values collide across authors."""
         # Word does not guarantee unique w:id across w:ins/w:del. The per-id
         # lookup checks w:ins first, so accepting B's deletion by id hits A's
         # insertion instead; only re-listing until no progress resolves B.
@@ -1687,7 +1687,7 @@ class TestNestedForeignRevisions:
         assert manager.list_revisions(author="B") == []
 
     def test_accept_all_author_filter_terminates_with_foreign_revisions(self):
-        """accept_all(author=...) returns promptly while other authors' revisions remain."""
+        """Test that accept_all(author=...) terminates while other authors' revisions remain."""
         manager = _make_revision_manager(self.NESTED_DEL_INSIDE_INS)
 
         count = manager.accept_all(author="B")
@@ -1699,7 +1699,7 @@ class TestNestedForeignRevisions:
         assert remaining[0].type == "insertion"
 
     def test_reject_all_author_filter_terminates_with_foreign_revisions(self):
-        """reject_all(author=...) returns promptly while other authors' revisions remain."""
+        """Test that reject_all(author=...) terminates while other authors' revisions remain."""
         manager = _make_revision_manager(self.NESTED_DEL_INSIDE_INS)
         dom = manager.editor.dom
 


### PR DESCRIPTION
## Problem

Word-authored documents can contain nested tracked changes — e.g. a `w:del` inside a `w:ins` when one reviewer edits another reviewer's tracked change. The single-pass `accept_all()`/`reject_all()` implementation processed a one-shot snapshot of `list_revisions()`, so whether nested revisions fully resolved depended on id-ordering luck. Duplicate `w:id` values across `w:ins`/`w:del` (legal in Word output) additionally broke author-filtered calls: the per-id lookup could hit the wrong element and the target author's revision was never processed.

## Fix

`accept_all()` and `reject_all()` now iterate to a fixed point: re-list revisions (with the author filter applied) and process them in reverse-id order, repeating until a full pass makes no progress.

- **Termination is guaranteed**: every successful accept/reject removes exactly one `w:ins`/`w:del` element and none creates one, so the revision-element count strictly decreases on each progressing pass.
- **The progress-based exit (not empty-list) is load-bearing**: with an author filter, other authors' revisions legitimately remain listed forever; exiting on "no progress" avoids spinning on them.
- Docstrings state the actual contract, including the caveat that revisions are matched by `w:id`, so duplicate ids across authors can cause a filtered call to also process a same-id revision by another author.

## Tests

New `TestNestedForeignRevisions` class (real minidom DOM, no mocks) covering: nested accept, nested reject in both id-orderings, duplicate-id convergence under author filter (red before this fix), and author-filter termination with foreign revisions remaining. The two pre-existing `TestRestoreDeletionAttributeCopying` tests were refactored onto the new `_make_revision_manager` helper.

Full suite (rebased onto latest main, including #34): 627 passed, 6 skipped. `ruff check` / `ruff format` clean. Multi-reviewer loop (3 independent reviewers + codex + adversarial meta-review, 2 iterations) reached target score 9/10.

## Follow-up candidates (pre-existing, out of scope)

- Author/type-aware revision dispatch in `accept_revision`/`reject_revision` so duplicate `w:id` values can't consume another author's revision (behavior is now honestly documented and pinned by test).
- `int` vs string `w:id` comparison mismatch for non-canonical ids (theoretical; Word emits canonical integers).
