### PR TITLE
fix: refuse to adopt a workspace holding unsaved changes from a previous session

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -543,6 +543,8 @@ Save the document.
 
 **Returns:** Path to the saved document (Path)
 
+After saving to a different path (or a save that fails), the workspace is flagged as holding unsaved changes; a later `Document.open()` of the source raises `WorkspaceSyncError` until the workspace is saved back to the source or discarded with `force_recreate=True`. See [`WorkspaceSyncError`](#workspacesyncerror) below.
+
 **Example:**
 
 ```python

--- a/docs/api.md
+++ b/docs/api.md
@@ -25,7 +25,7 @@ Open a Word document for editing.
 
 **Raises:**
 
-- `WorkspaceSyncError`: If the source `.docx` was modified since the workspace was created. Pass `force_recreate=True` to discard the stale workspace and re-unpack from the current source. The workspace is never deleted silently. The error message includes the workspace path.
+- `WorkspaceSyncError`: If the source `.docx` was modified since the workspace was created, or if a leftover workspace holds unsaved changes from a previous session (one that saved to a different path, or whose save failed, and never closed). Pass `force_recreate=True` to discard the workspace and re-unpack from the current source. The workspace is never deleted silently. The error message includes the workspace path.
 - `WorkspaceError`: If the workspace directory cannot be created (e.g. the base is not writable), the home directory backing the default cache cannot be determined, or an existing workspace was unpacked from a different document. The message names the override to set.
 
 **Example:**
@@ -676,7 +676,7 @@ from docx_editor.exceptions import WorkspaceExistsError
 
 ### `WorkspaceSyncError`
 
-Raised when the workspace is out of sync with the source document.
+Raised when the workspace is out of sync with the source document: the source changed on disk since the workspace was created, or the workspace holds unsaved changes from a previous session that the source never received.
 
 ```python
 from docx_editor.exceptions import WorkspaceSyncError

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -23,7 +23,7 @@ with Document.open("contract.docx", author="Legal Team") as doc:
     doc.save()
 ```
 
-If the source `.docx` was modified outside this library since the workspace was created, `Document.open()` raises `WorkspaceSyncError` instead of silently discarding the workspace. The error message includes the workspace path. Pass `force_recreate=True` to acknowledge the divergence and re-unpack from the current source:
+If the source `.docx` was modified outside this library since the workspace was created, `Document.open()` raises `WorkspaceSyncError` instead of silently discarding the workspace. The same error is raised when a leftover workspace holds unsaved changes from a previous session — for example, one that saved to a different path (or whose save failed) and never called `close()` — since adopting it would carry those edits into the new session. The error message includes the workspace path. Pass `force_recreate=True` to acknowledge the divergence and re-unpack from the current source:
 
 ```python
 doc = Document.open("contract.docx", force_recreate=True)

--- a/docx_editor/document.py
+++ b/docx_editor/document.py
@@ -836,6 +836,13 @@ class Document:
     def save(self, path: str | Path | None = None, validate: bool = False, force: bool = False) -> Path:
         """Save the document.
 
+        The workspace is flagged as holding unsaved changes before anything is
+        written, and the flag is cleared only by a successful save back to the
+        source. So after a save to a different path, or a save that raised
+        partway, a later open() of the source refuses to adopt the workspace
+        (WorkspaceSyncError) instead of silently carrying this session's edits
+        over. Recover with force_recreate=True.
+
         Args:
             path: Output path (defaults to original source path)
             validate: If True, validate with LibreOffice before saving
@@ -858,14 +865,6 @@ class Document:
                 final replace because another program holds the destination open.
                 force=True skips the ``~$`` check but cannot suppress the latter —
                 the OS still refuses the write.
-
-        Note:
-            The workspace is flagged as holding unsaved changes before anything
-            is written, and the flag is cleared only by a successful save back
-            to the source. So after a save to a different path, or a save that
-            raised partway, a later open() of the source refuses to adopt the
-            workspace (WorkspaceSyncError) instead of silently carrying this
-            session's edits over. Recover with force_recreate=True.
 
         Example:
             doc.save()  # Save to original path

--- a/docx_editor/document.py
+++ b/docx_editor/document.py
@@ -117,9 +117,12 @@ class Document:
                 undeterminable home directory) or an existing workspace was
                 unpacked from a different document.
             WorkspaceSyncError: If the source document was modified since the
-                workspace was created. The message includes the workspace path.
-                Pass force_recreate=True to discard the stale workspace and
-                re-unpack from the current source.
+                workspace was created, or if a leftover workspace holds unsaved
+                changes from a previous session (e.g. it saved to a different
+                path, or a save failed, and the session never closed cleanly).
+                The message includes the workspace path. Pass
+                force_recreate=True to discard the workspace and re-unpack from
+                the current source.
 
         Example:
             doc = Document.open("contract.docx")
@@ -856,11 +859,25 @@ class Document:
                 force=True skips the ``~$`` check but cannot suppress the latter —
                 the OS still refuses the write.
 
+        Note:
+            The workspace is flagged as holding unsaved changes before anything
+            is written, and the flag is cleared only by a successful save back
+            to the source. So after a save to a different path, or a save that
+            raised partway, a later open() of the source refuses to adopt the
+            workspace (WorkspaceSyncError) instead of silently carrying this
+            session's edits over. Recover with force_recreate=True.
+
         Example:
             doc.save()  # Save to original path
             doc.save("contract_v2.docx")  # Save to new path
         """
         self._ensure_open()
+
+        # Write-ahead: flag the workspace before any editor flush touches it,
+        # so a save that fails (or a process that dies) after the flushes still
+        # leaves the flag on disk and a later open() refuses to adopt the
+        # diverged workspace. A successful save back to the source clears it.
+        self._workspace.mark_dirty()
 
         # Ensure comment relationships and content types
         self._ensure_comment_relationships()

--- a/docx_editor/exceptions.py
+++ b/docx_editor/exceptions.py
@@ -34,7 +34,12 @@ class WorkspaceExistsError(WorkspaceError):
 
 
 class WorkspaceSyncError(WorkspaceError):
-    """Raised when the source document has changed since workspace creation."""
+    """Raised when the workspace is out of sync with the source document.
+
+    Two triggers: the source changed on disk since the workspace was created,
+    or the workspace holds unsaved changes from a previous session that the
+    source never received.
+    """
 
     pass
 

--- a/docx_editor/workspace.py
+++ b/docx_editor/workspace.py
@@ -177,11 +177,11 @@ class Workspace:
                     if existing_meta.get("dirty"):
                         raise WorkspaceSyncError(
                             f"Workspace {self.workspace_path} holds unsaved changes from a "
-                            f"previous session (the source document itself is unchanged). "
-                            f"Adopting it would carry those edits into this session and the "
-                            f"next save would write them into {self.source_path}. Use "
-                            f"force_recreate=True (or delete the workspace) to discard them, "
-                            f"or Workspace(source, create=False).save(destination=...) to "
+                            f"previous session. Adopting it would carry those edits into "
+                            f"this session and the next save would write them into "
+                            f"{self.source_path}. Use force_recreate=True (or delete the "
+                            f"workspace) to discard them, or "
+                            f"Workspace(source, create=False).save(destination=...) to "
                             f"rescue them first."
                         )
                     # Same staleness predicate as save(), so a workspace can never
@@ -361,6 +361,10 @@ class Workspace:
         previous session's edits would silently carry into the new session even
         though the source document itself is unchanged. The flag is cleared only
         by a successful save() back to the source.
+
+        Document.save() and Workspace.save() both call this themselves; callers
+        that mutate workspace files directly must call it before touching disk,
+        or a crash before save() leaves the divergence unflagged.
         """
         if not self.meta.get("dirty"):
             self.meta["dirty"] = True
@@ -430,6 +434,13 @@ class Workspace:
         output_path = Path(destination) if destination else self.source_path
         overwrites_source = self._is_source(output_path)
 
+        # Write-ahead: flag the workspace before any check or write can fail,
+        # so a crash from here on leaves the flag on disk. Not skipped by
+        # force= — this is bookkeeping, not a safety check. A save elsewhere
+        # leaves the flag set (the source never received that content); only
+        # a successful save back to the source clears it, below.
+        self.mark_dirty()
+
         # A missing source has no external edits to lose, so recreating it is safe
         # and must not be blocked — only an existing, changed source is protected.
         if not force and overwrites_source and self.source_path.exists() and not self.sync_check():
@@ -447,13 +458,7 @@ class Workspace:
         if not force:
             self._check_not_open(output_path, saving_in_place=destination is None)
 
-        # Update metadata before saving. A save to a non-source destination
-        # leaves the workspace holding content the source never received, so it
-        # is marked dirty ahead of the pack (not skipped by force= — this is
-        # bookkeeping, not a safety check). Only a later successful save back
-        # to the source clears it.
-        if not overwrites_source:
-            self.meta["dirty"] = True
+        # Update metadata before saving
         self.meta["last_saved"] = datetime.now(timezone.utc).isoformat()
         self._save_meta()
 

--- a/docx_editor/workspace.py
+++ b/docx_editor/workspace.py
@@ -143,6 +143,9 @@ class Workspace:
             DocumentNotFoundError: If the source document doesn't exist
             InvalidDocumentError: If the file is not a .docx file
             WorkspaceExistsError: If workspace exists and create=True
+            WorkspaceSyncError: If create=True and an existing workspace holds
+                unsaved changes from a previous session, or the source document
+                changed on disk since the workspace was created
         """
         # Keep the name the caller actually opened. If they opened a symlink, that is
         # the name Word was told to open — and therefore the name its ~$ owner file
@@ -358,9 +361,10 @@ class Workspace:
         Call this *before* mutating workspace content on disk (write-ahead), so
         that even a crash mid-mutation leaves the flag set. A dirty workspace is
         refused for adoption by a later ``Workspace(create=True)`` — otherwise a
-        previous session's edits would silently carry into the new session even
-        though the source document itself is unchanged. The flag is cleared only
-        by a successful save() back to the source.
+        previous session's edits could silently carry into the new session (the
+        staleness check cannot catch this case: the source itself may be
+        unchanged). The flag is cleared only by a successful save() back to the
+        source.
 
         Document.save() and Workspace.save() both call this themselves; callers
         that mutate workspace files directly must call it before touching disk,
@@ -411,6 +415,12 @@ class Workspace:
         force: bool = False,
     ) -> Path:
         """Pack workspace back to a .docx file.
+
+        The workspace is flagged as holding unsaved changes (see
+        :meth:`mark_dirty`) before any check or write runs; only a successful
+        save back to the source clears the flag. A failed save, or a save to a
+        different destination, leaves the workspace refused for adoption by a
+        later ``Workspace(create=True)``.
 
         Args:
             destination: Output path (defaults to original source path)

--- a/docx_editor/workspace.py
+++ b/docx_editor/workspace.py
@@ -172,6 +172,18 @@ class Workspace:
                 if existing_meta:
                     self._check_provenance(existing_meta)
                     self.meta = existing_meta
+                    # Checked before staleness: when both hold, the unsaved edits
+                    # are the data-loss-relevant fact to surface, not the mtime.
+                    if existing_meta.get("dirty"):
+                        raise WorkspaceSyncError(
+                            f"Workspace {self.workspace_path} holds unsaved changes from a "
+                            f"previous session (the source document itself is unchanged). "
+                            f"Adopting it would carry those edits into this session and the "
+                            f"next save would write them into {self.source_path}. Use "
+                            f"force_recreate=True (or delete the workspace) to discard them, "
+                            f"or Workspace(source, create=False).save(destination=...) to "
+                            f"rescue them first."
+                        )
                     # Same staleness predicate as save(), so a workspace can never
                     # open clean here and then fail sync_check() later at save time.
                     if not self.sync_check():
@@ -317,6 +329,7 @@ class Workspace:
             "rsid": rsid,
             "next_comment_id": 0,
             "next_change_id": 0,
+            "dirty": False,
         }
 
         self._save_meta()
@@ -338,6 +351,20 @@ class Workspace:
         meta_path = self.workspace_path / self.META_FILE
         with open(meta_path, "w", encoding="utf-8") as f:
             json.dump(self.meta, f, indent=2)
+
+    def mark_dirty(self) -> None:
+        """Persist that the workspace may hold content not saved to the source.
+
+        Call this *before* mutating workspace content on disk (write-ahead), so
+        that even a crash mid-mutation leaves the flag set. A dirty workspace is
+        refused for adoption by a later ``Workspace(create=True)`` — otherwise a
+        previous session's edits would silently carry into the new session even
+        though the source document itself is unchanged. The flag is cleared only
+        by a successful save() back to the source.
+        """
+        if not self.meta.get("dirty"):
+            self.meta["dirty"] = True
+            self._save_meta()
 
     def _check_not_open(self, output_path: Path, *, saving_in_place: bool) -> None:
         """Raise DocumentOpenError if Word appears to have the destination open.
@@ -420,7 +447,13 @@ class Workspace:
         if not force:
             self._check_not_open(output_path, saving_in_place=destination is None)
 
-        # Update metadata before saving
+        # Update metadata before saving. A save to a non-source destination
+        # leaves the workspace holding content the source never received, so it
+        # is marked dirty ahead of the pack (not skipped by force= — this is
+        # bookkeeping, not a safety check). Only a later successful save back
+        # to the source clears it.
+        if not overwrites_source:
+            self.meta["dirty"] = True
         self.meta["last_saved"] = datetime.now(timezone.utc).isoformat()
         self._save_meta()
 
@@ -442,6 +475,9 @@ class Workspace:
             saved_stat = output_path.stat()
             self.meta["source_mtime"] = saved_stat.st_mtime
             self.meta["source_size"] = saved_stat.st_size
+            # The source now holds everything the workspace holds — the
+            # workspace is no longer ahead of it, so adoption is safe again.
+            self.meta["dirty"] = False
             self._save_meta()
 
         return output_path

--- a/skills/docx/SKILL.md
+++ b/skills/docx/SKILL.md
@@ -609,6 +609,7 @@ Rules:
 - A `exec` sent while the kernel is still busy **queues** behind the running one; `--timeout` covers the whole wait. A timeout does not cancel the running code.
 - The session is non-interactive: `input()` (and anything reading stdin) raises `StdinNotImplementedError` rather than hanging.
 - `doc.save()` raises `WorkspaceSyncError` if the file changed on disk while the session held it open (e.g. the user edited it in Word). Ask the user before retrying with `doc.save(force=True)` — force overwrites their changes.
+- A session that saved to a different path (or whose save failed) and never called `doc.close()` leaves the workspace flagged as holding unsaved changes; the next `Document.open()` of the same source raises `WorkspaceSyncError` instead of silently carrying those edits over. Recover with `Document.open(path, force_recreate=True)`.
 - For a single edit, a one-off script is still fine — session mode pays off with repeated operations.
 
 ### Complementary Tools

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -1,11 +1,13 @@
 """Tests for the main Document class."""
 
+import json
 import zipfile
 
 import pytest
 from conftest import find_ref
 
 from docx_editor import Document
+from docx_editor.exceptions import DocumentOpenError, WorkspaceSyncError
 from docx_editor.workspace import Workspace
 
 
@@ -104,6 +106,98 @@ class TestDocumentSave:
         # Sanity: real OOXML parts are still present.
         assert "word/document.xml" in names
         assert "[Content_Types].xml" in names
+
+
+class TestStaleWorkspaceAdoption:
+    """Regression tests for issue #31: a workspace left behind by a session
+    that saved elsewhere (or crashed mid-save) must not be silently adopted —
+    the next save would write the previous session's edits into a source
+    document the user never touched."""
+
+    def test_save_elsewhere_without_close_refuses_reopen(self, clean_workspace, temp_dir):
+        """The issue's two-run repro: RUN 1 edits and saves elsewhere, RUN 2
+        opens the clean source and must get an error, not RUN 1's edits."""
+        # RUN 1: edit, save to a different path, exit without close().
+        doc = Document.open(clean_workspace, author="Run One")
+        doc.replace("fox", "cat", paragraph=find_ref(doc, "fox"))
+        doc.save(temp_dir / "reviewed.docx")
+        workspace_path = doc.workspace_path
+        del doc  # no close()
+
+        # RUN 2: the untouched source must refuse the diverged workspace.
+        with pytest.raises(WorkspaceSyncError, match="unsaved changes") as excinfo:
+            Document.open(clean_workspace, author="Run Two")
+        assert str(workspace_path) in str(excinfo.value)
+
+        # The documented recovery opens clean: no leaked edits, no revisions.
+        doc2 = Document.open(clean_workspace, author="Run Two", force_recreate=True)
+        assert doc2.list_revisions() == []
+        assert "cat" not in doc2.get_visible_text()
+        doc2.close()
+
+    def test_save_in_place_without_close_reopens_clean(self, clean_workspace):
+        """An in-place save leaves source and workspace in agreement, so a
+        later open (even without close()) adopts the workspace as before."""
+        doc = Document.open(clean_workspace, author="Run One")
+        doc.replace("fox", "cat", paragraph=find_ref(doc, "fox"))
+        doc.save()
+        del doc  # no close()
+
+        doc2 = Document.open(clean_workspace, author="Run Two")
+        # replace() records a paired deletion + insertion.
+        assert len(doc2.list_revisions()) == 2
+        doc2.close()
+
+    def test_crash_with_no_edits_still_adopts(self, clean_workspace):
+        """Opening writes tracking infrastructure (people.xml, rsid) into the
+        workspace; that alone must not count as unsaved changes."""
+        doc = Document.open(clean_workspace, author="Run One")
+        del doc  # no edits, no save, no close()
+
+        doc2 = Document.open(clean_workspace, author="Run Two")
+        assert doc2.list_revisions() == []
+        doc2.close()
+
+    def test_failed_save_still_flags_workspace(self, clean_workspace):
+        """Write-ahead ordering: Document.save() flushes edits into the
+        workspace before packing, so a save that fails after the flush must
+        already have persisted the dirty flag."""
+        doc = Document.open(clean_workspace, author="Run One")
+        doc.replace("fox", "cat", paragraph=find_ref(doc, "fox"))
+
+        # Make the pack step refuse: a ~$ owner stub marks the source as open
+        # in Word. The editors have already flushed by the time it is checked.
+        owner_stub = clean_workspace.parent / f"~${clean_workspace.name}"
+        owner_stub.write_text("stub")
+        try:
+            with pytest.raises(DocumentOpenError):
+                doc.save()
+        finally:
+            owner_stub.unlink()
+        del doc  # no close()
+
+        with pytest.raises(WorkspaceSyncError, match="unsaved changes"):
+            Document.open(clean_workspace, author="Run Two")
+
+    def test_relative_path_save_to_source_refreshes_mtime(self, clean_workspace, monkeypatch):
+        """Regression for issue #31's adjacent bug (fixed in PR #33): saving to
+        the source via a relative path must refresh the recorded mtime so the
+        workspace is not reported stale on the next open."""
+        doc = Document.open(clean_workspace, author="Run One")
+        doc.replace("fox", "cat", paragraph=find_ref(doc, "fox"))
+        monkeypatch.chdir(clean_workspace.parent)
+        doc.save(clean_workspace.name)
+
+        with open(doc.workspace_path / "meta.json") as f:
+            meta = json.load(f)
+        assert meta["source_mtime"] == clean_workspace.stat().st_mtime
+        assert meta["dirty"] is False
+        del doc  # no close()
+
+        doc2 = Document.open(clean_workspace, author="Run Two")
+        # replace() records a paired deletion + insertion.
+        assert len(doc2.list_revisions()) == 2
+        doc2.close()
 
 
 class TestDocumentClose:

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -725,6 +725,20 @@ class TestDirtyWorkspace:
 
         Workspace.delete(temp_docx)
 
+    def test_failed_in_place_save_sets_dirty(self, temp_docx):
+        """save() flags the workspace write-ahead even for in-place saves, so a
+        pack failure cannot leave a diverged workspace unflagged for adoption."""
+        from unittest.mock import patch
+
+        ws = Workspace(temp_docx, author="Test")
+        try:
+            with patch("docx_editor.workspace.pack_document", return_value=False):
+                with pytest.raises(WorkspaceError, match="Failed to pack"):
+                    ws.save()
+            assert self._meta_on_disk(ws)["dirty"] is True
+        finally:
+            ws.close()
+
     def test_mark_dirty_is_idempotent_and_persisted(self, temp_docx):
         ws = Workspace(temp_docx, author="Test")
         try:

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -48,6 +48,7 @@ class TestWorkspaceCreation:
         assert "author" in meta
         assert "rsid" in meta
         assert len(meta["rsid"]) == 8  # RSID is 8 hex chars
+        assert meta["dirty"] is False  # fresh workspace holds nothing unsaved
 
         workspace.close()
 
@@ -675,3 +676,76 @@ class TestSaveStaleness:
         # And the documented recovery (drop the workspace) works.
         Workspace.delete(temp_docx)
         Workspace(temp_docx, author="Test").close()
+
+
+class TestDirtyWorkspace:
+    """Tests for the dirty flag guarding stale-workspace adoption (issue #31)."""
+
+    def _meta_on_disk(self, ws):
+        with open(ws.workspace_path / "meta.json") as f:
+            return json.load(f)
+
+    def test_save_elsewhere_sets_dirty_on_disk(self, temp_docx, temp_dir):
+        ws = Workspace(temp_docx, author="Test")
+        try:
+            ws.save(destination=temp_dir / "elsewhere.docx")
+            assert self._meta_on_disk(ws)["dirty"] is True
+        finally:
+            ws.close()
+
+    def test_save_to_source_clears_dirty(self, temp_docx, temp_dir):
+        ws = Workspace(temp_docx, author="Test")
+        try:
+            ws.save(destination=temp_dir / "elsewhere.docx")
+            ws.save()  # back to the source: workspace no longer ahead of it
+            assert self._meta_on_disk(ws)["dirty"] is False
+        finally:
+            ws.close()
+
+    def test_dirty_workspace_is_refused_for_adoption(self, temp_docx, temp_dir):
+        ws = Workspace(temp_docx, author="Test")
+        ws.save(destination=temp_dir / "elsewhere.docx")
+        ws.close(cleanup=False)
+
+        with pytest.raises(WorkspaceSyncError, match="unsaved changes"):
+            Workspace(temp_docx, author="Test")
+
+        Workspace.delete(temp_docx)
+
+    def test_dirty_workspace_rescue_via_create_false(self, temp_docx, temp_dir):
+        """The error message's rescue hatch must keep working: create=False
+        reattaches without adoption checks so the contents can be saved out."""
+        ws = Workspace(temp_docx, author="Test")
+        ws.save(destination=temp_dir / "elsewhere.docx")
+        ws.close(cleanup=False)
+
+        rescue = Workspace(temp_docx, create=False)
+        out = rescue.save(destination=temp_dir / "rescued.docx")
+        assert out.exists()
+
+        Workspace.delete(temp_docx)
+
+    def test_mark_dirty_is_idempotent_and_persisted(self, temp_docx):
+        ws = Workspace(temp_docx, author="Test")
+        try:
+            ws.mark_dirty()
+            assert self._meta_on_disk(ws)["dirty"] is True
+            ws.mark_dirty()  # second call is a no-op, not an error
+            assert self._meta_on_disk(ws)["dirty"] is True
+        finally:
+            ws.close()
+
+    def test_pre_upgrade_meta_without_dirty_key_adopts(self, temp_docx):
+        """meta.json written before the flag existed must adopt exactly as before."""
+        ws = Workspace(temp_docx, author="Test")
+        ws.close(cleanup=False)
+
+        meta_path = ws.workspace_path / "meta.json"
+        with open(meta_path) as f:
+            meta = json.load(f)
+        del meta["dirty"]
+        with open(meta_path, "w") as f:
+            json.dump(meta, f)
+
+        ws2 = Workspace(temp_docx, author="Test")  # must not raise
+        ws2.close()


### PR DESCRIPTION
Fixes #31.

## Problem

A session that saves to a different path (or whose save fails partway) and never calls `close()` leaves a workspace whose content the source document never received. `Document.open()` silently adopted that workspace, so the next in-place save wrote the previous session's edits into a source the user never touched — the two-run scenario from #31 reproduces this exactly.

## Fix

Workspaces now carry a persisted `dirty` flag in `meta.json`:

- **`Document.save()` sets it write-ahead** — immediately after `_ensure_open()`, before any editor flush mutates workspace content on disk — so a save that fails (or a process that dies) after the flushes still leaves the flag persisted. User edits only reach workspace disk inside `save()`, so no crash window can leave unflagged edits behind.
- **`Workspace.save()`** marks the flag for any non-source destination (not skippable via `force=` — it is bookkeeping, not a safety check) and clears it only after a successful pack back to the source, alongside the existing mtime/size refresh (same `samefile`-based predicate, so symlinked and relative-path saves to the source clear it correctly).
- **Adoption** (`Workspace(create=True)` over an existing workspace) now raises `WorkspaceSyncError` for a dirty workspace, checked after provenance and before staleness — when both hold, the unsaved edits are the data-loss-relevant fact to surface. The message names the workspace path and both recovery routes: `force_recreate=True` to discard, or `Workspace(source, create=False).save(destination=...)` to rescue the edits first.

## Compatibility and deliberate trade-offs

- Pre-upgrade `meta.json` without the key adopts exactly as before; fresh workspaces initialize `dirty: false`.
- Opening a document (tracking-infrastructure writes: people.xml, content types, rels, settings) does not set the flag — a session that opens and exits without editing still adopts cleanly.
- Conservative by design: `save(elsewhere)` with zero edits still flags the workspace, so the next open of the untouched source raises. Always recoverable and documented.

## Testing

- 11 new tests: `TestStaleWorkspaceAdoption` (test_document.py) including the issue's two-run reproduction, failed-save write-ahead ordering, and the PR #33 relative-path regression; `TestDirtyWorkspace` (test_workspace.py) covering set/clear on disk, adoption refusal, the `create=False` rescue hatch, idempotency, and pre-upgrade meta.
- Full suite: 745 passed, 8 skipped. `ruff check` / `ruff format --check` clean.
- Validated end-to-end with a two-process reproduction of #31: run 1 edits and saves elsewhere without closing; run 2 gets `WorkspaceSyncError`, and `force_recreate=True` opens clean with zero leaked revisions.

## Docs

`docs/api.md` (`Document.open()` raises + `WorkspaceSyncError` glossary entry), `docs/quickstart.md`, `skills/docx/SKILL.md` session-mode notes, and both docstrings updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented accidental reuse of workspaces containing unsaved changes from a previous session.
  - `Document.open()` now reports workspace synchronization errors with clearer recovery guidance.
  - Failed saves and saves to alternate locations are detected reliably.
  - In-place saves continue to reopen cleanly without triggering stale-workspace errors.

- **Documentation**
  - Expanded API, quickstart, and session guidance for handling stale workspaces.
  - Documented using `force_recreate=True` to safely recover and recreate a workspace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->