### PR TITLE
feat: report list membership in ParagraphLocation

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -128,13 +128,13 @@ for start in range(1, count + 1, page_size):
 
 #### `get_paragraph_location(ref)`
 
-Report whether a paragraph lives in the document body or inside a table cell.
+Report whether a paragraph lives in the document body or inside a table cell, and whether it is a list item.
 
 **Parameters:**
 
 - `ref` (str): Paragraph reference from `list_paragraphs()`, such as `P2#f3c1`
 
-**Returns:** `ParagraphLocation`. `location.in_table` is `False` for body paragraphs; `True` when the paragraph is inside a `<w:tc>` cell, in which case `location.table` carries the 1-based table index, row, `w:gridSpan`-aware logical column, and nesting depth.
+**Returns:** `ParagraphLocation`. `location.in_table` is `False` for body paragraphs; `True` when the paragraph is inside a `<w:tc>` cell, in which case `location.table` carries the 1-based table index, row, `w:gridSpan`-aware logical column, and nesting depth. `location.list` is a `ListItem(num_id, ilvl)` for paragraphs carrying a direct `w:pPr/w:numPr`, `None` otherwise — raw values only: numbering inherited via a paragraph style is not resolved, and rendered display numbers (e.g. "7.2(a)") are not computed.
 
 **Example:**
 
@@ -143,13 +143,15 @@ loc = doc.get_paragraph_location("P3#a7b2")
 if loc.in_table:
     cell = loc.table
     print(f"table {cell.index} r{cell.row} c{cell.col} (depth {cell.depth})")
+if loc.list:
+    print(f"list numId={loc.list.num_id} level={loc.list.ilvl}")
 ```
 
 #### `list_paragraph_locations()`
 
 Batch counterpart to `get_paragraph_location()`: pair every paragraph with its structural location in one pass, precomputing table indices once instead of rescanning the table hierarchy per ref.
 
-**Returns:** List of `(ref, ParagraphLocation)` tuples in document order, where `ref` is the same `P{index}#{hash}` token emitted by `list_paragraphs()`.
+**Returns:** List of `(ref, ParagraphLocation)` tuples in document order, where `ref` is the same `P{index}#{hash}` token emitted by `list_paragraphs()`. Each location carries the same table and list info as `get_paragraph_location()`.
 
 **Example:**
 
@@ -158,6 +160,8 @@ for ref, loc in doc.list_paragraph_locations():
     if loc.in_table:
         cell = loc.table
         print(f"{ref}: table {cell.index} r{cell.row} c{cell.col} (depth {cell.depth})")
+    if loc.list:
+        print(f"{ref}: list numId={loc.list.num_id} level={loc.list.ilvl}")
 ```
 
 #### `get_visible_text()`

--- a/docx_editor/__init__.py
+++ b/docx_editor/__init__.py
@@ -56,6 +56,7 @@ from .exceptions import (
 )
 from .track_changes import EditOperation, EditValidationResult, Revision
 from .xml_editor import (
+    ListItem,
     ParagraphInfo,
     ParagraphLocation,
     ParagraphRef,
@@ -102,6 +103,7 @@ __all__ = [
     "compute_paragraph_hash",
     "find_in_text_map",
     # Paragraph location
+    "ListItem",
     "ParagraphLocation",
     "TableCell",
 ]

--- a/docx_editor/document.py
+++ b/docx_editor/document.py
@@ -359,12 +359,18 @@ class Document:
 
         Tells the caller whether a paragraph lives in the document body or
         inside a table cell, and — when in a table — gives its 1-based
-        coordinates (table index, row, logical column, depth).
+        coordinates (table index, row, logical column, depth). Also reports
+        list membership: ``location.list`` is a ``ListItem(num_id, ilvl)``
+        when the paragraph carries a direct ``w:pPr/w:numPr``, else ``None``.
 
         ``location.table.col`` is the *logical-grid* column, accounting for
         ``w:gridSpan`` of preceding cells in the same row. A cell that
         visually sits in column 4 reports ``col=4`` even when an earlier
         cell in the row spans 2 grid columns.
+
+        ``location.list`` holds raw values only: numbering inherited via a
+        paragraph style (``w:pStyle``) is not resolved, and rendered display
+        numbers (e.g. "7.2(a)") are not computed.
 
         Args:
             ref: Paragraph reference from :meth:`list_paragraphs` (e.g.,
@@ -374,6 +380,8 @@ class Document:
             :class:`ParagraphLocation`. ``location.in_table`` is ``False``
             for body paragraphs; ``True`` when the paragraph is inside a
             ``<w:tc>`` cell (in which case ``location.table`` is populated).
+            ``location.list`` is a :class:`ListItem` for list paragraphs,
+            ``None`` otherwise.
 
         Raises:
             ValueError: If ``ref`` has an invalid format.
@@ -389,6 +397,8 @@ class Document:
                 if loc.in_table:
                     cell = loc.table
                     print(f"{ref}: table {cell.index} r{cell.row} c{cell.col}")
+                if loc.list:
+                    print(f"{ref}: list numId={loc.list.num_id} level={loc.list.ilvl}")
         """
         self._ensure_open()
         parsed = ParagraphRef.parse(ref)
@@ -419,12 +429,17 @@ class Document:
             List of ``(ref, ParagraphLocation)`` tuples in document order.
             ``location.in_table`` is ``False`` for body paragraphs; ``True``
             when the paragraph is inside a ``<w:tc>`` cell.
+            ``location.list`` is a :class:`ListItem` for paragraphs with a
+            direct ``w:pPr/w:numPr``, ``None`` otherwise (raw values; no
+            style-inherited numbering, no rendered display numbers).
 
         Example:
             for ref, loc in doc.list_paragraph_locations():
                 if loc.in_table:
                     cell = loc.table
                     print(f"{ref}: table {cell.index} r{cell.row} c{cell.col}")
+                if loc.list:
+                    print(f"{ref}: list numId={loc.list.num_id} level={loc.list.ilvl}")
         """
         self._ensure_open()
         dom = self._document_editor.dom

--- a/docx_editor/xml_editor.py
+++ b/docx_editor/xml_editor.py
@@ -157,16 +157,38 @@ class TableCell:
 
 
 @dataclass(frozen=True)
+class ListItem:
+    """Raw numbering reference of a list paragraph.
+
+    Values come straight from the paragraph's direct ``<w:pPr>/<w:numPr>``:
+    ``num_id`` keys into ``word/numbering.xml``; ``ilvl`` is the 0-based
+    indentation level (0 when ``<w:ilvl>`` is absent, per spec default).
+
+    Limitations of this raw extraction: numbering inherited via a paragraph
+    style (``w:pStyle``) is NOT resolved — a paragraph numbered only through
+    its style reports ``list=None``. Rendered display numbers ("7.2(a)")
+    are not computed (that requires resolving ``word/numbering.xml``).
+    """
+
+    num_id: int  # w:numPr/w:numId/@w:val — key into word/numbering.xml
+    ilvl: int  # w:numPr/w:ilvl/@w:val — 0-based level, 0 when absent
+
+
+@dataclass(frozen=True)
 class ParagraphLocation:
     """Structural location of a paragraph within the document body.
 
-    Currently reports only table membership. The shape is intentionally
+    Reports table membership and list membership. The shape is intentionally
     extensible: future releases may add other container kinds (header,
-    footer, footnote), section index, list position, etc., as plain
-    optional field additions.
+    footer, footnote), section index, etc., as plain optional field
+    additions.
+
+    ``list`` is the paragraph's raw numbering reference (see
+    :class:`ListItem`), or ``None`` for non-list paragraphs.
     """
 
     table: TableCell | None
+    list: ListItem | None = None
 
     @property
     def in_table(self) -> bool:
@@ -295,12 +317,54 @@ def _table_depth(tbl) -> int:
     return depth
 
 
+def _direct_child(elem, tag_name: str) -> Element | None:
+    """Return the first direct child element of ``elem`` named ``tag_name``."""
+    for child in elem.childNodes:
+        if child.nodeType == child.ELEMENT_NODE and child.tagName == tag_name:
+            return child
+    return None
+
+
+def _extract_list_item(paragraph) -> ListItem | None:
+    """Raw ``<w:pPr>/<w:numPr>`` of ``paragraph``, as a :class:`ListItem`.
+
+    Walks direct children only, so a stale ``w:numPr`` inside a
+    ``<w:pPrChange>`` revision record is never picked up. Returns ``None``
+    when there is no ``w:numPr``, when ``w:numId`` is absent or malformed,
+    or when ``w:numId`` is 0 (the spec's "numbering disabled" marker).
+    ``w:ilvl`` absent/malformed → level 0 (spec default).
+    """
+    ppr = _direct_child(paragraph, "w:pPr")
+    if ppr is None:
+        return None
+    numpr = _direct_child(ppr, "w:numPr")
+    if numpr is None:
+        return None
+    numid_elem = _direct_child(numpr, "w:numId")
+    if numid_elem is None:
+        return None
+    try:
+        num_id = int(numid_elem.getAttribute("w:val"))
+    except ValueError:
+        return None
+    if num_id < 1:
+        return None
+    ilvl = 0
+    ilvl_elem = _direct_child(numpr, "w:ilvl")
+    if ilvl_elem is not None:
+        try:
+            ilvl = max(0, int(ilvl_elem.getAttribute("w:val")))
+        except ValueError:
+            ilvl = 0
+    return ListItem(num_id=num_id, ilvl=ilvl)
+
+
 def _compute_paragraph_location(paragraph, table_index: dict | None = None) -> ParagraphLocation:
     """Compute the structural location of a ``<w:p>`` element.
 
-    Reports the innermost enclosing ``<w:tc>`` (and its table), or
-    ``ParagraphLocation(table=None)`` if the paragraph is not inside any
-    table cell.
+    Reports the innermost enclosing ``<w:tc>`` (and its table) plus the
+    paragraph's raw list membership (see :func:`_extract_list_item`), or
+    ``ParagraphLocation(table=None, list=None)`` for a plain body paragraph.
 
     ``table_index`` is an optional ``{tbl_node: 1-based-index}`` map (see
     :func:`_build_table_index`). When supplied, the enclosing table's index
@@ -308,14 +372,15 @@ def _compute_paragraph_location(paragraph, table_index: dict | None = None) -> P
     fast path. The result is identical to the ``None`` (per-call) path; a
     table missing from the map falls back to the rescan defensively.
     """
+    list_item = _extract_list_item(paragraph)
     tc = _innermost_ancestor(paragraph, "w:tc")
     if tc is None:
-        return ParagraphLocation(table=None)
+        return ParagraphLocation(table=None, list=list_item)
     tr = _innermost_ancestor(tc, "w:tr")
     tbl = _innermost_ancestor(tr, "w:tbl") if tr is not None else None
     if tr is None or tbl is None:
         # Malformed table structure — tolerate by treating as body content.
-        return ParagraphLocation(table=None)
+        return ParagraphLocation(table=None, list=list_item)
     if table_index is not None and tbl in table_index:
         index = table_index[tbl]
     else:
@@ -326,7 +391,8 @@ def _compute_paragraph_location(paragraph, table_index: dict | None = None) -> P
             row=_row_index_in_table(tbl, tr),
             col=_logical_col_in_row(tr, tc),
             depth=_table_depth(tbl),
-        )
+        ),
+        list=list_item,
     )
 
 

--- a/skills/docx/SKILL.md
+++ b/skills/docx/SKILL.md
@@ -224,6 +224,13 @@ match = doc.find_text("30 days")
 # Get all visible text (inserted text included, deleted text excluded)
 visible = doc.get_visible_text()
 
+# Structural location: table cell and/or list item (raw numId/ilvl)
+loc = doc.get_paragraph_location("P3#b2c4")
+if loc.table:
+    print(f"table {loc.table.index} r{loc.table.row} c{loc.table.col}")
+if loc.list:
+    print(f"list numId={loc.list.num_id} level={loc.list.ilvl}")
+
 # All edit methods return the new paragraph ref as a plain string.
 # Use it for follow-up edits on the same paragraph:
 new_ref = doc.replace("30 days", "60 days", paragraph="P2#f3c1")

--- a/tests/test_paragraph_location.py
+++ b/tests/test_paragraph_location.py
@@ -7,6 +7,8 @@ Covers:
     ``<w:tc>`` count
   * nested tables increment ``depth`` and produce a depth-first doc-wide
     table ``index``
+  * list paragraphs report ``ListItem(num_id, ilvl)`` from their direct
+    ``w:pPr/w:numPr``; non-list paragraphs report ``list=None``
   * stale refs raise ``HashMismatchError``; out-of-range refs raise
     ``ParagraphIndexError``
 
@@ -23,6 +25,7 @@ from conftest import replace_document_xml
 from docx_editor import (
     Document,
     HashMismatchError,
+    ListItem,
     ParagraphIndexError,
     ParagraphLocation,
     TableCell,
@@ -97,6 +100,50 @@ def gridspan_docx(simple_docx, tmp_path) -> Path:
     """A .docx whose body contains a gridSpan row and a nested table."""
     dest = tmp_path / "gridspan.docx"
     replace_document_xml(simple_docx, dest, _build_document_xml())
+    return dest
+
+
+def _num_pr(num_id: str, ilvl: str | None) -> str:
+    """``<w:pPr><w:numPr>...`` block with the given numId and optional ilvl."""
+    ilvl_xml = f'<w:ilvl w:val="{ilvl}"/>' if ilvl is not None else ""
+    return f'<w:pPr><w:numPr>{ilvl_xml}<w:numId w:val="{num_id}"/></w:numPr></w:pPr>'
+
+
+def _build_numbered_document_xml() -> str:
+    """Hand-written ``word/document.xml`` with numbered paragraphs.
+
+    Layout (unique text snippets for ``_ref_for_text``):
+
+      "Plain paragraph"    body, no numPr                  → list=None
+      "Numbered top"       numId=5, ilvl=0                 → ListItem(5, 0)
+      "Numbered nested"    numId=5, ilvl=1                 → ListItem(5, 1)
+      "Numbered deeper"    numId=5, ilvl=2                 → ListItem(5, 2)
+      "Numbered no ilvl"   numId=5, no <w:ilvl>            → ListItem(5, 0)
+      "Cell numbered"      table cell + numId=7, ilvl=0    → table AND list
+    """
+    return (
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+        f"<w:document {_W_NS}>"
+        "<w:body>"
+        "<w:p><w:r><w:t>Plain paragraph</w:t></w:r></w:p>"
+        f"<w:p>{_num_pr('5', '0')}<w:r><w:t>Numbered top</w:t></w:r></w:p>"
+        f"<w:p>{_num_pr('5', '1')}<w:r><w:t>Numbered nested</w:t></w:r></w:p>"
+        f"<w:p>{_num_pr('5', '2')}<w:r><w:t>Numbered deeper</w:t></w:r></w:p>"
+        f"<w:p>{_num_pr('5', None)}<w:r><w:t>Numbered no ilvl</w:t></w:r></w:p>"
+        # --- a one-cell table whose paragraph is itself numbered ---
+        "<w:tbl><w:tr><w:tc>"
+        f"<w:p>{_num_pr('7', '0')}<w:r><w:t>Cell numbered</w:t></w:r></w:p>"
+        "</w:tc></w:tr></w:tbl>"
+        "</w:body>"
+        "</w:document>"
+    )
+
+
+@pytest.fixture
+def numbered_docx(simple_docx, tmp_path) -> Path:
+    """A .docx with numbered paragraphs at several levels, incl. one in a table."""
+    dest = tmp_path / "numbered.docx"
+    replace_document_xml(simple_docx, dest, _build_numbered_document_xml())
     return dest
 
 
@@ -587,3 +634,130 @@ class TestListParagraphLocations:
             assert entries  # simple.docx has at least one paragraph
             assert all(loc.table is None for _, loc in entries)
             assert all(loc.in_table is False for _, loc in entries)
+
+
+class TestParagraphLocationList:
+    """``location.list`` reports the raw ``w:pPr/w:numPr`` of the paragraph."""
+
+    def test_numbered_paragraph_reports_list_item(self, numbered_docx):
+        with Document.open(numbered_docx) as doc:
+            loc = doc.get_paragraph_location(_ref_for_text(doc, "Numbered top"))
+            assert loc.list == ListItem(num_id=5, ilvl=0)
+
+    def test_returns_list_item_dataclass(self, numbered_docx):
+        """API contract: ``loc.list`` is a ``ListItem``, not a tuple or dict."""
+        with Document.open(numbered_docx) as doc:
+            loc = doc.get_paragraph_location(_ref_for_text(doc, "Numbered top"))
+            assert isinstance(loc.list, ListItem)
+
+    def test_plain_paragraph_reports_none(self, numbered_docx):
+        with Document.open(numbered_docx) as doc:
+            loc = doc.get_paragraph_location(_ref_for_text(doc, "Plain paragraph"))
+            assert loc.list is None
+
+    def test_nested_levels_report_ilvl(self, numbered_docx):
+        with Document.open(numbered_docx) as doc:
+            loc_1 = doc.get_paragraph_location(_ref_for_text(doc, "Numbered nested"))
+            loc_2 = doc.get_paragraph_location(_ref_for_text(doc, "Numbered deeper"))
+            assert loc_1.list == ListItem(num_id=5, ilvl=1)
+            assert loc_2.list == ListItem(num_id=5, ilvl=2)
+
+    def test_missing_ilvl_defaults_to_zero(self, numbered_docx):
+        """``<w:numPr>`` without ``<w:ilvl>`` → level 0 (spec default)."""
+        with Document.open(numbered_docx) as doc:
+            loc = doc.get_paragraph_location(_ref_for_text(doc, "Numbered no ilvl"))
+            assert loc.list == ListItem(num_id=5, ilvl=0)
+
+
+class TestParagraphLocationListInTable:
+    """Table membership and list membership are independent axes."""
+
+    def test_cell_paragraph_reports_both(self, numbered_docx):
+        with Document.open(numbered_docx) as doc:
+            loc = doc.get_paragraph_location(_ref_for_text(doc, "Cell numbered"))
+            assert loc.in_table is True
+            assert loc.table == TableCell(index=1, row=1, col=1, depth=1)
+            assert loc.list == ListItem(num_id=7, ilvl=0)
+
+
+class TestParagraphLocationListMalformed:
+    """Defensive paths in ``_extract_list_item`` — malformed or spec-edge
+    ``w:numPr`` blocks must degrade to ``None`` (or ilvl=0), never raise.
+    """
+
+    @staticmethod
+    def _doc_with_p_pr(p_pr_xml: str) -> str:
+        """Single paragraph carrying ``p_pr_xml`` (the ``<w:pPr>`` block under test)."""
+        return (
+            '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+            f"<w:document {_W_NS}>"
+            "<w:body>"
+            f"<w:p>{p_pr_xml}<w:r><w:t>Target</w:t></w:r></w:p>"
+            "</w:body>"
+            "</w:document>"
+        )
+
+    @staticmethod
+    def _open(simple_docx: Path, tmp_path: Path, body_xml: str) -> Document:
+        dest = tmp_path / "list-malformed.docx"
+        replace_document_xml(simple_docx, dest, body_xml)
+        return Document.open(dest)
+
+    def test_num_pr_without_num_id_reports_none(self, simple_docx, tmp_path):
+        body = self._doc_with_p_pr('<w:pPr><w:numPr><w:ilvl w:val="1"/></w:numPr></w:pPr>')
+        with self._open(simple_docx, tmp_path, body) as doc:
+            loc = doc.get_paragraph_location(_ref_for_text(doc, "Target"))
+            assert loc.list is None
+
+    def test_num_id_zero_reports_none(self, simple_docx, tmp_path):
+        """``numId=0`` is the spec's "numbering disabled" marker, not a list."""
+        body = self._doc_with_p_pr(_num_pr("0", "0"))
+        with self._open(simple_docx, tmp_path, body) as doc:
+            loc = doc.get_paragraph_location(_ref_for_text(doc, "Target"))
+            assert loc.list is None
+
+    def test_non_integer_num_id_reports_none(self, simple_docx, tmp_path):
+        body = self._doc_with_p_pr(_num_pr("abc", "0"))
+        with self._open(simple_docx, tmp_path, body) as doc:
+            loc = doc.get_paragraph_location(_ref_for_text(doc, "Target"))
+            assert loc.list is None
+
+    def test_num_id_without_val_reports_none(self, simple_docx, tmp_path):
+        body = self._doc_with_p_pr("<w:pPr><w:numPr><w:numId/></w:numPr></w:pPr>")
+        with self._open(simple_docx, tmp_path, body) as doc:
+            loc = doc.get_paragraph_location(_ref_for_text(doc, "Target"))
+            assert loc.list is None
+
+    def test_non_integer_ilvl_falls_back_to_zero(self, simple_docx, tmp_path):
+        """Malformed ``w:ilvl`` doesn't discard the (valid) numId — level 0."""
+        body = self._doc_with_p_pr(_num_pr("5", "abc"))
+        with self._open(simple_docx, tmp_path, body) as doc:
+            loc = doc.get_paragraph_location(_ref_for_text(doc, "Target"))
+            assert loc.list == ListItem(num_id=5, ilvl=0)
+
+    def test_stale_num_pr_inside_p_pr_change_is_ignored(self, simple_docx, tmp_path):
+        """``w:pPrChange`` nests a *former* ``w:pPr`` (revision record); a
+        ``w:numPr`` found only there must not be reported — direct-child
+        walk regression guard against descendant search.
+        """
+        body = self._doc_with_p_pr(
+            "<w:pPr>"
+            '<w:pPrChange w:id="1" w:author="A" w:date="2026-01-01T00:00:00Z">'
+            '<w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="9"/></w:numPr></w:pPr>'
+            "</w:pPrChange>"
+            "</w:pPr>"
+        )
+        with self._open(simple_docx, tmp_path, body) as doc:
+            loc = doc.get_paragraph_location(_ref_for_text(doc, "Target"))
+            assert loc.list is None
+
+
+class TestListParagraphLocationsListInfo:
+    """Batch accessor carries the same list info as the per-call accessor."""
+
+    def test_equivalence_with_per_call_accessor(self, numbered_docx):
+        with Document.open(numbered_docx) as doc:
+            entries = doc.list_paragraph_locations()
+            for ref, loc in entries:
+                assert loc == doc.get_paragraph_location(ref)
+            assert any(loc.list is not None for _, loc in entries)


### PR DESCRIPTION
## Summary

`ParagraphLocation` gains a `list` field: a `ListItem(num_id, ilvl)` extracted from the paragraph's direct `w:pPr/w:numPr`, or `None` for non-list paragraphs. Exposed identically via `get_paragraph_location()` and `list_paragraph_locations()`; `ListItem` is exported from the package root.

Raw values only: numbering inherited via a paragraph style (`w:pStyle`) is not resolved, and rendered display numbers (e.g. "7.2(a)") are not computed — both are follow-up work.

## Details

- Direct-child walk (`_extract_list_item`) never uses descendant search, so a stale `w:numPr` inside a `w:pPrChange` revision record is ignored (regression-tested).
- `numId=0` — the spec's numbering-disabled marker — and malformed/missing `numId` report `None`; missing or malformed `w:ilvl` defaults to level 0 per spec. Malformed XML never raises, matching the module's existing defensive precedent.
- The new field is defaulted (`= None`), so existing `ParagraphLocation` consumers and equality semantics are unchanged.
- Table and list membership are independent axes: a numbered paragraph inside a table cell reports both.
- Docs updated: `docs/api.md`, `skills/docx/SKILL.md`, docstrings.

## Testing

- 13 new tests: happy paths (ilvl 0/1/2, missing ilvl default), table+list independence, 6 malformed/spec-edge cases incl. the `w:pPrChange` guard, batch/per-call equivalence.
- Full suite: 759 passed, 8 skipped. `ruff check` and `ruff format --check` clean.