### PR TITLE
Report style, outline level, and heading path in ParagraphLocation

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -128,13 +128,15 @@ for start in range(1, count + 1, page_size):
 
 #### `get_paragraph_location(ref)`
 
-Report whether a paragraph lives in the document body or inside a table cell, and whether it is a list item.
+Report whether a paragraph lives in the document body or inside a table cell, whether it is a list item, and its heading context (style, outline level, and the chain of headings above it).
 
 **Parameters:**
 
 - `ref` (str): Paragraph reference from `list_paragraphs()`, such as `P2#f3c1`
 
 **Returns:** `ParagraphLocation`. `location.in_table` is `False` for body paragraphs; `True` when the paragraph is inside a `<w:tc>` cell, in which case `location.table` carries the 1-based table index, row, `w:gridSpan`-aware logical column, and nesting depth. `location.list` is a `ListItem(num_id, ilvl)` for paragraphs carrying a direct `w:pPr/w:numPr`, `None` otherwise — raw values only: numbering inherited via a paragraph style is not resolved, and rendered display numbers (e.g. "7.2(a)") are not computed.
+
+`location.style` is the raw `w:pStyle` style id (e.g. `"Heading1"`), `None` when the paragraph carries no explicit style — no name resolution against `word/styles.xml`. `location.outline_level` is the 0-based outline level (`0` == Heading 1, so a document heading level is `outline_level + 1`): a direct `w:outlineLvl` on the paragraph wins, and the spec's `w:val="9"` marker means body text (`None`); otherwise the level defined by the paragraph's style applies, with `w:basedOn` inheritance chains resolved. `location.heading_path` is the chain of nearest preceding headings that contains the paragraph, outermost first (e.g. `("Chapter one", "Termination")`), built from each heading's current visible text; a heading's own path lists only its ancestors, never itself. Headings inside table cells participate in document order.
 
 **Example:**
 
@@ -145,13 +147,16 @@ if loc.in_table:
     print(f"table {cell.index} r{cell.row} c{cell.col} (depth {cell.depth})")
 if loc.list:
     print(f"list numId={loc.list.num_id} level={loc.list.ilvl}")
+if loc.outline_level is not None:
+    print(f"heading level {loc.outline_level + 1}: style={loc.style}")
+print(" > ".join(loc.heading_path))  # e.g. "Chapter one > Termination"
 ```
 
 #### `list_paragraph_locations()`
 
-Batch counterpart to `get_paragraph_location()`: pair every paragraph with its structural location in one pass, precomputing table indices once instead of rescanning the table hierarchy per ref.
+Batch counterpart to `get_paragraph_location()`: pair every paragraph with its structural location in one pass, precomputing table indices, style outline levels, and heading paths once instead of rescanning the document per ref.
 
-**Returns:** List of `(ref, ParagraphLocation)` tuples in document order, where `ref` is the same `P{index}#{hash}` token emitted by `list_paragraphs()`. Each location carries the same table and list info as `get_paragraph_location()`.
+**Returns:** List of `(ref, ParagraphLocation)` tuples in document order, where `ref` is the same `P{index}#{hash}` token emitted by `list_paragraphs()`. Each location carries the same table, list, style, outline-level, and heading-path info as `get_paragraph_location()`.
 
 **Example:**
 
@@ -162,6 +167,8 @@ for ref, loc in doc.list_paragraph_locations():
         print(f"{ref}: table {cell.index} r{cell.row} c{cell.col} (depth {cell.depth})")
     if loc.list:
         print(f"{ref}: list numId={loc.list.num_id} level={loc.list.ilvl}")
+    if loc.heading_path:
+        print(f"{ref}: under {' > '.join(loc.heading_path)}")
 ```
 
 #### `get_visible_text()`

--- a/docx_editor/document.py
+++ b/docx_editor/document.py
@@ -427,6 +427,10 @@ class Document:
         excludes itself. Headings inside table cells participate in
         document order.
 
+        Heading context is derived from whole-document scans on every
+        call; to locate many paragraphs, prefer
+        :meth:`list_paragraph_locations`, which precomputes it once.
+
         Args:
             ref: Paragraph reference from :meth:`list_paragraphs` (e.g.,
                 ``"P3#a7b2"``).
@@ -448,17 +452,15 @@ class Document:
                 was captured).
 
         Example:
-            for entry in doc.list_paragraphs():
-                ref = entry.split("|")[0]
-                loc = doc.get_paragraph_location(ref)
-                if loc.in_table:
-                    cell = loc.table
-                    print(f"{ref}: table {cell.index} r{cell.row} c{cell.col}")
-                if loc.list:
-                    print(f"{ref}: list numId={loc.list.num_id} level={loc.list.ilvl}")
-                if loc.outline_level is not None:
-                    print(f"{ref}: heading level {loc.outline_level + 1}")
-                print(f"{ref}: under {' > '.join(loc.heading_path) or '(no heading)'}")
+            loc = doc.get_paragraph_location("P3#a7b2")
+            if loc.in_table:
+                cell = loc.table
+                print(f"table {cell.index} r{cell.row} c{cell.col}")
+            if loc.list:
+                print(f"list numId={loc.list.num_id} level={loc.list.ilvl}")
+            if loc.outline_level is not None:
+                print(f"heading level {loc.outline_level + 1}")
+            print(f"under {' > '.join(loc.heading_path) or '(no heading)'}")
         """
         self._ensure_open()
         parsed = ParagraphRef.parse(ref)

--- a/docx_editor/document.py
+++ b/docx_editor/document.py
@@ -20,7 +20,10 @@ from .xml_editor import (
     ParagraphInfo,
     ParagraphLocation,
     ParagraphRef,
+    XMLEditor,
+    _build_style_outline_map,
     _build_table_index,
+    _compute_heading_paths,
     _compute_paragraph_location,
     build_text_map,
     compute_paragraph_hash,
@@ -383,6 +386,17 @@ class Document:
         h = compute_paragraph_hash(p)
         return ParagraphInfo(index=index, ref=f"P{index}#{h}", text=build_text_map(p).text)
 
+    def _style_outline_map(self) -> dict[str, int]:
+        """Outline levels defined by paragraph styles in ``word/styles.xml``.
+
+        Parsed per call (no caching, matching the per-call table rescan
+        philosophy); a document without a styles part degrades to ``{}``.
+        """
+        styles_path = self._workspace.word_path / "styles.xml"
+        if not styles_path.exists():
+            return {}
+        return _build_style_outline_map(XMLEditor(styles_path).dom)
+
     def get_paragraph_location(self, ref: str) -> ParagraphLocation:
         """Return the structural location of the paragraph identified by ``ref``.
 
@@ -401,6 +415,18 @@ class Document:
         paragraph style (``w:pStyle``) is not resolved, and rendered display
         numbers (e.g. "7.2(a)") are not computed.
 
+        ``location.style`` is the raw ``w:pStyle`` style id (e.g.
+        ``"Heading1"``), ``None`` when absent. ``location.outline_level``
+        is the 0-based outline level (0 == Heading 1): a direct
+        ``w:outlineLvl`` on the paragraph wins (the spec's ``w:val="9"``
+        means body text → ``None``); otherwise the level defined by the
+        paragraph's style in ``word/styles.xml`` applies, with ``w:basedOn``
+        chains resolved. ``location.heading_path`` is the chain of nearest
+        preceding headings containing the paragraph, outermost first,
+        using each heading's current visible text; a heading's own path
+        excludes itself. Headings inside table cells participate in
+        document order.
+
         Args:
             ref: Paragraph reference from :meth:`list_paragraphs` (e.g.,
                 ``"P3#a7b2"``).
@@ -410,7 +436,9 @@ class Document:
             for body paragraphs; ``True`` when the paragraph is inside a
             ``<w:tc>`` cell (in which case ``location.table`` is populated).
             ``location.list`` is a :class:`ListItem` for list paragraphs,
-            ``None`` otherwise.
+            ``None`` otherwise. ``location.style``,
+            ``location.outline_level`` and ``location.heading_path`` carry
+            the paragraph's heading context as described above.
 
         Raises:
             ValueError: If ``ref`` has an invalid format.
@@ -428,6 +456,9 @@ class Document:
                     print(f"{ref}: table {cell.index} r{cell.row} c{cell.col}")
                 if loc.list:
                     print(f"{ref}: list numId={loc.list.num_id} level={loc.list.ilvl}")
+                if loc.outline_level is not None:
+                    print(f"{ref}: heading level {loc.outline_level + 1}")
+                print(f"{ref}: under {' > '.join(loc.heading_path) or '(no heading)'}")
         """
         self._ensure_open()
         parsed = ParagraphRef.parse(ref)
@@ -442,17 +473,19 @@ class Document:
             if len(tm.text) > 80:
                 preview += "..."
             raise HashMismatchError(parsed.index, parsed.hash, actual_hash, preview)
-        return _compute_paragraph_location(p)
+        style_outlines = self._style_outline_map()
+        heading_path = _compute_heading_paths(paragraphs[: parsed.index], style_outlines)[-1]
+        return _compute_paragraph_location(p, style_outlines=style_outlines, heading_path=heading_path)
 
     def list_paragraph_locations(self) -> list[tuple[str, ParagraphLocation]]:
         """List every paragraph paired with its structural location.
 
         Batch counterpart to :meth:`get_paragraph_location`: precomputes
-        table indices once instead of re-scanning the table hierarchy per
-        ref. Each entry is ``(ref, location)`` where
-        ``ref`` is the same ``"P{i}#{hash}"`` token emitted by
-        :meth:`list_paragraphs` (the part before ``|``) and accepted by
-        :meth:`get_paragraph_location` and the editing methods.
+        table indices, style outline levels, and heading paths once instead
+        of re-scanning the document per ref. Each entry is ``(ref,
+        location)`` where ``ref`` is the same ``"P{i}#{hash}"`` token
+        emitted by :meth:`list_paragraphs` (the part before ``|``) and
+        accepted by :meth:`get_paragraph_location` and the editing methods.
 
         Returns:
             List of ``(ref, ParagraphLocation)`` tuples in document order.
@@ -461,6 +494,9 @@ class Document:
             ``location.list`` is a :class:`ListItem` for paragraphs with a
             direct ``w:pPr/w:numPr``, ``None`` otherwise (raw values; no
             style-inherited numbering, no rendered display numbers).
+            ``location.style``, ``location.outline_level`` and
+            ``location.heading_path`` carry the paragraph's heading context
+            with the same semantics as :meth:`get_paragraph_location`.
 
         Example:
             for ref, loc in doc.list_paragraph_locations():
@@ -469,14 +505,21 @@ class Document:
                     print(f"{ref}: table {cell.index} r{cell.row} c{cell.col}")
                 if loc.list:
                     print(f"{ref}: list numId={loc.list.num_id} level={loc.list.ilvl}")
+                print(f"{ref}: under {' > '.join(loc.heading_path) or '(no heading)'}")
         """
         self._ensure_open()
         dom = self._document_editor.dom
         table_index = _build_table_index(dom)
+        style_outlines = self._style_outline_map()
+        paragraphs = dom.getElementsByTagName("w:p")
+        heading_paths = _compute_heading_paths(paragraphs, style_outlines)
         result = []
-        for i, p in enumerate(dom.getElementsByTagName("w:p"), start=1):
+        for i, (p, path) in enumerate(zip(paragraphs, heading_paths, strict=True), start=1):
             ref = f"P{i}#{compute_paragraph_hash(p)}"
-            result.append((ref, _compute_paragraph_location(p, table_index)))
+            result.append((
+                ref,
+                _compute_paragraph_location(p, table_index, style_outlines=style_outlines, heading_path=path),
+            ))
         return result
 
     def get_visible_text(self) -> str:

--- a/docx_editor/xml_editor.py
+++ b/docx_editor/xml_editor.py
@@ -178,17 +178,35 @@ class ListItem:
 class ParagraphLocation:
     """Structural location of a paragraph within the document body.
 
-    Reports table membership and list membership. The shape is intentionally
-    extensible: future releases may add other container kinds (header,
-    footer, footnote), section index, etc., as plain optional field
-    additions.
+    Reports table membership, list membership, and heading context. The
+    shape is intentionally extensible: future releases may add other
+    container kinds (header, footer, footnote), section index, etc., as
+    plain optional field additions.
 
     ``list`` is the paragraph's raw numbering reference (see
     :class:`ListItem`), or ``None`` for non-list paragraphs.
+
+    ``style`` is the raw ``w:pPr/w:pStyle/@w:val`` style id (a key into
+    ``word/styles.xml``, e.g. ``"Heading1"``), or ``None`` when the
+    paragraph carries no explicit style. No name resolution is performed.
+
+    ``outline_level`` is the paragraph's 0-based outline level (0 ==
+    Heading 1). A direct ``w:pPr/w:outlineLvl`` wins; absent that, the
+    level defined by the paragraph's style (``w:basedOn`` chains resolved)
+    applies. ``None`` means body text — including the spec's explicit
+    "no outline" marker ``w:val="9"``.
+
+    ``heading_path`` is the chain of nearest preceding headings that
+    contains this paragraph, outermost first (e.g. ``("Chapter one",
+    "Termination")``), using each heading's current visible text. A
+    heading's own path lists only its ancestors, never itself.
     """
 
     table: TableCell | None
     list: ListItem | None = None
+    style: str | None = None
+    outline_level: int | None = None
+    heading_path: tuple[str, ...] = ()
 
     @property
     def in_table(self) -> bool:
@@ -359,28 +377,158 @@ def _extract_list_item(paragraph) -> ListItem | None:
     return ListItem(num_id=num_id, ilvl=ilvl)
 
 
-def _compute_paragraph_location(paragraph, table_index: dict | None = None) -> ParagraphLocation:
+def _extract_style(paragraph) -> str | None:
+    """Raw ``<w:pPr>/<w:pStyle>/@w:val`` of ``paragraph``, or ``None``.
+
+    Walks direct children only, so a stale ``w:pStyle`` inside a
+    ``<w:pPrChange>`` revision record is never picked up. Returns ``None``
+    when there is no ``w:pStyle`` or its ``w:val`` is absent/empty.
+    """
+    ppr = _direct_child(paragraph, "w:pPr")
+    if ppr is None:
+        return None
+    pstyle = _direct_child(ppr, "w:pStyle")
+    if pstyle is None:
+        return None
+    return pstyle.getAttribute("w:val") or None
+
+
+def _parse_outline_level(outline_elem) -> int | None:
+    """Parse a ``<w:outlineLvl>`` element's ``w:val`` as an outline level.
+
+    Valid levels are ``0..8`` (0 == Heading 1). ``9`` is the spec's
+    explicit "no outline level / body text" marker; it, out-of-range, and
+    malformed values all return ``None``.
+    """
+    try:
+        level = int(outline_elem.getAttribute("w:val"))
+    except ValueError:
+        return None
+    return level if 0 <= level <= 8 else None
+
+
+def _extract_outline_level(paragraph, style: str | None, style_outlines: dict[str, int]) -> int | None:
+    """Effective outline level of ``paragraph`` (0-based, ``None`` = body text).
+
+    A direct ``<w:pPr>/<w:outlineLvl>`` always wins: when the element is
+    present, its value decides (``9``, out-of-range, or malformed →
+    ``None`` — no style fallback, matching OOXML direct-formatting
+    override semantics). When absent, the level defined by ``style`` in
+    ``style_outlines`` (see :func:`_build_style_outline_map`) applies.
+    Direct-child walk only, so ``<w:pPrChange>`` decoys are ignored.
+    """
+    ppr = _direct_child(paragraph, "w:pPr")
+    outline_elem = _direct_child(ppr, "w:outlineLvl") if ppr is not None else None
+    if outline_elem is not None:
+        return _parse_outline_level(outline_elem)
+    if style is not None:
+        return style_outlines.get(style)
+    return None
+
+
+def _build_style_outline_map(styles_dom) -> dict[str, int]:
+    """Map paragraph-style ids to their effective 0-based outline level.
+
+    One pass over ``<w:style w:type="paragraph">`` elements collects each
+    style's own ``<w:pPr>/<w:outlineLvl>`` and its ``w:basedOn`` parent; a
+    second pass resolves ``basedOn`` chains (visited-set cycle guard) so a
+    custom style based on e.g. ``Heading1`` without restating the level
+    inherits it. A *present* ``w:outlineLvl`` terminates the chain even
+    when it yields no level (``w:val="9"`` explicitly resets to body text
+    — Word's ``TOCHeading`` based on ``Heading1`` relies on this). Styles
+    that end up with no outline level are omitted from the map.
+    """
+    raw: dict[str, tuple[int | None, bool, str | None]] = {}
+    for style in styles_dom.getElementsByTagName("w:style"):
+        if style.getAttribute("w:type") != "paragraph":
+            continue
+        style_id = style.getAttribute("w:styleId")
+        if not style_id:
+            continue
+        ppr = _direct_child(style, "w:pPr")
+        outline_elem = _direct_child(ppr, "w:outlineLvl") if ppr is not None else None
+        level = _parse_outline_level(outline_elem) if outline_elem is not None else None
+        based_on_elem = _direct_child(style, "w:basedOn")
+        based_on = based_on_elem.getAttribute("w:val") if based_on_elem is not None else None
+        raw[style_id] = (level, outline_elem is not None, based_on or None)
+
+    resolved: dict[str, int] = {}
+    for style_id in raw:
+        current: str | None = style_id
+        visited: set[str] = set()
+        while current is not None and current in raw and current not in visited:
+            visited.add(current)
+            level, has_own_outline, based_on = raw[current]
+            if has_own_outline:
+                if level is not None:
+                    resolved[style_id] = level
+                break
+            current = based_on
+    return resolved
+
+
+def _compute_heading_paths(paragraphs, style_outlines: dict[str, int]) -> list[tuple[str, ...]]:
+    """Heading-ancestor path for each of ``paragraphs`` (document order).
+
+    Single forward pass maintaining a stack of open headings. A heading at
+    outline level L first pops all open headings at level >= L (so its own
+    recorded path lists only its ancestors, never itself or a sibling),
+    then pushes its current visible text (insertions included, deletions
+    excluded, per :func:`build_text_map`). Non-heading paragraphs record
+    the stack as-is.
+    """
+    paths: list[tuple[str, ...]] = []
+    stack: list[tuple[int, str]] = []  # (outline_level, heading text)
+    for p in paragraphs:
+        level = _extract_outline_level(p, _extract_style(p), style_outlines)
+        if level is not None:
+            while stack and stack[-1][0] >= level:
+                stack.pop()
+        paths.append(tuple(text for _, text in stack))
+        if level is not None:
+            stack.append((level, build_text_map(p).text))
+    return paths
+
+
+def _compute_paragraph_location(
+    paragraph,
+    table_index: dict | None = None,
+    style_outlines: dict[str, int] | None = None,
+    heading_path: tuple[str, ...] = (),
+) -> ParagraphLocation:
     """Compute the structural location of a ``<w:p>`` element.
 
     Reports the innermost enclosing ``<w:tc>`` (and its table) plus the
-    paragraph's raw list membership (see :func:`_extract_list_item`), or
-    ``ParagraphLocation(table=None, list=None)`` for a plain body paragraph.
+    paragraph's raw list membership (see :func:`_extract_list_item`),
+    style id, and outline level; a plain body paragraph gets ``table=None``.
 
     ``table_index`` is an optional ``{tbl_node: 1-based-index}`` map (see
     :func:`_build_table_index`). When supplied, the enclosing table's index
     is looked up there instead of via a whole-document rescan — the batch
     fast path. The result is identical to the ``None`` (per-call) path; a
     table missing from the map falls back to the rescan defensively.
+
+    ``style_outlines`` is an optional precomputed ``{style_id:
+    outline_level}`` map (see :func:`_build_style_outline_map`) used to
+    resolve style-defined outline levels; ``None`` behaves like ``{}``.
+    ``heading_path`` is threaded through verbatim — computing it needs
+    whole-document context (see :func:`_compute_heading_paths`).
     """
     list_item = _extract_list_item(paragraph)
+    style = _extract_style(paragraph)
+    outline_level = _extract_outline_level(paragraph, style, style_outlines or {})
     tc = _innermost_ancestor(paragraph, "w:tc")
     if tc is None:
-        return ParagraphLocation(table=None, list=list_item)
+        return ParagraphLocation(
+            table=None, list=list_item, style=style, outline_level=outline_level, heading_path=heading_path
+        )
     tr = _innermost_ancestor(tc, "w:tr")
     tbl = _innermost_ancestor(tr, "w:tbl") if tr is not None else None
     if tr is None or tbl is None:
         # Malformed table structure — tolerate by treating as body content.
-        return ParagraphLocation(table=None, list=list_item)
+        return ParagraphLocation(
+            table=None, list=list_item, style=style, outline_level=outline_level, heading_path=heading_path
+        )
     if table_index is not None and tbl in table_index:
         index = table_index[tbl]
     else:
@@ -393,6 +541,9 @@ def _compute_paragraph_location(paragraph, table_index: dict | None = None) -> P
             depth=_table_depth(tbl),
         ),
         list=list_item,
+        style=style,
+        outline_level=outline_level,
+        heading_path=heading_path,
     )
 
 

--- a/skills/docx/SKILL.md
+++ b/skills/docx/SKILL.md
@@ -226,12 +226,15 @@ match = doc.find_text("30 days")
 # Get all visible text (inserted text included, deleted text excluded)
 visible = doc.get_visible_text()
 
-# Structural location: table cell and/or list item (raw numId/ilvl)
+# Structural location: table cell, list item (raw numId/ilvl), and heading context
 loc = doc.get_paragraph_location("P3#b2c4")
 if loc.table:
     print(f"table {loc.table.index} r{loc.table.row} c{loc.table.col}")
 if loc.list:
     print(f"list numId={loc.list.num_id} level={loc.list.ilvl}")
+if loc.outline_level is not None:  # 0-based; 0 == Heading 1
+    print(f"heading level {loc.outline_level + 1}: style={loc.style}")
+print(" > ".join(loc.heading_path))  # e.g. "Chapter one > Termination"
 
 # All edit methods return the new paragraph ref as a plain string.
 # Use it for follow-up edits on the same paragraph:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,15 +17,29 @@ def find_ref(doc, text):
     raise ValueError(f"Paragraph containing '{text}' not found")
 
 
-def replace_document_xml(src: Path, dest: Path, new_doc_xml: str) -> None:
-    """Copy ``src`` to ``dest``, swapping ``word/document.xml`` for ``new_doc_xml``."""
+def replace_docx_parts(src: Path, dest: Path, parts: dict[str, str | None]) -> None:
+    """Copy ``src`` to ``dest``, swapping each archive part named in ``parts``.
+
+    Keys are archive paths (e.g. ``"word/styles.xml"``); a ``None`` value
+    drops the part from the copy entirely.
+    """
     with (
         zipfile.ZipFile(src, "r") as z_in,
         zipfile.ZipFile(dest, "w", zipfile.ZIP_DEFLATED) as z_out,
     ):
         for item in z_in.infolist():
-            data = new_doc_xml.encode("utf-8") if item.filename == "word/document.xml" else z_in.read(item.filename)
-            z_out.writestr(item, data)
+            if item.filename in parts:
+                new_content = parts[item.filename]
+                if new_content is None:
+                    continue
+                z_out.writestr(item, new_content.encode("utf-8"))
+            else:
+                z_out.writestr(item, z_in.read(item.filename))
+
+
+def replace_document_xml(src: Path, dest: Path, new_doc_xml: str) -> None:
+    """Copy ``src`` to ``dest``, swapping ``word/document.xml`` for ``new_doc_xml``."""
+    replace_docx_parts(src, dest, {"word/document.xml": new_doc_xml})
 
 
 NS = 'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"'

--- a/tests/test_paragraph_location.py
+++ b/tests/test_paragraph_location.py
@@ -226,6 +226,15 @@ def _single_paragraph_body(p_pr_xml: str) -> str:
     )
 
 
+def _open_single_paragraph(simple_docx: Path, tmp_path: Path, p_pr_xml: str) -> Document:
+    """Open a copy of ``simple_docx`` whose body is one ``Target`` paragraph
+    carrying ``p_pr_xml`` (the ``<w:pPr>`` block under test).
+    """
+    dest = tmp_path / "single-paragraph.docx"
+    replace_document_xml(simple_docx, dest, _single_paragraph_body(p_pr_xml))
+    return Document.open(dest)
+
+
 def _ref_for_text(doc: Document, snippet: str) -> str:
     """Return the first paragraph ref whose preview contains ``snippet``."""
     for entry in doc.list_paragraphs():
@@ -764,53 +773,32 @@ class TestParagraphLocationListMalformed:
     ``w:numPr`` blocks must degrade to ``None`` (or ilvl=0), never raise.
     """
 
-    @staticmethod
-    def _doc_with_p_pr(p_pr_xml: str) -> str:
-        """Single paragraph carrying ``p_pr_xml`` (the ``<w:pPr>`` block under test)."""
-        return (
-            '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
-            f"<w:document {_W_NS}>"
-            "<w:body>"
-            f"<w:p>{p_pr_xml}<w:r><w:t>Target</w:t></w:r></w:p>"
-            "</w:body>"
-            "</w:document>"
-        )
-
-    @staticmethod
-    def _open(simple_docx: Path, tmp_path: Path, body_xml: str) -> Document:
-        dest = tmp_path / "list-malformed.docx"
-        replace_document_xml(simple_docx, dest, body_xml)
-        return Document.open(dest)
-
     def test_num_pr_without_num_id_reports_none(self, simple_docx, tmp_path):
-        body = self._doc_with_p_pr('<w:pPr><w:numPr><w:ilvl w:val="1"/></w:numPr></w:pPr>')
-        with self._open(simple_docx, tmp_path, body) as doc:
+        p_pr = '<w:pPr><w:numPr><w:ilvl w:val="1"/></w:numPr></w:pPr>'
+        with _open_single_paragraph(simple_docx, tmp_path, p_pr) as doc:
             loc = doc.get_paragraph_location(_ref_for_text(doc, "Target"))
             assert loc.list is None
 
     def test_num_id_zero_reports_none(self, simple_docx, tmp_path):
         """``numId=0`` is the spec's "numbering disabled" marker, not a list."""
-        body = self._doc_with_p_pr(_num_pr("0", "0"))
-        with self._open(simple_docx, tmp_path, body) as doc:
+        with _open_single_paragraph(simple_docx, tmp_path, _num_pr("0", "0")) as doc:
             loc = doc.get_paragraph_location(_ref_for_text(doc, "Target"))
             assert loc.list is None
 
     def test_non_integer_num_id_reports_none(self, simple_docx, tmp_path):
-        body = self._doc_with_p_pr(_num_pr("abc", "0"))
-        with self._open(simple_docx, tmp_path, body) as doc:
+        with _open_single_paragraph(simple_docx, tmp_path, _num_pr("abc", "0")) as doc:
             loc = doc.get_paragraph_location(_ref_for_text(doc, "Target"))
             assert loc.list is None
 
     def test_num_id_without_val_reports_none(self, simple_docx, tmp_path):
-        body = self._doc_with_p_pr("<w:pPr><w:numPr><w:numId/></w:numPr></w:pPr>")
-        with self._open(simple_docx, tmp_path, body) as doc:
+        p_pr = "<w:pPr><w:numPr><w:numId/></w:numPr></w:pPr>"
+        with _open_single_paragraph(simple_docx, tmp_path, p_pr) as doc:
             loc = doc.get_paragraph_location(_ref_for_text(doc, "Target"))
             assert loc.list is None
 
     def test_non_integer_ilvl_falls_back_to_zero(self, simple_docx, tmp_path):
         """Malformed ``w:ilvl`` doesn't discard the (valid) numId — level 0."""
-        body = self._doc_with_p_pr(_num_pr("5", "abc"))
-        with self._open(simple_docx, tmp_path, body) as doc:
+        with _open_single_paragraph(simple_docx, tmp_path, _num_pr("5", "abc")) as doc:
             loc = doc.get_paragraph_location(_ref_for_text(doc, "Target"))
             assert loc.list == ListItem(num_id=5, ilvl=0)
 
@@ -819,14 +807,14 @@ class TestParagraphLocationListMalformed:
         ``w:numPr`` found only there must not be reported — direct-child
         walk regression guard against descendant search.
         """
-        body = self._doc_with_p_pr(
+        p_pr = (
             "<w:pPr>"
             '<w:pPrChange w:id="1" w:author="A" w:date="2026-01-01T00:00:00Z">'
             '<w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="9"/></w:numPr></w:pPr>'
             "</w:pPrChange>"
             "</w:pPr>"
         )
-        with self._open(simple_docx, tmp_path, body) as doc:
+        with _open_single_paragraph(simple_docx, tmp_path, p_pr) as doc:
             loc = doc.get_paragraph_location(_ref_for_text(doc, "Target"))
             assert loc.list is None
 
@@ -844,12 +832,6 @@ class TestListParagraphLocationsListInfo:
 
 class TestParagraphStyleField:
     """``location.style`` reports the raw ``w:pPr/w:pStyle`` id."""
-
-    @staticmethod
-    def _open(simple_docx: Path, tmp_path: Path, p_pr_xml: str) -> Document:
-        dest = tmp_path / "style-edge.docx"
-        replace_document_xml(simple_docx, dest, _single_paragraph_body(p_pr_xml))
-        return Document.open(dest)
 
     def test_heading_reports_raw_style_id(self, styled_docx):
         with Document.open(styled_docx) as doc:
@@ -869,12 +851,12 @@ class TestParagraphStyleField:
             assert loc.outline_level is None
 
     def test_p_style_without_val_reports_none(self, simple_docx, tmp_path):
-        with self._open(simple_docx, tmp_path, "<w:pPr><w:pStyle/></w:pPr>") as doc:
+        with _open_single_paragraph(simple_docx, tmp_path, "<w:pPr><w:pStyle/></w:pPr>") as doc:
             loc = doc.get_paragraph_location(_ref_for_text(doc, "Target"))
             assert loc.style is None
 
     def test_p_style_with_empty_val_reports_none(self, simple_docx, tmp_path):
-        with self._open(simple_docx, tmp_path, '<w:pPr><w:pStyle w:val=""/></w:pPr>') as doc:
+        with _open_single_paragraph(simple_docx, tmp_path, '<w:pPr><w:pStyle w:val=""/></w:pPr>') as doc:
             loc = doc.get_paragraph_location(_ref_for_text(doc, "Target"))
             assert loc.style is None
 
@@ -894,12 +876,6 @@ class TestOutlineLevel:
     style definition from ``word/styles.xml`` applies (0-based; ``None`` =
     body text).
     """
-
-    @staticmethod
-    def _open(simple_docx: Path, tmp_path: Path, p_pr_xml: str) -> Document:
-        dest = tmp_path / "outline-edge.docx"
-        replace_document_xml(simple_docx, dest, _single_paragraph_body(p_pr_xml))
-        return Document.open(dest)
 
     def test_level_from_style_definition(self, styled_docx):
         with Document.open(styled_docx) as doc:
@@ -922,7 +898,7 @@ class TestOutlineLevel:
     def test_direct_value_overrides_style_definition(self, simple_docx, tmp_path):
         """Heading1 defines level 0, but a direct ``w:outlineLvl`` wins."""
         p_pr = '<w:pPr><w:pStyle w:val="Heading1"/><w:outlineLvl w:val="4"/></w:pPr>'
-        with self._open(simple_docx, tmp_path, p_pr) as doc:
+        with _open_single_paragraph(simple_docx, tmp_path, p_pr) as doc:
             loc = doc.get_paragraph_location(_ref_for_text(doc, "Target"))
             assert loc.outline_level == 4
 
@@ -931,7 +907,7 @@ class TestOutlineLevel:
         Heading1 style definition must NOT leak back in as a fallback.
         """
         p_pr = '<w:pPr><w:pStyle w:val="Heading1"/><w:outlineLvl w:val="9"/></w:pPr>'
-        with self._open(simple_docx, tmp_path, p_pr) as doc:
+        with _open_single_paragraph(simple_docx, tmp_path, p_pr) as doc:
             loc = doc.get_paragraph_location(_ref_for_text(doc, "Target"))
             assert loc.outline_level is None
 
@@ -941,7 +917,7 @@ class TestOutlineLevel:
         all degrade to ``None``, never raise.
         """
         p_pr = f'<w:pPr><w:outlineLvl w:val="{val}"/></w:pPr>'
-        with self._open(simple_docx, tmp_path, p_pr) as doc:
+        with _open_single_paragraph(simple_docx, tmp_path, p_pr) as doc:
             loc = doc.get_paragraph_location(_ref_for_text(doc, "Target"))
             assert loc.outline_level is None
 

--- a/tests/test_paragraph_location.py
+++ b/tests/test_paragraph_location.py
@@ -9,6 +9,11 @@ Covers:
     table ``index``
   * list paragraphs report ``ListItem(num_id, ilvl)`` from their direct
     ``w:pPr/w:numPr``; non-list paragraphs report ``list=None``
+  * ``style`` reports the raw ``w:pStyle`` id; ``outline_level`` comes from
+    a direct ``w:outlineLvl`` or the style definition in ``word/styles.xml``
+    (``w:basedOn`` chains resolved, ``w:val="9"`` = body text)
+  * ``heading_path`` is the chain of nearest preceding headings, outermost
+    first, excluding the paragraph itself
   * stale refs raise ``HashMismatchError``; out-of-range refs raise
     ``ParagraphIndexError``
 
@@ -20,7 +25,7 @@ another binary and don't pull in ``python-docx``.
 from pathlib import Path
 
 import pytest
-from conftest import replace_document_xml
+from conftest import replace_document_xml, replace_docx_parts
 
 from docx_editor import (
     Document,
@@ -145,6 +150,80 @@ def numbered_docx(simple_docx, tmp_path) -> Path:
     dest = tmp_path / "numbered.docx"
     replace_document_xml(simple_docx, dest, _build_numbered_document_xml())
     return dest
+
+
+def _p_style(style_id: str) -> str:
+    """``<w:pPr><w:pStyle .../></w:pPr>`` block with the given style id."""
+    return f'<w:pPr><w:pStyle w:val="{style_id}"/></w:pPr>'
+
+
+def _build_styled_document_xml() -> str:
+    """Hand-written ``word/document.xml`` with styled/heading paragraphs.
+
+    Relies on the styles.xml shipped inside ``simple.docx``: ``Heading1``/
+    ``Heading2`` define ``w:outlineLvl`` 0/1, and ``TOCHeading`` is based
+    on ``Heading1`` but carries ``w:outlineLvl w:val="9"`` (the spec's
+    "no outline" marker).
+
+    Layout (unique text snippets for ``_ref_for_text``):
+
+      "Preamble text"    plain, before any heading    → path ()
+      "Chapter one"      pStyle=Heading1              → outline 0, path ()
+      "Termination"      pStyle=Heading2              → outline 1, path ("Chapter one",)
+      "Body under h2"    plain                        → path ("Chapter one", "Termination")
+      "Cell under h2"    table cell paragraph         → table AND heading_path
+      "Direct outline"   no pStyle, direct lvl 3      → style None, outline 3
+      "Unknown style"    pStyle=NoSuchStyle           → style kept raw, outline None
+      "Toc heading"      pStyle=TOCHeading (lvl 9)    → outline None despite basedOn=Heading1
+      "Chapter two"      pStyle=Heading1              → path (); pops the stack
+      "Body under ch2"   plain                        → path ("Chapter two",)
+      "Decoy paragraph"  pStyle/outlineLvl only inside
+                         a w:pPrChange revision record → style None, outline None
+    """
+    return (
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+        f"<w:document {_W_NS}>"
+        "<w:body>"
+        "<w:p><w:r><w:t>Preamble text</w:t></w:r></w:p>"
+        f"<w:p>{_p_style('Heading1')}<w:r><w:t>Chapter one</w:t></w:r></w:p>"
+        f"<w:p>{_p_style('Heading2')}<w:r><w:t>Termination</w:t></w:r></w:p>"
+        "<w:p><w:r><w:t>Body under h2</w:t></w:r></w:p>"
+        "<w:tbl><w:tr><w:tc>"
+        "<w:p><w:r><w:t>Cell under h2</w:t></w:r></w:p>"
+        "</w:tc></w:tr></w:tbl>"
+        '<w:p><w:pPr><w:outlineLvl w:val="3"/></w:pPr><w:r><w:t>Direct outline</w:t></w:r></w:p>'
+        f"<w:p>{_p_style('NoSuchStyle')}<w:r><w:t>Unknown style</w:t></w:r></w:p>"
+        f"<w:p>{_p_style('TOCHeading')}<w:r><w:t>Toc heading</w:t></w:r></w:p>"
+        f"<w:p>{_p_style('Heading1')}<w:r><w:t>Chapter two</w:t></w:r></w:p>"
+        "<w:p><w:r><w:t>Body under ch2</w:t></w:r></w:p>"
+        "<w:p><w:pPr>"
+        '<w:pPrChange w:id="1" w:author="A" w:date="2026-01-01T00:00:00Z">'
+        '<w:pPr><w:pStyle w:val="Heading1"/><w:outlineLvl w:val="0"/></w:pPr>'
+        "</w:pPrChange>"
+        "</w:pPr><w:r><w:t>Decoy paragraph</w:t></w:r></w:p>"
+        "</w:body>"
+        "</w:document>"
+    )
+
+
+@pytest.fixture
+def styled_docx(simple_docx, tmp_path) -> Path:
+    """A .docx with heading-styled paragraphs (uses simple.docx's own styles.xml)."""
+    dest = tmp_path / "styled.docx"
+    replace_document_xml(simple_docx, dest, _build_styled_document_xml())
+    return dest
+
+
+def _single_paragraph_body(p_pr_xml: str) -> str:
+    """Full document XML with one ``Target`` paragraph carrying ``p_pr_xml``."""
+    return (
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+        f"<w:document {_W_NS}>"
+        "<w:body>"
+        f"<w:p>{p_pr_xml}<w:r><w:t>Target</w:t></w:r></w:p>"
+        "</w:body>"
+        "</w:document>"
+    )
 
 
 def _ref_for_text(doc: Document, snippet: str) -> str:
@@ -761,3 +840,281 @@ class TestListParagraphLocationsListInfo:
             for ref, loc in entries:
                 assert loc == doc.get_paragraph_location(ref)
             assert any(loc.list is not None for _, loc in entries)
+
+
+class TestParagraphStyleField:
+    """``location.style`` reports the raw ``w:pPr/w:pStyle`` id."""
+
+    @staticmethod
+    def _open(simple_docx: Path, tmp_path: Path, p_pr_xml: str) -> Document:
+        dest = tmp_path / "style-edge.docx"
+        replace_document_xml(simple_docx, dest, _single_paragraph_body(p_pr_xml))
+        return Document.open(dest)
+
+    def test_heading_reports_raw_style_id(self, styled_docx):
+        with Document.open(styled_docx) as doc:
+            loc = doc.get_paragraph_location(_ref_for_text(doc, "Chapter one"))
+            assert loc.style == "Heading1"
+
+    def test_plain_body_reports_none(self, styled_docx):
+        with Document.open(styled_docx) as doc:
+            loc = doc.get_paragraph_location(_ref_for_text(doc, "Body under h2"))
+            assert loc.style is None
+
+    def test_unknown_style_id_passes_through_raw(self, styled_docx):
+        """No styles.xml lookup for the id itself — raw value, no validation."""
+        with Document.open(styled_docx) as doc:
+            loc = doc.get_paragraph_location(_ref_for_text(doc, "Unknown style"))
+            assert loc.style == "NoSuchStyle"
+            assert loc.outline_level is None
+
+    def test_p_style_without_val_reports_none(self, simple_docx, tmp_path):
+        with self._open(simple_docx, tmp_path, "<w:pPr><w:pStyle/></w:pPr>") as doc:
+            loc = doc.get_paragraph_location(_ref_for_text(doc, "Target"))
+            assert loc.style is None
+
+    def test_p_style_with_empty_val_reports_none(self, simple_docx, tmp_path):
+        with self._open(simple_docx, tmp_path, '<w:pPr><w:pStyle w:val=""/></w:pPr>') as doc:
+            loc = doc.get_paragraph_location(_ref_for_text(doc, "Target"))
+            assert loc.style is None
+
+    def test_stale_p_style_inside_p_pr_change_is_ignored(self, styled_docx):
+        """A ``w:pStyle``/``w:outlineLvl`` found only inside a ``w:pPrChange``
+        revision record must not be reported — direct-child walk regression
+        guard against descendant search.
+        """
+        with Document.open(styled_docx) as doc:
+            loc = doc.get_paragraph_location(_ref_for_text(doc, "Decoy paragraph"))
+            assert loc.style is None
+            assert loc.outline_level is None
+
+
+class TestOutlineLevel:
+    """``location.outline_level`` — direct ``w:outlineLvl`` wins, else the
+    style definition from ``word/styles.xml`` applies (0-based; ``None`` =
+    body text).
+    """
+
+    @staticmethod
+    def _open(simple_docx: Path, tmp_path: Path, p_pr_xml: str) -> Document:
+        dest = tmp_path / "outline-edge.docx"
+        replace_document_xml(simple_docx, dest, _single_paragraph_body(p_pr_xml))
+        return Document.open(dest)
+
+    def test_level_from_style_definition(self, styled_docx):
+        with Document.open(styled_docx) as doc:
+            loc_h1 = doc.get_paragraph_location(_ref_for_text(doc, "Chapter one"))
+            loc_h2 = doc.get_paragraph_location(_ref_for_text(doc, "Termination"))
+            assert loc_h1.outline_level == 0
+            assert loc_h2.outline_level == 1
+
+    def test_direct_outline_without_style(self, styled_docx):
+        with Document.open(styled_docx) as doc:
+            loc = doc.get_paragraph_location(_ref_for_text(doc, "Direct outline"))
+            assert loc.style is None
+            assert loc.outline_level == 3
+
+    def test_plain_body_reports_none(self, styled_docx):
+        with Document.open(styled_docx) as doc:
+            loc = doc.get_paragraph_location(_ref_for_text(doc, "Body under h2"))
+            assert loc.outline_level is None
+
+    def test_direct_value_overrides_style_definition(self, simple_docx, tmp_path):
+        """Heading1 defines level 0, but a direct ``w:outlineLvl`` wins."""
+        p_pr = '<w:pPr><w:pStyle w:val="Heading1"/><w:outlineLvl w:val="4"/></w:pPr>'
+        with self._open(simple_docx, tmp_path, p_pr) as doc:
+            loc = doc.get_paragraph_location(_ref_for_text(doc, "Target"))
+            assert loc.outline_level == 4
+
+    def test_direct_body_marker_overrides_style(self, simple_docx, tmp_path):
+        """A direct ``w:val="9"`` explicitly resets to body text — the
+        Heading1 style definition must NOT leak back in as a fallback.
+        """
+        p_pr = '<w:pPr><w:pStyle w:val="Heading1"/><w:outlineLvl w:val="9"/></w:pPr>'
+        with self._open(simple_docx, tmp_path, p_pr) as doc:
+            loc = doc.get_paragraph_location(_ref_for_text(doc, "Target"))
+            assert loc.outline_level is None
+
+    @pytest.mark.parametrize("val", ["9", "12", "-1", "abc", ""])
+    def test_invalid_direct_values_report_none(self, simple_docx, tmp_path, val):
+        """``9`` (spec body-text marker), out-of-range, and malformed values
+        all degrade to ``None``, never raise.
+        """
+        p_pr = f'<w:pPr><w:outlineLvl w:val="{val}"/></w:pPr>'
+        with self._open(simple_docx, tmp_path, p_pr) as doc:
+            loc = doc.get_paragraph_location(_ref_for_text(doc, "Target"))
+            assert loc.outline_level is None
+
+    def test_style_with_outline_9_reports_none(self, styled_docx):
+        """``TOCHeading`` is based on ``Heading1`` but restates
+        ``w:outlineLvl w:val="9"`` — the explicit reset must terminate the
+        ``basedOn`` chain, not inherit level 0.
+        """
+        with Document.open(styled_docx) as doc:
+            loc = doc.get_paragraph_location(_ref_for_text(doc, "Toc heading"))
+            assert loc.style == "TOCHeading"
+            assert loc.outline_level is None
+
+
+class TestHeadingPath:
+    """``location.heading_path`` — nearest preceding headings, outermost first."""
+
+    def test_preamble_before_any_heading_is_empty(self, styled_docx):
+        with Document.open(styled_docx) as doc:
+            loc = doc.get_paragraph_location(_ref_for_text(doc, "Preamble text"))
+            assert loc.heading_path == ()
+
+    def test_heading_own_path_excludes_itself(self, styled_docx):
+        with Document.open(styled_docx) as doc:
+            loc_h1 = doc.get_paragraph_location(_ref_for_text(doc, "Chapter one"))
+            loc_h2 = doc.get_paragraph_location(_ref_for_text(doc, "Termination"))
+            assert loc_h1.heading_path == ()
+            assert loc_h2.heading_path == ("Chapter one",)
+
+    def test_body_under_nested_headings(self, styled_docx):
+        """The issue's acceptance case: locating a paragraph "under the
+        Termination heading".
+        """
+        with Document.open(styled_docx) as doc:
+            loc = doc.get_paragraph_location(_ref_for_text(doc, "Body under h2"))
+            assert loc.heading_path == ("Chapter one", "Termination")
+
+    def test_table_cell_carries_heading_path(self, styled_docx):
+        """Table membership and heading context are independent axes."""
+        with Document.open(styled_docx) as doc:
+            loc = doc.get_paragraph_location(_ref_for_text(doc, "Cell under h2"))
+            assert loc.in_table is True
+            assert loc.heading_path == ("Chapter one", "Termination")
+
+    def test_direct_outline_heading_participates(self, styled_docx):
+        """A heading defined only by a direct ``w:outlineLvl`` (no style)
+        still nests under shallower headings and extends the path.
+        """
+        with Document.open(styled_docx) as doc:
+            loc = doc.get_paragraph_location(_ref_for_text(doc, "Unknown style"))
+            assert loc.heading_path == ("Chapter one", "Termination", "Direct outline")
+
+    def test_new_h1_pops_deeper_headings(self, styled_docx):
+        """A later Heading1 pops every open heading at level >= 0."""
+        with Document.open(styled_docx) as doc:
+            loc_h1 = doc.get_paragraph_location(_ref_for_text(doc, "Chapter two"))
+            loc_body = doc.get_paragraph_location(_ref_for_text(doc, "Body under ch2"))
+            assert loc_h1.heading_path == ()
+            assert loc_body.heading_path == ("Chapter two",)
+
+
+class TestStyleOutlineBasedOnChain:
+    """``w:basedOn`` chain resolution in the style outline map."""
+
+    _STYLES_XML = (
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+        f"<w:styles {_W_NS}>"
+        '<w:style w:type="paragraph" w:styleId="Heading1">'
+        '<w:name w:val="heading 1"/>'
+        '<w:pPr><w:outlineLvl w:val="0"/></w:pPr>'
+        "</w:style>"
+        # Custom style inheriting the outline level from Heading1.
+        '<w:style w:type="paragraph" w:styleId="MyHead">'
+        '<w:name w:val="My Head"/>'
+        '<w:basedOn w:val="Heading1"/>'
+        "</w:style>"
+        # basedOn cycle — must terminate, not hang.
+        '<w:style w:type="paragraph" w:styleId="CycleA"><w:basedOn w:val="CycleB"/></w:style>'
+        '<w:style w:type="paragraph" w:styleId="CycleB"><w:basedOn w:val="CycleA"/></w:style>'
+        # Non-paragraph style carrying an outlineLvl — must be ignored.
+        '<w:style w:type="character" w:styleId="CharStyle">'
+        '<w:pPr><w:outlineLvl w:val="4"/></w:pPr>'
+        "</w:style>"
+        "</w:styles>"
+    )
+
+    _DOCUMENT_XML = (
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+        f"<w:document {_W_NS}>"
+        "<w:body>"
+        f"<w:p>{_p_style('MyHead')}<w:r><w:t>Custom heading</w:t></w:r></w:p>"
+        f"<w:p>{_p_style('CycleA')}<w:r><w:t>Cycle target</w:t></w:r></w:p>"
+        f"<w:p>{_p_style('CharStyle')}<w:r><w:t>Char styled</w:t></w:r></w:p>"
+        "</w:body>"
+        "</w:document>"
+    )
+
+    @pytest.fixture
+    def based_on_docx(self, simple_docx, tmp_path) -> Path:
+        dest = tmp_path / "based-on.docx"
+        replace_docx_parts(
+            simple_docx,
+            dest,
+            {"word/document.xml": self._DOCUMENT_XML, "word/styles.xml": self._STYLES_XML},
+        )
+        return dest
+
+    def test_based_on_chain_inherits_outline_level(self, based_on_docx):
+        with Document.open(based_on_docx) as doc:
+            loc = doc.get_paragraph_location(_ref_for_text(doc, "Custom heading"))
+            assert loc.style == "MyHead"
+            assert loc.outline_level == 0
+
+    def test_inherited_heading_opens_a_path(self, based_on_docx):
+        """A style-inherited heading participates in ``heading_path``."""
+        with Document.open(based_on_docx) as doc:
+            loc = doc.get_paragraph_location(_ref_for_text(doc, "Cycle target"))
+            assert loc.heading_path == ("Custom heading",)
+
+    def test_based_on_cycle_degrades_to_none(self, based_on_docx):
+        """A ``basedOn`` cycle must terminate (visited guard), yielding no level."""
+        with Document.open(based_on_docx) as doc:
+            loc = doc.get_paragraph_location(_ref_for_text(doc, "Cycle target"))
+            assert loc.outline_level is None
+
+    def test_non_paragraph_styles_are_ignored(self, based_on_docx):
+        with Document.open(based_on_docx) as doc:
+            loc = doc.get_paragraph_location(_ref_for_text(doc, "Char styled"))
+            assert loc.style == "CharStyle"
+            assert loc.outline_level is None
+
+
+class TestMissingStylesPart:
+    """A document without ``word/styles.xml`` degrades gracefully."""
+
+    @pytest.fixture
+    def no_styles_docx(self, simple_docx, tmp_path) -> Path:
+        dest = tmp_path / "no-styles.docx"
+        replace_docx_parts(
+            simple_docx,
+            dest,
+            {"word/document.xml": _build_styled_document_xml(), "word/styles.xml": None},
+        )
+        return dest
+
+    def test_style_outline_falls_back_to_direct_only(self, no_styles_docx):
+        with Document.open(no_styles_docx) as doc:
+            loc_styled = doc.get_paragraph_location(_ref_for_text(doc, "Chapter one"))
+            loc_direct = doc.get_paragraph_location(_ref_for_text(doc, "Direct outline"))
+            # Raw style id still reported; no styles.xml → no level to inherit.
+            assert loc_styled.style == "Heading1"
+            assert loc_styled.outline_level is None
+            # Direct w:outlineLvl needs no styles part at all.
+            assert loc_direct.outline_level == 3
+
+    def test_batch_accessor_still_works(self, no_styles_docx):
+        with Document.open(no_styles_docx) as doc:
+            entries = doc.list_paragraph_locations()
+            assert entries
+            for ref, loc in entries:
+                assert loc == doc.get_paragraph_location(ref)
+
+
+class TestListParagraphLocationsStyleInfo:
+    """Batch accessor carries the same style/outline/heading-path info as
+    the per-call accessor — including the shared style-outline map and the
+    single heading pass.
+    """
+
+    def test_equivalence_with_per_call_accessor(self, styled_docx):
+        with Document.open(styled_docx) as doc:
+            entries = doc.list_paragraph_locations()
+            for ref, loc in entries:
+                assert loc == doc.get_paragraph_location(ref)
+            assert any(loc.outline_level is not None for _, loc in entries)
+            assert any(loc.heading_path for _, loc in entries)


### PR DESCRIPTION
Implements ISSUES.md item 27 (paragraph location by heading context).

## What

Extends `ParagraphLocation` with three new fields, populated by both `get_paragraph_location()` and the batch `list_paragraph_locations()`:

- **`style`** — raw `w:pPr/w:pStyle/@w:val` style id (e.g. `"Heading1"`), `None` when the paragraph carries no explicit style. No name resolution.
- **`outline_level`** — effective 0-based outline level (0 == Heading 1). A direct `w:outlineLvl` on the paragraph wins, including the spec's `w:val="9"` "body text" reset; otherwise the level defined by the paragraph's style in `word/styles.xml` applies, with `w:basedOn` inheritance chains resolved (cycle-guarded).
- **`heading_path`** — chain of nearest preceding headings containing the paragraph, outermost first (e.g. `("Chapter one", "Termination")`), built from each heading's current visible text. A heading's own path lists only its ancestors.

## Notes

- Both new fields ignore stale values inside `w:pPrChange` revision records (direct-child walks only).
- A document without `word/styles.xml` degrades gracefully (style ids still reported raw; only direct `w:outlineLvl` yields levels).
- New fields have defaults and new internal parameters are keyword-with-default, so existing callers are unaffected.
- Batch accessor precomputes the style-outline map and heading paths once; the per-call docstring now points whole-document loops at it.
- Test fixture helper `replace_document_xml` generalized into `replace_docx_parts` to allow swapping/dropping `word/styles.xml` in fixtures.

## Testing

- 832 passed, 2 skipped; ruff check and format clean.
- New coverage: style edge cases (missing/empty `w:val`, unknown id), outline precedence (direct beats style, `9` reset), `basedOn` inheritance and cycles, non-paragraph styles ignored, heading paths across tables and direct-outline headings, missing-styles degradation, batch/per-call equivalence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Paragraph location details now include raw style, resolved outline level, and visible heading context.
  * Heading ancestry is reported in document order, including for paragraphs within tables.
  * Batch paragraph location lookups provide consistent structural context with improved efficiency.

* **Documentation**
  * Updated API and DOCX editing guidance with the new paragraph location fields and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->