### PR TITLE
fix: unpack workspace XML as UTF-8 to stop text-node splitting

### DIFF
--- a/docx_editor/ooxml/unpack.py
+++ b/docx_editor/ooxml/unpack.py
@@ -86,7 +86,7 @@ def unpack_document(input_file: str | Path, output_dir: str | Path) -> str:
     for xml_file in xml_files:
         content = xml_file.read_text(encoding="utf-8")
         dom = defusedxml.minidom.parseString(content)
-        xml_file.write_bytes(dom.toprettyxml(indent="  ", encoding="ascii"))
+        xml_file.write_bytes(dom.toprettyxml(indent="  ", encoding="utf-8"))
 
     # Generate and return RSID for tracked changes
     suggested_rsid = "".join(random.choices("0123456789ABCDEF", k=8))

--- a/tests/test_ooxml.py
+++ b/tests/test_ooxml.py
@@ -5,10 +5,12 @@ import sys
 import zipfile
 
 import pytest
+from conftest import NS, replace_document_xml
 
 from docx_editor.exceptions import DocumentNotFoundError, InvalidDocumentError
 from docx_editor.ooxml.pack import pack_document
 from docx_editor.ooxml.unpack import _is_symlink_entry, unpack_document
+from docx_editor.xml_editor import DocxXMLEditor
 
 
 def _build_zip(path, entries):
@@ -166,6 +168,57 @@ class TestUnpack:
 
         with pytest.raises(InvalidDocumentError, match="Symlink inside output directory"):
             unpack_document(simple_docx, output)
+
+
+SMART_TEXT = "“He said ‘hello’ — it’s fine”"
+
+
+def _smart_quote_document() -> str:
+    """One paragraph whose single <w:t> carries smart quotes and an em-dash."""
+    return (
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+        f"<w:document {NS}>"
+        "<w:body>"
+        f"<w:p><w:r><w:t>{SMART_TEXT}</w:t></w:r></w:p>"
+        "</w:body>"
+        "</w:document>"
+    )
+
+
+class TestUnpackUtf8:
+    """Unpack must write UTF-8 workspace XML so non-ASCII text stays literal.
+
+    With ascii output, toprettyxml escapes non-ASCII characters as numeric
+    character references, which the line-tracking parser fragments into
+    multiple TEXT_NODEs (ISSUES.md #18, root cause of issue #9).
+    """
+
+    def test_unpack_preserves_non_ascii_text(self, simple_docx, temp_dir):
+        """Unpacked document.xml keeps smart quotes/em-dash literal, no charrefs."""
+        docx = temp_dir / "smart.docx"
+        replace_document_xml(simple_docx, docx, _smart_quote_document())
+
+        unpack_document(docx, temp_dir / "output")
+
+        content = (temp_dir / "output" / "word" / "document.xml").read_text(encoding="utf-8")
+        assert SMART_TEXT in content
+        assert "&#" not in content
+
+    def test_unpack_yields_single_text_node_per_wt(self, simple_docx, temp_dir):
+        """Each non-empty w:t parses to exactly one TEXT_NODE via the editor parser."""
+        docx = temp_dir / "smart.docx"
+        replace_document_xml(simple_docx, docx, _smart_quote_document())
+
+        unpack_document(docx, temp_dir / "output")
+
+        editor = DocxXMLEditor(temp_dir / "output" / "word" / "document.xml", rsid="00AABBCC", author="Test")
+        wts = editor.dom.getElementsByTagName("w:t")
+        assert wts
+        for wt in wts:
+            text_children = [c for c in wt.childNodes if c.nodeType == c.TEXT_NODE]
+            if text_children:
+                assert len(text_children) == 1
+        assert any(wt.firstChild is not None and wt.firstChild.data == SMART_TEXT for wt in wts)
 
 
 class TestPack:

--- a/tests/test_ooxml.py
+++ b/tests/test_ooxml.py
@@ -186,11 +186,11 @@ def _smart_quote_document() -> str:
 
 
 class TestUnpackUtf8:
-    """Unpack must write UTF-8 workspace XML so non-ASCII text stays literal.
+    """Issue #9: unpack must write UTF-8 workspace XML so non-ASCII text stays literal.
 
     With ascii output, toprettyxml escapes non-ASCII characters as numeric
     character references, which the line-tracking parser fragments into
-    multiple TEXT_NODEs (ISSUES.md #18, root cause of issue #9).
+    multiple TEXT_NODEs — the root cause of the issue #9 bug class.
     """
 
     def test_unpack_preserves_non_ascii_text(self, simple_docx, temp_dir):


### PR DESCRIPTION
## Summary

`unpack_document()` pretty-printed workspace XML with `toprettyxml(encoding="ascii")`, which escaped every non-ASCII character (smart quotes, em-dashes, …) as a numeric character reference. The line-tracking parser used by `DocxXMLEditor` fragments each charref boundary into a separate TEXT_NODE, so a single `<w:t>` holding `"He said 'hello' — it's fine"` parsed back as **11 TEXT_NODEs instead of 1**. This fragmentation is the root cause of the #9 bug class (TextNotFoundError on smart quotes, split-node workarounds across track_changes / comments / foreign revisions).

This PR fixes it at the source: write workspace XML as UTF-8 (one line in `unpack.py`), so non-ASCII characters stay literal and each `w:t` parses to a single TEXT_NODE.

## Why this is safe

- **Final .docx output unchanged** — `pack.py` always serializes the packed document as UTF-8, regardless of workspace encoding.
- **Old workspaces keep working** — `xml_editor.py` sniffs the XML declaration and round-trips pre-existing `encoding="ascii"` workspaces as ascii (covered by `test_detects_ascii_encoding`).
- **Defensive layers stay in place** — existing split-node mitigations (`get_text_node_data`, condense whitelist) are kept for edge cases outside the unpack path.

## Tests

New `TestUnpackUtf8` class (written first, TDD red step confirmed the fragmentation):
- `test_unpack_preserves_non_ascii_text` — unpacked `document.xml` keeps smart quotes/em-dash literal, no `&#` charrefs.
- `test_unpack_yields_single_text_node_per_wt` — parsing the unpacked document through `DocxXMLEditor` (the exact parser path where the bug lived) yields one TEXT_NODE per non-empty `w:t`.

Full suite: **748 passed, 8 skipped** — including all issue #9 regression tests (`TestSmartQuoteEndToEnd`, split-node tests, foreign-revision em-dash/smart-quote tests). Ruff check and format clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DOCX XML extraction to preserve UTF-8 characters, including smart quotes and em dashes.
  * Prevented non-ASCII text from being converted into numeric character references.
  * Ensured extracted text remains correctly represented as single text nodes when edited.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->