### PR TITLE
fix: author-aware in-place edits — preserve foreign insertions (ISSUES.md #19)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -232,7 +232,7 @@ if doc.count_matches("Section 5") > 1:
 
 #### `replace(find, replace_with, *, paragraph, occurrence=0)`
 
-Replace text with tracked changes.
+Replace text with tracked changes. When the target sits inside another author's pending insertion, that insertion is preserved: the matched text gets a nested `<w:del>` under your authorship and the replacement lands in your own sibling `<w:ins>` (Word's behavior), instead of silently rewriting the other author's proposal.
 
 **Parameters:**
 
@@ -252,7 +252,7 @@ doc.replace("net", "gross", paragraph=ref)
 
 #### `delete(text, *, paragraph, occurrence=0)`
 
-Mark text as deleted with tracked changes.
+Mark text as deleted with tracked changes. Deleting text inside another author's pending insertion nests a `<w:del>` under your authorship inside their `<w:ins>`, preserving their proposal; only your own pending insertions are edited in place.
 
 **Parameters:**
 
@@ -270,7 +270,7 @@ ref = doc.delete("obsolete clause", paragraph="P5#d4e5")
 
 #### `insert_after(anchor, text, *, paragraph, occurrence=0)`
 
-Insert text after anchor with tracked changes.
+Insert text after anchor with tracked changes. An anchor inside another author's pending insertion produces your own sibling `<w:ins>` (splitting theirs when the anchor falls mid-content) rather than splicing your words into their proposal.
 
 **Parameters:**
 
@@ -289,7 +289,7 @@ ref = doc.insert_after("Section 5", " (as amended)", paragraph="P3#b2c4")
 
 #### `insert_before(anchor, text, *, paragraph, occurrence=0)`
 
-Insert text before anchor with tracked changes.
+Insert text before anchor with tracked changes. Foreign pending insertions are treated the same as in `insert_after()`.
 
 **Parameters:**
 

--- a/docx_editor/track_changes.py
+++ b/docx_editor/track_changes.py
@@ -958,9 +958,9 @@ class RevisionManager:
                     first_child = ins_elem.firstChild
                     if first_child:
                         self.editor.insert_before(first_child, new_run_xml)
-                    else:
+                    else:  # pragma: no cover - removing all content deletes the ins outright
                         self.editor.append_to(ins_elem, new_run_xml)
-                elif ins_parent:
+                elif ins_parent:  # pragma: no branch - an ins removed from the DOM had a parent
                     # ins_elem was fully removed — wrap replacement in a new <w:ins>
                     ins_wrapper_xml = f"<w:ins>{new_run_xml}</w:ins>"
                     if ins_next:
@@ -976,19 +976,18 @@ class RevisionManager:
 
             first_rPr = parts[0][1]
             replacement_xml = f"<w:ins><w:r>{first_rPr}<w:t>{_escape_xml(replace_with)}</w:t></w:r></w:ins>"
-            if last_del is None:
-                # Degenerate: no deletion was created — nothing to anchor to
+            if last_del is None:  # pragma: no cover - a foreign group always creates a del
                 return first_id
             del_ins = self._find_ancestor(last_del, "w:ins")
             if del_ins is not None:
                 self._split_ins_after_child(del_ins, last_del)
                 new_nodes = self.editor.insert_after(del_ins, replacement_xml)
-            else:
+            else:  # pragma: no cover - Site D positions are inside ins, so the del is nested
                 new_nodes = self.editor.insert_after(last_del, replacement_xml)
             for node in new_nodes:
-                if node.nodeType == node.ELEMENT_NODE and node.tagName == "w:ins":
+                if node.nodeType == node.ELEMENT_NODE and node.tagName == "w:ins":  # pragma: no branch
                     return int(node.getAttribute("w:id"))
-            return first_id
+            return first_id  # pragma: no cover - the fragment always yields a w:ins
 
         # Use first run's rPr for the insertion
         first_rPr = parts[0][1]
@@ -1210,7 +1209,7 @@ class RevisionManager:
                 del_id, group_last_del = self._delete_regular_segment(group)
                 if first_del_id == -1:
                     first_del_id = del_id
-                if group_last_del is not None:
+                if group_last_del is not None:  # pragma: no branch - a foreign group always creates a del
                     last_del = group_last_del
         return first_del_id, last_del
 
@@ -1248,7 +1247,7 @@ class RevisionManager:
         very start of the insertion's content).
         """
         run, rPr_xml = self._get_run_info(edge_node)
-        if not run:
+        if not run:  # pragma: no cover - a w:t node always sits inside a run
             return None
         node_text = self._get_node_text(edge_node)
 
@@ -1310,16 +1309,16 @@ class RevisionManager:
             new_nodes = self.editor.insert_after(ins_elem, own_ins_xml)
         else:
             boundary = self._split_foreign_ins_at(edge_node, offset)
-            if boundary is None:
+            if boundary is None:  # pragma: no cover - non-boundary offsets never split at the start
                 new_nodes = self.editor.insert_before(ins_elem, own_ins_xml)
             else:
                 self._split_ins_after_child(ins_elem, boundary)
                 new_nodes = self.editor.insert_after(ins_elem, own_ins_xml)
 
         for node in new_nodes:
-            if node.nodeType == node.ELEMENT_NODE and node.tagName == "w:ins":
+            if node.nodeType == node.ELEMENT_NODE and node.tagName == "w:ins":  # pragma: no branch
                 return int(node.getAttribute("w:id"))
-        return -1
+        return -1  # pragma: no cover - the fragment always yields a w:ins
 
     def _remove_from_insertion(self, positions: list) -> None:
         """Remove matched text from inside a <w:ins> element.

--- a/docx_editor/track_changes.py
+++ b/docx_editor/track_changes.py
@@ -1173,13 +1173,14 @@ class RevisionManager:
                 parts.append(f' {attr}="{_escape_xml(value)}"')
         return "".join(parts)
 
-    def _group_positions_by_ins(self, positions: list) -> list[tuple[Element, list]]:
+    def _group_positions_by_ins(self, positions: list) -> list[tuple[Element | None, list]]:
         """Group contiguous positions by their ancestor <w:ins> element.
 
         Positions are in document order, so positions sharing an ins element
         are contiguous; adjacent distinct ins elements form separate groups.
+        A group's element is None for positions outside any insertion.
         """
-        groups: list[tuple[Element, list]] = []
+        groups: list[tuple[Element | None, list]] = []
         current_ins = None
         for pos in positions:
             ins_elem = self._find_ancestor(pos.node, "w:ins")
@@ -1218,9 +1219,11 @@ class RevisionManager:
 
         Everything following ``child`` moves into a fresh sibling <w:ins>
         that copies this insertion's w:author/w:date (fresh w:id via the
-        stamper). Returns the new right-half ins, or None when nothing
-        follows ``child``. ``child`` may be a descendant; the split happens
-        after the direct child containing it.
+        stamper). ``ins_elem`` is typically another author's insertion —
+        the copied identity keeps both halves attributed to them. Returns
+        the new right-half ins, or None when nothing follows ``child``.
+        ``child`` may be a descendant; the split happens after the direct
+        child containing it.
         """
         while child.parentNode is not ins_elem:
             child = child.parentNode
@@ -1234,22 +1237,24 @@ class RevisionManager:
         children_xml = "".join(n.toxml() for n in trailing)
         for n in trailing:
             ins_elem.removeChild(n)
-        identity = self._ins_identity_attrs(ins_elem)
-        new_nodes = self.editor.insert_after(ins_elem, f"<w:ins{identity}>{children_xml}</w:ins>")
+        identity_xml = self._ins_identity_attrs(ins_elem)
+        new_nodes = self.editor.insert_after(ins_elem, f"<w:ins{identity_xml}>{children_xml}</w:ins>")
         for n in new_nodes:
             if n.nodeType == n.ELEMENT_NODE and n.tagName == "w:ins":
                 return n
         return None
 
-    def _split_foreign_ins_at(self, ins_elem, edge_node, offset: int) -> Element | None:
-        """Make (edge_node, offset) fall on a child boundary of ``ins_elem``.
+    def _split_foreign_ins_at(self, edge_node, offset: int) -> Element | None:
+        """Make (edge_node, offset) fall on a child boundary of its <w:ins>.
 
         Splits the run containing ``edge_node`` at ``offset`` when the split
         point falls mid-run. Returns the last element that belongs to the
         left side of the split point (None when the split point is at the
-        very start of ``ins_elem``'s content).
+        very start of the insertion's content).
         """
         run, rPr_xml = self._get_run_info(edge_node)
+        if not run:
+            return None
         node_text = self._get_node_text(edge_node)
 
         run_wts = list(run.getElementsByTagName("w:t"))
@@ -1268,9 +1273,11 @@ class RevisionManager:
         if not left_texts:
             # Split point is immediately before this run
             prev = run.previousSibling
-            while prev is not None and prev.nodeType != prev.ELEMENT_NODE:
+            while prev is not None:
+                if isinstance(prev, Element):
+                    return prev
                 prev = prev.previousSibling
-            return prev
+            return None
 
         # Mid-run: rebuild as left/right runs (non-text children front-hoisted,
         # matching the existing sites — interleaving is issue #20's follow-up)
@@ -1305,7 +1312,7 @@ class RevisionManager:
         elif edge_node is wt_nodes[-1] and offset == len(node_text):
             new_nodes = self.editor.insert_after(ins_elem, own_ins_xml)
         else:
-            boundary = self._split_foreign_ins_at(ins_elem, edge_node, offset)
+            boundary = self._split_foreign_ins_at(edge_node, offset)
             if boundary is None:
                 new_nodes = self.editor.insert_before(ins_elem, own_ins_xml)
             else:

--- a/docx_editor/track_changes.py
+++ b/docx_editor/track_changes.py
@@ -1163,7 +1163,7 @@ class RevisionManager:
 
         Returns ``w:author``/``w:date``/``w16du:dateUtc`` (those present) as an
         XML attribute string, so a re-created half of a split ``w:ins`` keeps
-        the original author's identity; the attribute stamper only adds a
+        the original author's identity; attribute injection only adds a
         fresh ``w:id``.
         """
         parts = []
@@ -1173,14 +1173,14 @@ class RevisionManager:
                 parts.append(f' {attr}="{_escape_xml(value)}"')
         return "".join(parts)
 
-    def _group_positions_by_ins(self, positions: list) -> list[tuple[Element | None, list]]:
+    def _group_positions_by_ins(self, positions: list) -> list[tuple[Element | None, list[TextPosition]]]:
         """Group contiguous positions by their ancestor <w:ins> element.
 
         Positions are in document order, so positions sharing an ins element
         are contiguous; adjacent distinct ins elements form separate groups.
         A group's element is None for positions outside any insertion.
         """
-        groups: list[tuple[Element | None, list]] = []
+        groups: list[tuple[Element | None, list[TextPosition]]] = []
         current_ins = None
         for pos in positions:
             ins_elem = self._find_ancestor(pos.node, "w:ins")
@@ -1214,16 +1214,15 @@ class RevisionManager:
                     last_del = group_last_del
         return first_del_id, last_del
 
-    def _split_ins_after_child(self, ins_elem, child) -> Element | None:
+    def _split_ins_after_child(self, ins_elem, child) -> None:
         """Split ``ins_elem`` after ``child``, keeping the author's identity.
 
         Everything following ``child`` moves into a fresh sibling <w:ins>
-        that copies this insertion's w:author/w:date (fresh w:id via the
-        stamper). ``ins_elem`` is typically another author's insertion —
-        the copied identity keeps both halves attributed to them. Returns
-        the new right-half ins, or None when nothing follows ``child``.
-        ``child`` may be a descendant; the split happens after the direct
-        child containing it.
+        that copies this insertion's w:author/w:date (fresh w:id via
+        attribute injection). ``ins_elem`` is typically another author's
+        insertion — the copied identity keeps both halves attributed to
+        them. No-op when nothing follows ``child``. ``child`` may be a
+        descendant; the split happens after the direct child containing it.
         """
         while child.parentNode is not ins_elem:
             child = child.parentNode
@@ -1233,16 +1232,12 @@ class RevisionManager:
             trailing.append(node)
             node = node.nextSibling
         if not any(n.nodeType == n.ELEMENT_NODE for n in trailing):
-            return None
+            return
         children_xml = "".join(n.toxml() for n in trailing)
         for n in trailing:
             ins_elem.removeChild(n)
         identity_xml = self._ins_identity_attrs(ins_elem)
-        new_nodes = self.editor.insert_after(ins_elem, f"<w:ins{identity_xml}>{children_xml}</w:ins>")
-        for n in new_nodes:
-            if n.nodeType == n.ELEMENT_NODE and n.tagName == "w:ins":
-                return n
-        return None
+        self.editor.insert_after(ins_elem, f"<w:ins{identity_xml}>{children_xml}</w:ins>")
 
     def _split_foreign_ins_at(self, edge_node, offset: int) -> Element | None:
         """Make (edge_node, offset) fall on a child boundary of its <w:ins>.
@@ -1272,6 +1267,8 @@ class RevisionManager:
             return run
         if not left_texts:
             # Split point is immediately before this run
+            # (isinstance so ty narrows minidom's sibling union — the usual
+            # nodeType comparison doesn't)
             prev = run.previousSibling
             while prev is not None:
                 if isinstance(prev, Element):

--- a/docx_editor/track_changes.py
+++ b/docx_editor/track_changes.py
@@ -612,12 +612,17 @@ class RevisionManager:
             if not run:
                 return
 
-            # If inside <w:ins>, splice text directly
+            # Inside our own <w:ins>: splice text directly; a foreign
+            # author's insertion gets our own sibling <w:ins> instead
             ins_ancestor = self._find_ancestor(run, "w:ins")
             if ins_ancestor:
-                node_text = self._get_node_text(last_pos.node)
-                self._set_node_text(last_pos.node, node_text + text)
-                _set_xml_space_preserve(last_pos.node)
+                if self._owns_ins(ins_ancestor):
+                    node_text = self._get_node_text(last_pos.node)
+                    self._set_node_text(last_pos.node, node_text + text)
+                    _set_xml_space_preserve(last_pos.node)
+                else:
+                    node_text = self._get_node_text(last_pos.node)
+                    self._insert_own_ins_within_foreign_ins(ins_ancestor, last_pos.node, len(node_text), text, rPr_xml)
                 return
 
             ins_xml = f"<w:ins><w:r>{rPr_xml}<w:t>{_escape_xml(text)}</w:t></w:r></w:ins>"
@@ -630,13 +635,17 @@ class RevisionManager:
         if not run:
             return
 
-        # If inside <w:ins>, splice text directly
+        # Inside our own <w:ins>: splice text directly; a foreign author's
+        # insertion gets our own sibling <w:ins> (splitting theirs mid-content)
         ins_ancestor = self._find_ancestor(run, "w:ins")
         if ins_ancestor:
-            node_text = self._get_node_text(pos.node)
-            offset = pos.offset_in_node
-            self._set_node_text(pos.node, node_text[:offset] + text + node_text[offset:])
-            _set_xml_space_preserve(pos.node)
+            if self._owns_ins(ins_ancestor):
+                node_text = self._get_node_text(pos.node)
+                offset = pos.offset_in_node
+                self._set_node_text(pos.node, node_text[:offset] + text + node_text[offset:])
+                _set_xml_space_preserve(pos.node)
+            else:
+                self._insert_own_ins_within_foreign_ins(ins_ancestor, pos.node, pos.offset_in_node, text, rPr_xml)
             return
 
         # Split the run at the offset and insert <w:ins> between
@@ -927,34 +936,59 @@ class RevisionManager:
         if not parts:
             return -1
 
-        # Site D: If all positions inside <w:ins>, edit in-place
+        # Site D: all positions inside <w:ins> — dispatch on insertion ownership
         if all(p.is_inside_ins for p in match.positions):
             first_node = match.positions[0].node
             ins_elem = self._find_ancestor(first_node, "w:ins")
-            # Save parent/next sibling before removal may detach ins_elem
-            ins_parent = ins_elem.parentNode if ins_elem else None
-            ins_next = ins_elem.nextSibling if ins_elem else None
+            ins_groups = self._group_positions_by_ins(match.positions)
 
-            self._remove_from_insertion(match.positions)
+            if all(g_ins is None or self._owns_ins(g_ins) for g_ins, _ in ins_groups):
+                # All our own — edit in place (historical behavior)
+                # Save parent/next sibling before removal may detach ins_elem
+                ins_parent = ins_elem.parentNode if ins_elem else None
+                ins_next = ins_elem.nextSibling if ins_elem else None
+
+                self._remove_from_insertion(match.positions)
+
+                first_rPr = parts[0][1]
+                new_run_xml = f"<w:r>{first_rPr}<w:t>{_escape_xml(replace_with)}</w:t></w:r>"
+
+                if ins_elem and ins_elem.parentNode:
+                    # ins_elem still in DOM — insert replacement inside it
+                    first_child = ins_elem.firstChild
+                    if first_child:
+                        self.editor.insert_before(first_child, new_run_xml)
+                    else:
+                        self.editor.append_to(ins_elem, new_run_xml)
+                elif ins_parent:
+                    # ins_elem was fully removed — wrap replacement in a new <w:ins>
+                    ins_wrapper_xml = f"<w:ins>{new_run_xml}</w:ins>"
+                    if ins_next:
+                        self.editor.insert_before(ins_next, ins_wrapper_xml)
+                    else:
+                        self.editor.append_to(ins_parent, ins_wrapper_xml)
+                return -1
+
+            # Foreign insertion(s) involved — preserve them: nest our deletion
+            # inside, then place our replacement <w:ins> right after it,
+            # splitting the foreign ins when trailing content follows.
+            first_id, last_del = self._delete_from_ins_positions(match.positions)
 
             first_rPr = parts[0][1]
-            new_run_xml = f"<w:r>{first_rPr}<w:t>{_escape_xml(replace_with)}</w:t></w:r>"
-
-            if ins_elem and ins_elem.parentNode:
-                # ins_elem still in DOM — insert replacement inside it
-                first_child = ins_elem.firstChild
-                if first_child:
-                    self.editor.insert_before(first_child, new_run_xml)
-                else:
-                    self.editor.append_to(ins_elem, new_run_xml)
-            elif ins_parent:
-                # ins_elem was fully removed — wrap replacement in a new <w:ins>
-                ins_wrapper_xml = f"<w:ins>{new_run_xml}</w:ins>"
-                if ins_next:
-                    self.editor.insert_before(ins_next, ins_wrapper_xml)
-                else:
-                    self.editor.append_to(ins_parent, ins_wrapper_xml)
-            return -1
+            replacement_xml = f"<w:ins><w:r>{first_rPr}<w:t>{_escape_xml(replace_with)}</w:t></w:r></w:ins>"
+            if last_del is None:
+                # Degenerate: no deletion was created — nothing to anchor to
+                return first_id
+            del_ins = self._find_ancestor(last_del, "w:ins")
+            if del_ins is not None:
+                self._split_ins_after_child(del_ins, last_del)
+                new_nodes = self.editor.insert_after(del_ins, replacement_xml)
+            else:
+                new_nodes = self.editor.insert_after(last_del, replacement_xml)
+            for node in new_nodes:
+                if node.nodeType == node.ELEMENT_NODE and node.tagName == "w:ins":
+                    return int(node.getAttribute("w:id"))
+            return first_id
 
         # Use first run's rPr for the insertion
         first_rPr = parts[0][1]
@@ -1065,9 +1099,11 @@ class RevisionManager:
         ref_node.parentNode.insertBefore(marker, ref_node)  # type: ignore[union-attr]
 
         # Process each segment to delete/remove the matched text
+        # (author-aware: foreign insertions get a nested <w:del>, our own are
+        # edited in place)
         for is_inside_ins, positions in segments:
             if is_inside_ins:
-                self._remove_from_insertion(positions)
+                self._delete_from_ins_positions(positions)
             else:
                 self._delete_regular_segment(positions)
 
@@ -1109,6 +1145,177 @@ class RevisionManager:
                 return parent
             parent = parent.parentNode
         return None
+
+    def _owns_ins(self, ins_elem) -> bool:
+        """Whether ``ins_elem`` is the current author's own pending insertion.
+
+        A missing or empty ``w:author`` reads as foreign: we must never
+        destructively edit an insertion we cannot attribute to ourselves.
+        Comparison is exact string equality — differing Unicode normalization
+        or case reads as foreign, which fails safe (we nest instead of
+        destroy).
+        """
+        author = ins_elem.getAttribute("w:author")
+        return bool(author) and author == self.editor.author
+
+    def _ins_identity_attrs(self, ins_elem) -> str:
+        """Serialize the identity attributes of an insertion for re-creation.
+
+        Returns ``w:author``/``w:date``/``w16du:dateUtc`` (those present) as an
+        XML attribute string, so a re-created half of a split ``w:ins`` keeps
+        the original author's identity; the attribute stamper only adds a
+        fresh ``w:id``.
+        """
+        parts = []
+        for attr in ("w:author", "w:date", "w16du:dateUtc"):
+            value = ins_elem.getAttribute(attr)
+            if value:
+                parts.append(f' {attr}="{_escape_xml(value)}"')
+        return "".join(parts)
+
+    def _group_positions_by_ins(self, positions: list) -> list[tuple[Element, list]]:
+        """Group contiguous positions by their ancestor <w:ins> element.
+
+        Positions are in document order, so positions sharing an ins element
+        are contiguous; adjacent distinct ins elements form separate groups.
+        """
+        groups: list[tuple[Element, list]] = []
+        current_ins = None
+        for pos in positions:
+            ins_elem = self._find_ancestor(pos.node, "w:ins")
+            if not groups or ins_elem is not current_ins:
+                groups.append((ins_elem, [pos]))
+                current_ins = ins_elem
+            else:
+                groups[-1][1].append(pos)
+        return groups
+
+    def _delete_from_ins_positions(self, positions: list) -> tuple[int, Element | None]:
+        """Author-aware deletion of match positions that sit inside <w:ins>.
+
+        Our own insertions are edited in place (text physically removed, as
+        before). A foreign author's insertion is preserved: the matched text
+        is wrapped in a nested <w:del> carrying our authorship — Word's own
+        representation for deleting another reviewer's pending insertion.
+
+        Returns (first created del id or -1, last created del element or None).
+        """
+        first_del_id = -1
+        last_del: Element | None = None
+        for ins_elem, group in self._group_positions_by_ins(positions):
+            if ins_elem is None or self._owns_ins(ins_elem):
+                self._remove_from_insertion(group)
+            else:
+                del_id, group_last_del = self._delete_regular_segment(group)
+                if first_del_id == -1:
+                    first_del_id = del_id
+                if group_last_del is not None:
+                    last_del = group_last_del
+        return first_del_id, last_del
+
+    def _split_ins_after_child(self, ins_elem, child) -> Element | None:
+        """Split ``ins_elem`` after ``child``, keeping the author's identity.
+
+        Everything following ``child`` moves into a fresh sibling <w:ins>
+        that copies this insertion's w:author/w:date (fresh w:id via the
+        stamper). Returns the new right-half ins, or None when nothing
+        follows ``child``. ``child`` may be a descendant; the split happens
+        after the direct child containing it.
+        """
+        while child.parentNode is not ins_elem:
+            child = child.parentNode
+        trailing = []
+        node = child.nextSibling
+        while node is not None:
+            trailing.append(node)
+            node = node.nextSibling
+        if not any(n.nodeType == n.ELEMENT_NODE for n in trailing):
+            return None
+        children_xml = "".join(n.toxml() for n in trailing)
+        for n in trailing:
+            ins_elem.removeChild(n)
+        identity = self._ins_identity_attrs(ins_elem)
+        new_nodes = self.editor.insert_after(ins_elem, f"<w:ins{identity}>{children_xml}</w:ins>")
+        for n in new_nodes:
+            if n.nodeType == n.ELEMENT_NODE and n.tagName == "w:ins":
+                return n
+        return None
+
+    def _split_foreign_ins_at(self, ins_elem, edge_node, offset: int) -> Element | None:
+        """Make (edge_node, offset) fall on a child boundary of ``ins_elem``.
+
+        Splits the run containing ``edge_node`` at ``offset`` when the split
+        point falls mid-run. Returns the last element that belongs to the
+        left side of the split point (None when the split point is at the
+        very start of ``ins_elem``'s content).
+        """
+        run, rPr_xml = self._get_run_info(edge_node)
+        node_text = self._get_node_text(edge_node)
+
+        run_wts = list(run.getElementsByTagName("w:t"))
+        edge_idx = next(i for i, wt in enumerate(run_wts) if wt is edge_node)
+        left_texts = [self._get_node_text(wt) for wt in run_wts[:edge_idx]]
+        if node_text[:offset]:
+            left_texts.append(node_text[:offset])
+        right_texts = []
+        if node_text[offset:]:
+            right_texts.append(node_text[offset:])
+        right_texts += [self._get_node_text(wt) for wt in run_wts[edge_idx + 1 :]]
+
+        if not right_texts:
+            # Split point is at the end of this run — run boundary already
+            return run
+        if not left_texts:
+            # Split point is immediately before this run
+            prev = run.previousSibling
+            while prev is not None and prev.nodeType != prev.ELEMENT_NODE:
+                prev = prev.previousSibling
+            return prev
+
+        # Mid-run: rebuild as left/right runs (non-text children front-hoisted,
+        # matching the existing sites — interleaving is issue #20's follow-up)
+        xml_parts = []
+        non_text_xml = self._get_non_text_children_xml(run)
+        if non_text_xml:
+            xml_parts.append(f"<w:r>{rPr_xml}{non_text_xml}</w:r>")
+        xml_parts += [f"<w:r>{rPr_xml}<w:t>{_escape_xml(t)}</w:t></w:r>" for t in left_texts]
+        left_len = len(xml_parts)
+        xml_parts += [f"<w:r>{rPr_xml}<w:t>{_escape_xml(t)}</w:t></w:r>" for t in right_texts]
+
+        new_nodes = self.editor.replace_node(run, "".join(xml_parts))
+        elements = [n for n in new_nodes if n.nodeType == n.ELEMENT_NODE]
+        return elements[left_len - 1]
+
+    def _insert_own_ins_within_foreign_ins(self, ins_elem, edge_node, offset: int, text: str, rPr_xml: str) -> int:
+        """Insert our own <w:ins> at (edge_node, offset) inside a foreign ins.
+
+        Never splices into the foreign insertion (that would credit the other
+        author) and never nests <w:ins> in <w:ins> (invalid OOXML). Boundary
+        offsets produce a plain sibling; mid-insertion offsets split the
+        foreign ins into two identity-preserving halves with our ins between.
+
+        Returns the new insertion's change id.
+        """
+        own_ins_xml = f"<w:ins><w:r>{rPr_xml}<w:t>{_escape_xml(text)}</w:t></w:r></w:ins>"
+        wt_nodes = self._get_wt_nodes_in_ancestor(ins_elem)
+        node_text = self._get_node_text(edge_node)
+
+        if edge_node is wt_nodes[0] and offset == 0:
+            new_nodes = self.editor.insert_before(ins_elem, own_ins_xml)
+        elif edge_node is wt_nodes[-1] and offset == len(node_text):
+            new_nodes = self.editor.insert_after(ins_elem, own_ins_xml)
+        else:
+            boundary = self._split_foreign_ins_at(ins_elem, edge_node, offset)
+            if boundary is None:
+                new_nodes = self.editor.insert_before(ins_elem, own_ins_xml)
+            else:
+                self._split_ins_after_child(ins_elem, boundary)
+                new_nodes = self.editor.insert_after(ins_elem, own_ins_xml)
+
+        for node in new_nodes:
+            if node.nodeType == node.ELEMENT_NODE and node.tagName == "w:ins":
+                return int(node.getAttribute("w:id"))
+        return -1
 
     def _remove_from_insertion(self, positions: list) -> None:
         """Remove matched text from inside a <w:ins> element.
@@ -1220,14 +1427,17 @@ class RevisionManager:
             return []
         return ancestor.getElementsByTagName("w:t")
 
-    def _delete_regular_segment(self, positions: list) -> int:
-        """Delete regular (non-insertion) text by wrapping in <w:del>.
+    def _delete_regular_segment(self, positions: list) -> tuple[int, Element | None]:
+        """Wrap matched text in <w:del> in place, run by run.
 
         Groups positions by run first, then by w:t node within each run,
         so that each run is removed exactly once even when it contains
-        multiple w:t nodes involved in the match.
+        multiple w:t nodes involved in the match. The rebuilt runs stay at
+        the original location, so this serves both regular top-level text
+        and nesting a deletion inside a foreign author's <w:ins> (the new
+        <w:del> is stamped with the current author either way).
 
-        Returns the w:id of the first <w:del> element created, or -1.
+        Returns (first created del id or -1, last created del element or None).
         """
         # Group positions by run, then by node within each run
         run_groups: OrderedDict[int, dict] = OrderedDict()
@@ -1253,6 +1463,7 @@ class RevisionManager:
 
         total = len(all_node_groups)
         first_del_id = -1
+        last_del: Element | None = None
         processed_runs: set[int] = set()
 
         for _global_idx, (run_info, _) in enumerate(all_node_groups):
@@ -1316,13 +1527,13 @@ class RevisionManager:
                 run.parentNode.removeChild(run)
             processed_runs.add(rid)
 
-            if first_del_id == -1:
-                for n in nodes:
-                    if n.nodeType == n.ELEMENT_NODE and n.tagName == "w:del":
+            for n in nodes:
+                if n.nodeType == n.ELEMENT_NODE and n.tagName == "w:del":
+                    if first_del_id == -1:
                         first_del_id = int(n.getAttribute("w:id"))
-                        break
+                    last_del = n
 
-        return first_del_id
+        return first_del_id, last_del
 
     def _delete_across_nodes(self, match: TextMapMatch) -> int:
         """Delete text spanning multiple w:t elements."""
@@ -1336,10 +1547,11 @@ class RevisionManager:
         if not parts:
             return -1
 
-        # Site F: If all positions inside <w:ins>, remove from insertion directly
+        # Site F: all positions inside <w:ins> — author-aware dispatch (our own
+        # insertions edited in place, foreign ones get a nested <w:del>)
         if all(p.is_inside_ins for p in match.positions):
-            self._remove_from_insertion(match.positions)
-            return -1
+            first_id, _ = self._delete_from_ins_positions(match.positions)
+            return first_id
 
         # Group parts by run, using node ids from _build_cross_boundary_parts
         matched_node_ids = {nid for _, _, _, _, _, nid in parts}
@@ -1410,11 +1622,11 @@ class RevisionManager:
         first_del_id = -1
         for is_inside_ins, positions in segments:
             if is_inside_ins:
-                self._remove_from_insertion(positions)
+                del_id, _ = self._delete_from_ins_positions(positions)
             else:
-                del_id = self._delete_regular_segment(positions)
-                if first_del_id == -1:
-                    first_del_id = del_id
+                del_id, _ = self._delete_regular_segment(positions)
+            if first_del_id == -1:
+                first_del_id = del_id
 
         return first_del_id
 
@@ -1495,13 +1707,17 @@ class RevisionManager:
         if not run:
             return -1
 
-        # If the edge run is inside <w:ins>, splice text at the exact offset
-        # (no wrapper, so no nested <w:ins>)
-        if self._find_ancestor(run, "w:ins"):
-            node_text = self._get_node_text(edge.node)
-            self._set_node_text(edge.node, node_text[:offset] + text + node_text[offset:])
-            _set_xml_space_preserve(edge.node)
-            return -1
+        # Edge run inside <w:ins>: splice into our own insertion (no wrapper,
+        # so no nested <w:ins>); a foreign author's insertion gets our own
+        # sibling <w:ins>, splitting theirs when the anchor falls mid-content.
+        ins_ancestor = self._find_ancestor(run, "w:ins")
+        if ins_ancestor:
+            if self._owns_ins(ins_ancestor):
+                node_text = self._get_node_text(edge.node)
+                self._set_node_text(edge.node, node_text[:offset] + text + node_text[offset:])
+                _set_xml_space_preserve(edge.node)
+                return -1
+            return self._insert_own_ins_within_foreign_ins(ins_ancestor, edge.node, offset, text, rPr_xml)
 
         # Rebuild the edge run: split its w:t at the offset and wrap text in <w:ins>
         ins_xml = f"<w:ins><w:r>{rPr_xml}<w:t>{_escape_xml(text)}</w:t></w:r></w:ins>"

--- a/skills/docx/SKILL.md
+++ b/skills/docx/SKILL.md
@@ -255,6 +255,8 @@ doc.close()
 
 **Return values:** All edit methods return the new paragraph reference as a plain `str` (e.g., `"P2#c3d4"`). Use this for follow-up edits on the same paragraph without calling `list_paragraphs()` again. To get change IDs for accept/reject, use `doc.list_revisions()`.
 
+**Multi-author documents:** Editing inside *another* author's pending insertion preserves their proposal, matching Word: deletions nest a `<w:del>` under your authorship inside their `<w:ins>`, and replacements/insertions put your text in your own sibling `<w:ins>` (splitting theirs when needed) instead of silently rewriting it. `accept_all(author=...)` / `reject_all(author=...)` then resolve each author's changes independently. Only your own pending insertions are edited in place.
+
 **Raises:** `TextNotFoundError` if the text is not found.
 
 ### Comments API

--- a/tests/test_foreign_ins_edits.py
+++ b/tests/test_foreign_ins_edits.py
@@ -217,6 +217,26 @@ class TestDeleteInsideForeignIns:
         assert len(dels) == 1
         assert change_id == int(dels[0].getAttribute("w:id"))
 
+    def test_delete_across_two_foreign_insertions(self, temp_xml):
+        """A match spanning two adjacent foreign insertions nests a del in each."""
+        body = (
+            f"<w:p>{_foreign_ins('<w:r><w:t>abc </w:t></w:r>', ins_id=1)}"
+            f"{_foreign_ins('<w:r><w:t>def</w:t></w:r>', ins_id=2)}</w:p>"
+        )
+        manager = _make_manager(temp_xml(body))
+
+        manager.suggest_deletion("abc def")
+
+        _assert_no_nested_ins(manager)
+        assert _visible_text(manager) == ""
+        a_ins = [e for e in _ins_elems(manager) if e.getAttribute("w:author") == AUTHOR_A]
+        assert len(a_ins) == 2
+        nested = [d for ins in a_ins for d in _nested_dels(ins)]
+        assert len(nested) == 2
+        assert all(d.getAttribute("w:author") == AUTHOR_B for d in nested)
+        assert _del_text(nested[0]) == "abc "
+        assert _del_text(nested[1]) == "def"
+
 
 class TestReplaceInsideForeignIns:
     """B replacing text inside A's insertion: nested del + sibling B ins."""
@@ -320,6 +340,53 @@ class TestInsertInsideForeignIns:
         assert len(b_ins) == 1
         assert _ins_visible_text(b_ins[0]) == "brave "
         assert change_id == int(b_ins[0].getAttribute("w:id"))
+
+    def test_insert_after_at_run_boundary_inside_foreign_ins(self, temp_xml):
+        """Anchor ends exactly at a run boundary (not the ins end): no mid-run split."""
+        xml_path = temp_xml(f"<w:p>{_foreign_ins('<w:r><w:t>Hello</w:t></w:r><w:r><w:t> world</w:t></w:r>')}</w:p>")
+        manager = _make_manager(xml_path)
+
+        manager.insert_text_after("Hello", "X")
+
+        _assert_no_nested_ins(manager)
+        assert _visible_text(manager) == "HelloX world"
+        ins_elems = _ins_elems(manager)
+        a_ins = [e for e in ins_elems if e.getAttribute("w:author") == AUTHOR_A]
+        b_ins = [e for e in ins_elems if e.getAttribute("w:author") == AUTHOR_B]
+        assert len(a_ins) == 2
+        assert len(b_ins) == 1
+        assert _ins_visible_text(a_ins[0]) == "Hello"
+        assert _ins_visible_text(a_ins[1]) == " world"
+
+    def test_insert_before_at_run_boundary_inside_foreign_ins(self, temp_xml):
+        """Anchor starts exactly at a run boundary (not the ins start): no mid-run split."""
+        xml_path = temp_xml(f"<w:p>{_foreign_ins('<w:r><w:t>Hello </w:t></w:r><w:r><w:t>world</w:t></w:r>')}</w:p>")
+        manager = _make_manager(xml_path)
+
+        manager.insert_text_before("world", "X")
+
+        _assert_no_nested_ins(manager)
+        assert _visible_text(manager) == "Hello Xworld"
+        ins_elems = _ins_elems(manager)
+        a_ins = [e for e in ins_elems if e.getAttribute("w:author") == AUTHOR_A]
+        b_ins = [e for e in ins_elems if e.getAttribute("w:author") == AUTHOR_B]
+        assert len(a_ins) == 2
+        assert len(b_ins) == 1
+        assert _ins_visible_text(a_ins[0]) == "Hello "
+        assert _ins_visible_text(a_ins[1]) == "world"
+
+    def test_insert_mid_run_with_non_text_child(self, temp_xml):
+        """Mid-run split of a run that also carries a w:tab (front-hoisted, see #20)."""
+        xml_path = temp_xml(f"<w:p>{_foreign_ins('<w:r><w:tab/><w:t>Hello world</w:t></w:r>')}</w:p>")
+        manager = _make_manager(xml_path)
+
+        manager.insert_text_after("Hello", "X")
+
+        _assert_no_nested_ins(manager)
+        assert _visible_text(manager) == "HelloX world"
+        a_ins = [e for e in _ins_elems(manager) if e.getAttribute("w:author") == AUTHOR_A]
+        assert len(a_ins) == 2
+        assert len(a_ins[0].getElementsByTagName("w:tab")) == 1
 
     def test_insert_before_at_ins_start_no_split(self, temp_xml):
         xml_path = temp_xml(f"<w:p>{_foreign_ins('<w:r><w:t>Hello</w:t></w:r>')}</w:p>")

--- a/tests/test_foreign_ins_edits.py
+++ b/tests/test_foreign_ins_edits.py
@@ -1,0 +1,750 @@
+"""Tests for author-aware edits inside another author's pending insertion.
+
+When the current author (B) edits text that sits inside a foreign author's
+(A's) pending ``w:ins``, the edit must not destroy A's proposal:
+
+- B deleting text inside A's insertion nests a ``<w:del w:author="B">``
+  inside A's ``w:ins`` (Word's own behavior).
+- B replacing text produces that nested deletion plus B's own *sibling*
+  ``<w:ins>`` carrying the replacement — never nested inside A's.
+- B inserting text mid-insertion splits A's ``w:ins`` into two siblings
+  (both keeping A's author/date, fresh ids) with B's ``w:ins`` between.
+
+Edits inside the current author's *own* insertions keep the historical
+in-place behavior (no ``w:del``, direct text surgery).
+"""
+
+from pathlib import Path
+
+import pytest
+
+from docx_editor.track_changes import RevisionManager
+from docx_editor.xml_editor import DocxXMLEditor, compute_paragraph_hash
+
+NS = 'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"'
+
+AUTHOR_A = "Reviewer A"
+AUTHOR_B = "Reviewer B"
+DATE_A = "2024-01-01T00:00:00Z"
+
+
+@pytest.fixture
+def temp_xml(tmp_path):
+    """Fixture that returns a function to create temp XML files."""
+
+    def _create_xml(body_xml: str) -> Path:
+        xml = f'<?xml version="1.0" encoding="utf-8"?><w:document {NS}><w:body>{body_xml}</w:body></w:document>'
+        xml_path = tmp_path / "test_doc.xml"
+        xml_path.write_text(xml)
+        return xml_path
+
+    return _create_xml
+
+
+def _make_manager(xml_path: Path, author: str = AUTHOR_B) -> RevisionManager:
+    """Create a RevisionManager editing as ``author``."""
+    editor = DocxXMLEditor(xml_path, rsid="00000000", author=author)
+    return RevisionManager(editor)
+
+
+def _foreign_ins(content: str, ins_id: int = 1) -> str:
+    """Wrap run XML in a w:ins authored by Reviewer A."""
+    return f'<w:ins w:id="{ins_id}" w:author="{AUTHOR_A}" w:date="{DATE_A}">{content}</w:ins>'
+
+
+def _ins_elems(manager: RevisionManager) -> list:
+    return list(manager.editor.dom.getElementsByTagName("w:ins"))
+
+
+def _del_elems(manager: RevisionManager) -> list:
+    return list(manager.editor.dom.getElementsByTagName("w:del"))
+
+
+def _visible_text(manager: RevisionManager) -> str:
+    """Accepted-view text: all w:t content not inside w:del."""
+    result = []
+    for wt in manager.editor.dom.getElementsByTagName("w:t"):
+        parent = wt.parentNode
+        inside_del = False
+        while parent:
+            if parent.nodeType == parent.ELEMENT_NODE and parent.tagName == "w:del":
+                inside_del = True
+                break
+            parent = parent.parentNode
+        if not inside_del:
+            result.append("".join(c.data for c in wt.childNodes if c.nodeType == c.TEXT_NODE))
+    return "".join(result)
+
+
+def _del_text(del_elem) -> str:
+    parts = []
+    for dt in del_elem.getElementsByTagName("w:delText"):
+        parts.append("".join(c.data for c in dt.childNodes if c.nodeType == c.TEXT_NODE))
+    return "".join(parts)
+
+
+def _ins_visible_text(ins_elem) -> str:
+    """Text of an insertion excluding any nested deletion content."""
+    parts = []
+    for wt in ins_elem.getElementsByTagName("w:t"):
+        parent = wt.parentNode
+        inside_del = False
+        while parent is not ins_elem and parent is not None:
+            if parent.nodeType == parent.ELEMENT_NODE and parent.tagName == "w:del":
+                inside_del = True
+                break
+            parent = parent.parentNode
+        if not inside_del:
+            parts.append("".join(c.data for c in wt.childNodes if c.nodeType == c.TEXT_NODE))
+    return "".join(parts)
+
+
+def _assert_no_nested_ins(manager: RevisionManager) -> None:
+    """No w:ins may ever nest inside another w:ins (invalid OOXML)."""
+    for ins in _ins_elems(manager):
+        assert len(ins.getElementsByTagName("w:ins")) == 0, f"Nested w:ins inside w:ins: {ins.toxml()}"
+
+
+def _assert_no_del_in_own_ins(manager: RevisionManager, own_author: str) -> None:
+    """Our own insertions are edited in place — never via nested w:del."""
+    for ins in _ins_elems(manager):
+        if ins.getAttribute("w:author") == own_author:
+            assert len(ins.getElementsByTagName("w:del")) == 0, f"w:del nested inside our own w:ins: {ins.toxml()}"
+
+
+def _nested_dels(ins_elem) -> list:
+    return list(ins_elem.getElementsByTagName("w:del"))
+
+
+class TestDeleteInsideForeignIns:
+    """B deleting text inside A's pending insertion nests a w:del by B."""
+
+    def test_delete_mid_single_run(self, temp_xml):
+        xml_path = temp_xml(f"<w:p>{_foreign_ins('<w:r><w:t>Hello world today</w:t></w:r>')}</w:p>")
+        manager = _make_manager(xml_path)
+
+        manager.suggest_deletion("world")
+
+        _assert_no_nested_ins(manager)
+        ins_elems = _ins_elems(manager)
+        assert len(ins_elems) == 1
+        a_ins = ins_elems[0]
+        # A's proposal survives untouched: element, author, and id preserved
+        assert a_ins.getAttribute("w:author") == AUTHOR_A
+        assert a_ins.getAttribute("w:id") == "1"
+        assert a_ins.getAttribute("w:date") == DATE_A
+        # B's counter-proposal nests inside it
+        dels = _nested_dels(a_ins)
+        assert len(dels) == 1
+        assert dels[0].getAttribute("w:author") == AUTHOR_B
+        assert _del_text(dels[0]) == "world"
+        # Surviving insertion text keeps its order
+        assert _ins_visible_text(a_ins) == "Hello  today"
+        assert _visible_text(manager) == "Hello  today"
+
+    def test_delete_at_start(self, temp_xml):
+        xml_path = temp_xml(f"<w:p>{_foreign_ins('<w:r><w:t>Hello world</w:t></w:r>')}</w:p>")
+        manager = _make_manager(xml_path)
+
+        manager.suggest_deletion("Hello ")
+
+        a_ins = _ins_elems(manager)[0]
+        dels = _nested_dels(a_ins)
+        assert len(dels) == 1
+        assert _del_text(dels[0]) == "Hello "
+        assert _visible_text(manager) == "world"
+        # Deletion comes before the surviving text inside the ins
+        children = [c for c in a_ins.childNodes if c.nodeType == c.ELEMENT_NODE]
+        assert children[0].tagName == "w:del"
+
+    def test_delete_at_end(self, temp_xml):
+        xml_path = temp_xml(f"<w:p>{_foreign_ins('<w:r><w:t>Hello world</w:t></w:r>')}</w:p>")
+        manager = _make_manager(xml_path)
+
+        manager.suggest_deletion(" world")
+
+        a_ins = _ins_elems(manager)[0]
+        dels = _nested_dels(a_ins)
+        assert len(dels) == 1
+        assert _del_text(dels[0]) == " world"
+        assert _visible_text(manager) == "Hello"
+        children = [c for c in a_ins.childNodes if c.nodeType == c.ELEMENT_NODE]
+        assert children[-1].tagName == "w:del"
+
+    def test_delete_across_runs(self, temp_xml):
+        xml_path = temp_xml(f"<w:p>{_foreign_ins('<w:r><w:t>Hello </w:t></w:r><w:r><w:t>world</w:t></w:r>')}</w:p>")
+        manager = _make_manager(xml_path)
+
+        manager.suggest_deletion("lo wor")
+
+        _assert_no_nested_ins(manager)
+        ins_elems = _ins_elems(manager)
+        assert len(ins_elems) == 1
+        a_ins = ins_elems[0]
+        assert a_ins.getAttribute("w:author") == AUTHOR_A
+        dels = _nested_dels(a_ins)
+        assert len(dels) >= 1
+        for d in dels:
+            assert d.getAttribute("w:author") == AUTHOR_B
+        assert "".join(_del_text(d) for d in dels) == "lo wor"
+        assert _visible_text(manager) == "Helld"
+
+    def test_delete_entire_insertion_content(self, temp_xml):
+        xml_path = temp_xml(f"<w:p>{_foreign_ins('<w:r><w:t>Hello</w:t></w:r>')}</w:p>")
+        manager = _make_manager(xml_path)
+
+        manager.suggest_deletion("Hello")
+
+        # A's ins survives, holding only B's nested deletion
+        ins_elems = _ins_elems(manager)
+        assert len(ins_elems) == 1
+        a_ins = ins_elems[0]
+        assert a_ins.getAttribute("w:author") == AUTHOR_A
+        dels = _nested_dels(a_ins)
+        assert len(dels) == 1
+        assert _del_text(dels[0]) == "Hello"
+        assert _visible_text(manager) == ""
+
+    def test_delete_returns_real_change_id(self, temp_xml):
+        xml_path = temp_xml(f"<w:p>{_foreign_ins('<w:r><w:t>Hello world</w:t></w:r>')}</w:p>")
+        manager = _make_manager(xml_path)
+
+        change_id = manager.suggest_deletion("world")
+
+        dels = _del_elems(manager)
+        assert len(dels) == 1
+        assert change_id == int(dels[0].getAttribute("w:id"))
+
+
+class TestReplaceInsideForeignIns:
+    """B replacing text inside A's insertion: nested del + sibling B ins."""
+
+    def test_replace_mid_splits_foreign_ins(self, temp_xml):
+        xml_path = temp_xml(f"<w:p>{_foreign_ins('<w:r><w:t>Hello world today</w:t></w:r>')}</w:p>")
+        manager = _make_manager(xml_path)
+
+        change_id = manager.replace_text("world", "earth")
+
+        _assert_no_nested_ins(manager)
+        assert _visible_text(manager) == "Hello earth today"
+
+        ins_elems = _ins_elems(manager)
+        a_ins = [e for e in ins_elems if e.getAttribute("w:author") == AUTHOR_A]
+        b_ins = [e for e in ins_elems if e.getAttribute("w:author") == AUTHOR_B]
+        # A's insertion is split into two halves around B's replacement
+        assert len(a_ins) == 2
+        assert len(b_ins) == 1
+        # Halves keep A's identity with fresh, distinct ids
+        assert a_ins[0].getAttribute("w:date") == DATE_A
+        assert a_ins[1].getAttribute("w:date") == DATE_A
+        assert a_ins[0].getAttribute("w:id") != a_ins[1].getAttribute("w:id")
+        # The nested deletion carries B's authorship
+        dels = _nested_dels(a_ins[0])
+        assert len(dels) == 1
+        assert dels[0].getAttribute("w:author") == AUTHOR_B
+        assert _del_text(dels[0]) == "world"
+        # The second half holds the split-off tail
+        assert _ins_visible_text(a_ins[1]) == " today"
+        # B's replacement sits between the halves, never nested
+        assert _ins_visible_text(b_ins[0]) == "earth"
+        assert change_id == int(b_ins[0].getAttribute("w:id"))
+
+    def test_replace_at_end_no_split_needed(self, temp_xml):
+        xml_path = temp_xml(f"<w:p>{_foreign_ins('<w:r><w:t>Hello world</w:t></w:r>')}</w:p>")
+        manager = _make_manager(xml_path)
+
+        manager.replace_text("world", "earth")
+
+        _assert_no_nested_ins(manager)
+        assert _visible_text(manager) == "Hello earth"
+        ins_elems = _ins_elems(manager)
+        a_ins = [e for e in ins_elems if e.getAttribute("w:author") == AUTHOR_A]
+        b_ins = [e for e in ins_elems if e.getAttribute("w:author") == AUTHOR_B]
+        # No trailing text — no split required
+        assert len(a_ins) == 1
+        assert len(b_ins) == 1
+        assert _del_text(_nested_dels(a_ins[0])[0]) == "world"
+        assert _ins_visible_text(b_ins[0]) == "earth"
+
+    def test_replace_across_runs(self, temp_xml):
+        xml_path = temp_xml(f"<w:p>{_foreign_ins('<w:r><w:t>Hello </w:t></w:r><w:r><w:t>world</w:t></w:r>')}</w:p>")
+        manager = _make_manager(xml_path)
+
+        manager.replace_text("lo wor", "LO WOR")
+
+        _assert_no_nested_ins(manager)
+        assert _visible_text(manager) == "HelLO WORld"
+        a_ins = [e for e in _ins_elems(manager) if e.getAttribute("w:author") == AUTHOR_A]
+        for ins in a_ins:
+            assert ins.getAttribute("w:date") == DATE_A
+        all_nested = [d for ins in a_ins for d in _nested_dels(ins)]
+        assert "".join(_del_text(d) for d in all_nested) == "lo wor"
+
+
+class TestInsertInsideForeignIns:
+    """B inserting with an anchor inside A's insertion."""
+
+    def test_insert_after_mid_splits_foreign_ins(self, temp_xml):
+        xml_path = temp_xml(f"<w:p>{_foreign_ins('<w:r><w:t>Hello world</w:t></w:r>')}</w:p>")
+        manager = _make_manager(xml_path)
+
+        change_id = manager.insert_text_after("Hello", " brave")
+
+        _assert_no_nested_ins(manager)
+        assert _visible_text(manager) == "Hello brave world"
+        ins_elems = _ins_elems(manager)
+        a_ins = [e for e in ins_elems if e.getAttribute("w:author") == AUTHOR_A]
+        b_ins = [e for e in ins_elems if e.getAttribute("w:author") == AUTHOR_B]
+        assert len(a_ins) == 2
+        assert len(b_ins) == 1
+        assert _ins_visible_text(a_ins[0]) == "Hello"
+        assert _ins_visible_text(b_ins[0]) == " brave"
+        assert _ins_visible_text(a_ins[1]) == " world"
+        # Split halves keep A's identity, fresh distinct ids
+        assert a_ins[0].getAttribute("w:date") == DATE_A
+        assert a_ins[1].getAttribute("w:date") == DATE_A
+        assert a_ins[0].getAttribute("w:id") != a_ins[1].getAttribute("w:id")
+        assert change_id == int(b_ins[0].getAttribute("w:id"))
+
+    def test_insert_before_mid_splits_foreign_ins(self, temp_xml):
+        xml_path = temp_xml(f"<w:p>{_foreign_ins('<w:r><w:t>Hello world</w:t></w:r>')}</w:p>")
+        manager = _make_manager(xml_path)
+
+        change_id = manager.insert_text_before("world", "brave ")
+
+        _assert_no_nested_ins(manager)
+        assert _visible_text(manager) == "Hello brave world"
+        b_ins = [e for e in _ins_elems(manager) if e.getAttribute("w:author") == AUTHOR_B]
+        assert len(b_ins) == 1
+        assert _ins_visible_text(b_ins[0]) == "brave "
+        assert change_id == int(b_ins[0].getAttribute("w:id"))
+
+    def test_insert_before_at_ins_start_no_split(self, temp_xml):
+        xml_path = temp_xml(f"<w:p>{_foreign_ins('<w:r><w:t>Hello</w:t></w:r>')}</w:p>")
+        manager = _make_manager(xml_path)
+
+        change_id = manager.insert_text_before("Hello", "Say ")
+
+        _assert_no_nested_ins(manager)
+        assert _visible_text(manager) == "Say Hello"
+        ins_elems = _ins_elems(manager)
+        a_ins = [e for e in ins_elems if e.getAttribute("w:author") == AUTHOR_A]
+        b_ins = [e for e in ins_elems if e.getAttribute("w:author") == AUTHOR_B]
+        # Boundary anchor: plain sibling, A's ins untouched
+        assert len(a_ins) == 1
+        assert a_ins[0].getAttribute("w:id") == "1"
+        assert len(b_ins) == 1
+        assert change_id == int(b_ins[0].getAttribute("w:id"))
+
+    def test_insert_after_at_ins_end_no_split(self, temp_xml):
+        xml_path = temp_xml(f"<w:p>{_foreign_ins('<w:r><w:t>Hello</w:t></w:r>')}</w:p>")
+        manager = _make_manager(xml_path)
+
+        change_id = manager.insert_text_after("Hello", " world")
+
+        _assert_no_nested_ins(manager)
+        assert _visible_text(manager) == "Hello world"
+        ins_elems = _ins_elems(manager)
+        a_ins = [e for e in ins_elems if e.getAttribute("w:author") == AUTHOR_A]
+        b_ins = [e for e in ins_elems if e.getAttribute("w:author") == AUTHOR_B]
+        assert len(a_ins) == 1
+        assert a_ins[0].getAttribute("w:id") == "1"
+        assert len(b_ins) == 1
+        assert change_id == int(b_ins[0].getAttribute("w:id"))
+
+    def test_insert_anchor_across_runs_inside_foreign_ins(self, temp_xml):
+        xml_path = temp_xml(f"<w:p>{_foreign_ins('<w:r><w:t>Hello </w:t></w:r><w:r><w:t>world</w:t></w:r>')}</w:p>")
+        manager = _make_manager(xml_path)
+
+        change_id = manager.insert_text_after("lo wor", "!!")
+
+        _assert_no_nested_ins(manager)
+        assert _visible_text(manager) == "Hello wor!!ld"
+        b_ins = [e for e in _ins_elems(manager) if e.getAttribute("w:author") == AUTHOR_B]
+        assert len(b_ins) == 1
+        assert change_id == int(b_ins[0].getAttribute("w:id"))
+
+
+class TestMixedStateAcrossForeignBoundary:
+    """Matches straddling regular text and a foreign insertion."""
+
+    def test_replace_regular_into_foreign_ins(self, temp_xml):
+        body = f"<w:p><w:r><w:t>Hello </w:t></w:r>{_foreign_ins('<w:r><w:t>world</w:t></w:r>')}</w:p>"
+        xml_path = temp_xml(body)
+        manager = _make_manager(xml_path)
+
+        manager.replace_text("lo wor", "LO WOR")
+
+        _assert_no_nested_ins(manager)
+        assert _visible_text(manager) == "HelLO WORld"
+        # Regular part -> top-level del; foreign part -> nested del by B
+        a_ins = [e for e in _ins_elems(manager) if e.getAttribute("w:author") == AUTHOR_A]
+        assert len(a_ins) == 1
+        nested = _nested_dels(a_ins[0])
+        assert len(nested) == 1
+        assert nested[0].getAttribute("w:author") == AUTHOR_B
+        assert _del_text(nested[0]) == "wor"
+        top_level = [d for d in _del_elems(manager) if d not in nested]
+        assert "".join(_del_text(d) for d in top_level) == "lo "
+        assert _ins_visible_text(a_ins[0]) == "ld"
+
+    def test_replace_foreign_ins_into_regular(self, temp_xml):
+        body = f"<w:p>{_foreign_ins('<w:r><w:t>Hello</w:t></w:r>')}<w:r><w:t> world</w:t></w:r></w:p>"
+        xml_path = temp_xml(body)
+        manager = _make_manager(xml_path)
+
+        manager.replace_text("lo wor", "LO WOR")
+
+        _assert_no_nested_ins(manager)
+        assert _visible_text(manager) == "HelLO WORld"
+        a_ins = [e for e in _ins_elems(manager) if e.getAttribute("w:author") == AUTHOR_A]
+        assert len(a_ins) == 1
+        nested = _nested_dels(a_ins[0])
+        assert len(nested) == 1
+        assert _del_text(nested[0]) == "lo"
+        assert _ins_visible_text(a_ins[0]) == "Hel"
+        top_level = [d for d in _del_elems(manager) if d not in nested]
+        assert "".join(_del_text(d) for d in top_level) == " wor"
+
+    def test_delete_regular_into_foreign_ins(self, temp_xml):
+        body = f"<w:p><w:r><w:t>Hello </w:t></w:r>{_foreign_ins('<w:r><w:t>world</w:t></w:r>')}</w:p>"
+        xml_path = temp_xml(body)
+        manager = _make_manager(xml_path)
+
+        change_id = manager.suggest_deletion("lo wor")
+
+        _assert_no_nested_ins(manager)
+        assert _visible_text(manager) == "Helld"
+        a_ins = [e for e in _ins_elems(manager) if e.getAttribute("w:author") == AUTHOR_A]
+        assert len(a_ins) == 1
+        nested = _nested_dels(a_ins[0])
+        assert len(nested) == 1
+        assert _del_text(nested[0]) == "wor"
+        assert change_id >= 0
+
+    def test_mixed_replace_accept_and_reject_round_trip(self, temp_xml):
+        body = f"<w:p><w:r><w:t>Hello </w:t></w:r>{_foreign_ins('<w:r><w:t>world</w:t></w:r>')}</w:p>"
+
+        # Accepting everything lands on B's outcome
+        manager = _make_manager(temp_xml(body))
+        manager.replace_text("lo wor", "LO WOR")
+        manager.accept_all()
+        assert _visible_text(manager) == "HelLO WORld"
+        assert not _ins_elems(manager)
+        assert not _del_elems(manager)
+
+        # Rejecting everything restores the pre-A original (regular text only)
+        manager = _make_manager(temp_xml(body))
+        manager.replace_text("lo wor", "LO WOR")
+        manager.reject_all()
+        assert _visible_text(manager) == "Hello "
+        assert not _ins_elems(manager)
+        assert not _del_elems(manager)
+
+        # Rejecting only B leaves A's pending insertion intact
+        manager = _make_manager(temp_xml(body))
+        manager.replace_text("lo wor", "LO WOR")
+        manager.reject_all(author=AUTHOR_B)
+        assert _visible_text(manager) == "Hello world"
+        a_ins = [e for e in _ins_elems(manager) if e.getAttribute("w:author") == AUTHOR_A]
+        assert len(a_ins) == 1
+        assert _ins_visible_text(a_ins[0]) == "world"
+
+
+class TestRewriteParagraphWithForeignIns:
+    """rewrite_paragraph diffs that land inside a foreign insertion."""
+
+    def _rewrite(self, manager: RevisionManager, new_text: str) -> None:
+        p = manager.editor.dom.getElementsByTagName("w:p")[0]
+        ref = f"P1#{compute_paragraph_hash(p)}"
+        manager.rewrite_paragraph(ref, new_text)
+
+    def test_rewrite_insert_inside_foreign_ins(self, temp_xml):
+        xml_path = temp_xml(f"<w:p>{_foreign_ins('<w:r><w:t>Hello world</w:t></w:r>')}</w:p>")
+        manager = _make_manager(xml_path)
+
+        self._rewrite(manager, "Hello brave world")
+
+        _assert_no_nested_ins(manager)
+        assert _visible_text(manager) == "Hello brave world"
+        ins_elems = _ins_elems(manager)
+        a_ins = [e for e in ins_elems if e.getAttribute("w:author") == AUTHOR_A]
+        b_ins = [e for e in ins_elems if e.getAttribute("w:author") == AUTHOR_B]
+        # A's content stays under A's authorship; B's words under B's
+        assert "".join(_ins_visible_text(e) for e in a_ins) == "Hello world"
+        assert "".join(_ins_visible_text(e) for e in b_ins) == "brave "
+
+    def test_rewrite_delete_inside_foreign_ins(self, temp_xml):
+        xml_path = temp_xml(f"<w:p>{_foreign_ins('<w:r><w:t>Hello brave world</w:t></w:r>')}</w:p>")
+        manager = _make_manager(xml_path)
+
+        self._rewrite(manager, "Hello world")
+
+        _assert_no_nested_ins(manager)
+        assert _visible_text(manager) == "Hello world"
+        a_ins = [e for e in _ins_elems(manager) if e.getAttribute("w:author") == AUTHOR_A]
+        all_nested = [d for ins in a_ins for d in _nested_dels(ins)]
+        assert len(all_nested) >= 1
+        for d in all_nested:
+            assert d.getAttribute("w:author") == AUTHOR_B
+        assert "".join(_del_text(d) for d in all_nested) == "brave "
+
+    def test_rewrite_append_at_end_of_foreign_ins(self, temp_xml):
+        xml_path = temp_xml(f"<w:p>{_foreign_ins('<w:r><w:t>Hello</w:t></w:r>')}</w:p>")
+        manager = _make_manager(xml_path)
+
+        self._rewrite(manager, "Hello world")
+
+        _assert_no_nested_ins(manager)
+        assert _visible_text(manager) == "Hello world"
+        ins_elems = _ins_elems(manager)
+        a_ins = [e for e in ins_elems if e.getAttribute("w:author") == AUTHOR_A]
+        b_ins = [e for e in ins_elems if e.getAttribute("w:author") == AUTHOR_B]
+        assert len(a_ins) == 1
+        assert _ins_visible_text(a_ins[0]) == "Hello"
+        assert "".join(_ins_visible_text(e) for e in b_ins) == " world"
+
+
+class TestResolutionMatrix:
+    """accept_all / reject_all outcomes for B's edits inside A's insertion."""
+
+    DELETE_BODY = f"<w:p>{_foreign_ins('<w:r><w:t>Hello world</w:t></w:r>')}</w:p>"
+
+    def _managed_delete(self, temp_xml) -> RevisionManager:
+        manager = _make_manager(temp_xml(self.DELETE_BODY))
+        manager.suggest_deletion("world")
+        return manager
+
+    def test_accept_all_applies_both(self, temp_xml):
+        manager = self._managed_delete(temp_xml)
+        manager.accept_all()
+        assert _visible_text(manager) == "Hello "
+        assert not _ins_elems(manager)
+        assert not _del_elems(manager)
+
+    def test_reject_all_restores_original(self, temp_xml):
+        manager = self._managed_delete(temp_xml)
+        manager.reject_all()
+        # A's insertion (and B's edit with it) fully gone
+        assert _visible_text(manager) == ""
+        assert not _ins_elems(manager)
+        assert not _del_elems(manager)
+
+    def test_reject_b_keeps_a_intact(self, temp_xml):
+        manager = self._managed_delete(temp_xml)
+        rejected = manager.reject_all(author=AUTHOR_B)
+        assert rejected == 1
+        a_ins = [e for e in _ins_elems(manager) if e.getAttribute("w:author") == AUTHOR_A]
+        assert len(a_ins) == 1
+        assert _ins_visible_text(a_ins[0]) == "Hello world"
+        assert not _del_elems(manager)
+
+    def test_accept_a_leaves_b_pending_top_level(self, temp_xml):
+        manager = self._managed_delete(temp_xml)
+        manager.accept_all(author=AUTHOR_A)
+        # A's text becomes regular; B's deletion is now a pending top-level del
+        assert _visible_text(manager) == "Hello "
+        assert not _ins_elems(manager)
+        dels = _del_elems(manager)
+        assert len(dels) == 1
+        assert dels[0].getAttribute("w:author") == AUTHOR_B
+        assert _del_text(dels[0]) == "world"
+
+    def test_accept_b_resolves_del_keeps_a_pending(self, temp_xml):
+        manager = self._managed_delete(temp_xml)
+        manager.accept_all(author=AUTHOR_B)
+        assert _visible_text(manager) == "Hello "
+        a_ins = [e for e in _ins_elems(manager) if e.getAttribute("w:author") == AUTHOR_A]
+        assert len(a_ins) == 1
+        assert _ins_visible_text(a_ins[0]) == "Hello "
+        assert not _del_elems(manager)
+
+    def test_replace_matrix_accept_all(self, temp_xml):
+        manager = _make_manager(temp_xml(self.DELETE_BODY))
+        manager.replace_text("world", "earth")
+        manager.accept_all()
+        assert _visible_text(manager) == "Hello earth"
+        assert not _ins_elems(manager)
+        assert not _del_elems(manager)
+
+    def test_replace_matrix_reject_all(self, temp_xml):
+        manager = _make_manager(temp_xml(self.DELETE_BODY))
+        manager.replace_text("world", "earth")
+        manager.reject_all()
+        assert _visible_text(manager) == ""
+        assert not _ins_elems(manager)
+        assert not _del_elems(manager)
+
+    def test_replace_matrix_reject_b_only(self, temp_xml):
+        manager = _make_manager(temp_xml(self.DELETE_BODY))
+        manager.replace_text("world", "earth")
+        manager.reject_all(author=AUTHOR_B)
+        a_ins = [e for e in _ins_elems(manager) if e.getAttribute("w:author") == AUTHOR_A]
+        assert "".join(_ins_visible_text(e) for e in a_ins) == "Hello world"
+        assert not _del_elems(manager)
+        assert _visible_text(manager) == "Hello world"
+
+    def test_replace_matrix_accept_b_only(self, temp_xml):
+        manager = _make_manager(temp_xml(self.DELETE_BODY))
+        manager.replace_text("world", "earth")
+        manager.accept_all(author=AUTHOR_B)
+        # B's del and ins resolve; A's remaining insertion stays pending
+        assert _visible_text(manager) == "Hello earth"
+        assert not _del_elems(manager)
+        remaining = _ins_elems(manager)
+        assert remaining
+        for ins in remaining:
+            assert ins.getAttribute("w:author") == AUTHOR_A
+
+
+class TestSameAuthorInPlaceUnchanged:
+    """Author matches -> historical in-place editing, no nesting of anything."""
+
+    def _own_ins(self, content: str) -> str:
+        return f'<w:ins w:id="1" w:author="{AUTHOR_B}" w:date="{DATE_A}">{content}</w:ins>'
+
+    def test_own_delete_stays_physical(self, temp_xml):
+        xml_path = temp_xml(f"<w:p>{self._own_ins('<w:r><w:t>Hello world</w:t></w:r>')}</w:p>")
+        manager = _make_manager(xml_path)
+
+        manager.suggest_deletion(" world")
+
+        assert not _del_elems(manager)
+        _assert_no_nested_ins(manager)
+        _assert_no_del_in_own_ins(manager, AUTHOR_B)
+        assert _visible_text(manager) == "Hello"
+
+    def test_own_replace_stays_in_place(self, temp_xml):
+        xml_path = temp_xml(f"<w:p>{self._own_ins('<w:r><w:t>Hello world</w:t></w:r>')}</w:p>")
+        manager = _make_manager(xml_path)
+
+        manager.replace_text("world", "earth")
+
+        assert not _del_elems(manager)
+        _assert_no_nested_ins(manager)
+        _assert_no_del_in_own_ins(manager, AUTHOR_B)
+        text = _visible_text(manager)
+        assert "earth" in text
+        assert "world" not in text
+
+    def test_own_insert_splices(self, temp_xml):
+        xml_path = temp_xml(f"<w:p>{self._own_ins('<w:r><w:t>Hello world</w:t></w:r>')}</w:p>")
+        manager = _make_manager(xml_path)
+
+        manager.insert_text_after("Hello", " brave")
+
+        assert not _del_elems(manager)
+        _assert_no_nested_ins(manager)
+        assert len(_ins_elems(manager)) == 1
+        assert _visible_text(manager) == "Hello brave world"
+
+    def test_adjacent_own_and_foreign_ins_delete(self, temp_xml):
+        body = (
+            f'<w:p><w:ins w:id="1" w:author="{AUTHOR_B}" w:date="{DATE_A}">'
+            "<w:r><w:t>abc </w:t></w:r></w:ins>"
+            f"{_foreign_ins('<w:r><w:t>def</w:t></w:r>', ins_id=2)}</w:p>"
+        )
+        xml_path = temp_xml(body)
+        manager = _make_manager(xml_path)
+
+        manager.suggest_deletion("abc def")
+
+        _assert_no_nested_ins(manager)
+        _assert_no_del_in_own_ins(manager, AUTHOR_B)
+        assert _visible_text(manager) == ""
+        # Own half physically removed; foreign half survives with nested del
+        ins_elems = _ins_elems(manager)
+        b_ins = [e for e in ins_elems if e.getAttribute("w:author") == AUTHOR_B]
+        a_ins = [e for e in ins_elems if e.getAttribute("w:author") == AUTHOR_A]
+        assert not b_ins
+        assert len(a_ins) == 1
+        nested = _nested_dels(a_ins[0])
+        assert len(nested) == 1
+        assert _del_text(nested[0]) == "def"
+
+
+class TestMissingAuthorTreatedAsForeign:
+    """An ins without w:author can't be attributed to us — never edit in place."""
+
+    def test_delete_in_authorless_ins_nests(self, temp_xml):
+        body = '<w:p><w:ins w:id="1" w:date="2024-01-01T00:00:00Z"><w:r><w:t>Hello world</w:t></w:r></w:ins></w:p>'
+        xml_path = temp_xml(body)
+        manager = _make_manager(xml_path)
+
+        manager.suggest_deletion("world")
+
+        ins_elems = _ins_elems(manager)
+        assert len(ins_elems) == 1
+        dels = _nested_dels(ins_elems[0])
+        assert len(dels) == 1
+        assert _del_text(dels[0]) == "world"
+
+
+class TestDocumentIntegration:
+    """Two-session flow through the public Document API."""
+
+    def test_two_author_review_flow(self, temp_docx):
+        from docx_editor import Document
+        from tests.conftest import find_ref
+
+        # Session 1: A proposes an insertion
+        doc = Document.open(temp_docx, author=AUTHOR_A)
+        try:
+            ref = find_ref(doc, "quick brown fox")
+            doc.insert_after("fox", " PROPOSAL", paragraph=ref)
+            doc.save()
+        finally:
+            doc.close()
+
+        # Session 2: B edits inside A's pending insertion
+        doc = Document.open(temp_docx, author=AUTHOR_B)
+        try:
+            ref = find_ref(doc, "PROPOSAL")
+            doc.replace("PROPOSAL", "REVISED", paragraph=ref)
+            doc.save()
+        finally:
+            doc.close()
+
+        # Session 3: both authors' revisions are present and resolvable
+        doc = Document.open(temp_docx, author="Reviewer C")
+        try:
+            revisions = doc.list_revisions()
+            authors = {r.author for r in revisions}
+            assert AUTHOR_A in authors
+            assert AUTHOR_B in authors
+            deletions = [r for r in revisions if r.type == "deletion"]
+            assert any(r.author == AUTHOR_B and "PROPOSAL" in r.text for r in deletions)
+
+            doc.accept_all()
+            assert doc.list_revisions() == []
+            full_text = "\n".join(doc.list_paragraphs(max_chars=500))
+            assert "REVISED" in full_text
+            assert "PROPOSAL" not in full_text
+            doc.save()
+        finally:
+            doc.close()
+
+    def test_reject_b_preserves_a_proposal_via_document(self, temp_docx):
+        from docx_editor import Document
+        from tests.conftest import find_ref
+
+        doc = Document.open(temp_docx, author=AUTHOR_A)
+        try:
+            ref = find_ref(doc, "quick brown fox")
+            doc.insert_after("fox", " PROPOSAL", paragraph=ref)
+            doc.save()
+        finally:
+            doc.close()
+
+        doc = Document.open(temp_docx, author=AUTHOR_B)
+        try:
+            ref = find_ref(doc, "PROPOSAL")
+            doc.delete("PROPOSAL", paragraph=ref)
+            doc.reject_all(author=AUTHOR_B)
+            # A's proposal must survive B's retracted edit
+            revisions = doc.list_revisions()
+            assert len(revisions) == 1
+            assert revisions[0].author == AUTHOR_A
+            assert "PROPOSAL" in revisions[0].text
+        finally:
+            doc.close()

--- a/tests/test_foreign_ins_edits.py
+++ b/tests/test_foreign_ins_edits.py
@@ -17,7 +17,9 @@ in-place behavior (no ``w:del``, direct text surgery).
 from pathlib import Path
 
 import pytest
+from conftest import find_ref
 
+from docx_editor import Document
 from docx_editor.track_changes import RevisionManager
 from docx_editor.xml_editor import DocxXMLEditor, compute_paragraph_hash
 
@@ -684,9 +686,6 @@ class TestDocumentIntegration:
     """Two-session flow through the public Document API."""
 
     def test_two_author_review_flow(self, temp_docx):
-        from docx_editor import Document
-        from tests.conftest import find_ref
-
         # Session 1: A proposes an insertion
         doc = Document.open(temp_docx, author=AUTHOR_A)
         try:
@@ -725,9 +724,6 @@ class TestDocumentIntegration:
             doc.close()
 
     def test_reject_b_preserves_a_proposal_via_document(self, temp_docx):
-        from docx_editor import Document
-        from tests.conftest import find_ref
-
         doc = Document.open(temp_docx, author=AUTHOR_A)
         try:
             ref = find_ref(doc, "quick brown fox")

--- a/tests/test_multi_wt_safety.py
+++ b/tests/test_multi_wt_safety.py
@@ -70,7 +70,7 @@ class TestSingleNodeRemovalGuard:
 
     def test_remove_one_run_preserves_sibling(self, temp_xml):
         xml_path = temp_xml(
-            '<w:p><w:ins w:id="1" w:author="A" w:date="2024-01-01T00:00:00Z">'
+            '<w:p><w:ins w:id="1" w:author="Test Author" w:date="2024-01-01T00:00:00Z">'
             "<w:r><w:t>Hello </w:t></w:r>"
             "<w:r><w:t>world</w:t></w:r>"
             "</w:ins></w:p>"
@@ -85,7 +85,7 @@ class TestSingleNodeRemovalGuard:
 
     def test_remove_one_wt_preserves_sibling_in_same_run(self, temp_xml):
         xml_path = temp_xml(
-            '<w:p><w:ins w:id="1" w:author="A" w:date="2024-01-01T00:00:00Z">'
+            '<w:p><w:ins w:id="1" w:author="Test Author" w:date="2024-01-01T00:00:00Z">'
             "<w:r><w:t>Hello </w:t><w:t>world</w:t></w:r>"
             "</w:ins></w:p>"
         )
@@ -125,7 +125,7 @@ class TestMidNodeInsertionOrder:
         xml_path = temp_xml(
             "<w:p>"
             "<w:r><w:t>Hello world</w:t></w:r>"
-            '<w:ins w:id="1" w:author="A" w:date="2024-01-01T00:00:00Z">'
+            '<w:ins w:id="1" w:author="Test Author" w:date="2024-01-01T00:00:00Z">'
             "<w:r><w:t> added</w:t></w:r>"
             "</w:ins>"
             "</w:p>"

--- a/tests/test_nested_ins.py
+++ b/tests/test_nested_ins.py
@@ -1,7 +1,10 @@
-"""Tests for nested w:ins prevention.
+"""Tests for same-author in-place editing inside w:ins.
 
-These tests verify that operations inside existing w:ins elements do not create
-nested w:ins or w:del elements, which are invalid in OOXML.
+These tests verify that operations inside the current author's *own* w:ins
+elements edit the insertion in place: no nested w:ins (invalid OOXML) and no
+w:del inside our own w:ins (our own pending text is simply rewritten, not
+counter-proposed). Edits inside *another* author's w:ins legitimately nest a
+w:del — that behavior is covered by test_foreign_ins_edits.py.
 """
 
 from pathlib import Path
@@ -42,6 +45,11 @@ def _make_manager(xml_path: Path) -> RevisionManager:
 
 def _assert_no_nested_ins(manager: RevisionManager) -> None:
     """Assert no w:ins or w:del is nested inside another w:ins.
+
+    All fixtures here are authored by the manager's own author ("Test
+    Author"), so in-place editing must never nest anything: no w:ins in
+    w:ins (invalid OOXML), and no w:del in our *own* w:ins (nested w:del is
+    reserved for edits inside a foreign author's insertion).
 
     Args:
         manager: RevisionManager to check
@@ -97,7 +105,7 @@ class TestReplaceInsideIns:
     def test_replace_inside_ins(self, temp_xml):
         """Test single-element replace inside w:ins."""
         body_xml = (
-            '<w:p><w:ins w:id="1" w:author="A" w:date="2024-01-01T00:00:00Z">'
+            '<w:p><w:ins w:id="1" w:author="Test Author" w:date="2024-01-01T00:00:00Z">'
             "<w:r><w:t>Hello world</w:t></w:r></w:ins></w:p>"
         )
         xml_path = temp_xml(body_xml)
@@ -120,7 +128,7 @@ class TestDeleteInsideIns:
     def test_delete_inside_ins(self, temp_xml):
         """Test single-element delete inside w:ins."""
         body_xml = (
-            '<w:p><w:ins w:id="1" w:author="A" w:date="2024-01-01T00:00:00Z">'
+            '<w:p><w:ins w:id="1" w:author="Test Author" w:date="2024-01-01T00:00:00Z">'
             "<w:r><w:t>Hello world</w:t></w:r></w:ins></w:p>"
         )
         xml_path = temp_xml(body_xml)
@@ -143,7 +151,8 @@ class TestInsertInsideIns:
     def test_insert_after_inside_ins(self, temp_xml):
         """Test insert_after with anchor inside w:ins."""
         body_xml = (
-            '<w:p><w:ins w:id="1" w:author="A" w:date="2024-01-01T00:00:00Z"><w:r><w:t>Hello</w:t></w:r></w:ins></w:p>'
+            '<w:p><w:ins w:id="1" w:author="Test Author" w:date="2024-01-01T00:00:00Z">'
+            "<w:r><w:t>Hello</w:t></w:r></w:ins></w:p>"
         )
         xml_path = temp_xml(body_xml)
         manager = _make_manager(xml_path)
@@ -161,7 +170,8 @@ class TestInsertInsideIns:
     def test_insert_before_inside_ins(self, temp_xml):
         """Test insert_before with anchor inside w:ins."""
         body_xml = (
-            '<w:p><w:ins w:id="1" w:author="A" w:date="2024-01-01T00:00:00Z"><w:r><w:t>Hello</w:t></w:r></w:ins></w:p>'
+            '<w:p><w:ins w:id="1" w:author="Test Author" w:date="2024-01-01T00:00:00Z">'
+            "<w:r><w:t>Hello</w:t></w:r></w:ins></w:p>"
         )
         xml_path = temp_xml(body_xml)
         manager = _make_manager(xml_path)
@@ -183,7 +193,7 @@ class TestCrossBoundaryInsideIns:
     def test_cross_boundary_replace_all_inside_ins(self, temp_xml):
         """Test replace spanning two runs both inside w:ins (site D)."""
         body_xml = (
-            '<w:p><w:ins w:id="1" w:author="A" w:date="2024-01-01T00:00:00Z">'
+            '<w:p><w:ins w:id="1" w:author="Test Author" w:date="2024-01-01T00:00:00Z">'
             "<w:r><w:t>Hello </w:t></w:r><w:r><w:t>world</w:t></w:r></w:ins></w:p>"
         )
         xml_path = temp_xml(body_xml)
@@ -202,7 +212,7 @@ class TestCrossBoundaryInsideIns:
     def test_cross_boundary_delete_all_inside_ins(self, temp_xml):
         """Test delete spanning two runs both inside w:ins (site F)."""
         body_xml = (
-            '<w:p><w:ins w:id="1" w:author="A" w:date="2024-01-01T00:00:00Z">'
+            '<w:p><w:ins w:id="1" w:author="Test Author" w:date="2024-01-01T00:00:00Z">'
             "<w:r><w:t>Hello </w:t></w:r><w:r><w:t>world</w:t></w:r></w:ins></w:p>"
         )
         xml_path = temp_xml(body_xml)
@@ -221,7 +231,7 @@ class TestCrossBoundaryInsideIns:
     def test_cross_boundary_insert_near_match_inside_ins(self, temp_xml):
         """Test insert near cross-boundary match inside w:ins (sites H/I)."""
         body_xml = (
-            '<w:p><w:ins w:id="1" w:author="A" w:date="2024-01-01T00:00:00Z">'
+            '<w:p><w:ins w:id="1" w:author="Test Author" w:date="2024-01-01T00:00:00Z">'
             "<w:r><w:t>Hello </w:t></w:r><w:r><w:t>world</w:t></w:r></w:ins></w:p>"
         )
         xml_path = temp_xml(body_xml)
@@ -244,7 +254,7 @@ class TestMixedBoundaryScenarios:
     def test_replace_crossing_ins_boundary_start(self, temp_xml):
         """Test replace that starts inside w:ins and ends outside."""
         body_xml = (
-            '<w:p><w:ins w:id="1" w:author="A" w:date="2024-01-01T00:00:00Z">'
+            '<w:p><w:ins w:id="1" w:author="Test Author" w:date="2024-01-01T00:00:00Z">'
             "<w:r><w:t>Hello</w:t></w:r></w:ins><w:r><w:t> world</w:t></w:r></w:p>"
         )
         xml_path = temp_xml(body_xml)
@@ -263,7 +273,7 @@ class TestMixedBoundaryScenarios:
     def test_replace_crossing_ins_boundary_end(self, temp_xml):
         """Test replace that starts outside w:ins and ends inside."""
         body_xml = (
-            '<w:p><w:r><w:t>Hello </w:t></w:r><w:ins w:id="1" w:author="A" '
+            '<w:p><w:r><w:t>Hello </w:t></w:r><w:ins w:id="1" w:author="Test Author" '
             'w:date="2024-01-01T00:00:00Z"><w:r><w:t>world</w:t></w:r></w:ins></w:p>'
         )
         xml_path = temp_xml(body_xml)
@@ -282,7 +292,7 @@ class TestMixedBoundaryScenarios:
     def test_replace_surrounding_ins(self, temp_xml):
         """Test replace that contains an entire w:ins element."""
         body_xml = (
-            '<w:p><w:r><w:t>Hello </w:t></w:r><w:ins w:id="1" w:author="A" '
+            '<w:p><w:r><w:t>Hello </w:t></w:r><w:ins w:id="1" w:author="Test Author" '
             'w:date="2024-01-01T00:00:00Z"><w:r><w:t>big</w:t></w:r></w:ins>'
             "<w:r><w:t> world</w:t></w:r></w:p>"
         )

--- a/tests/test_review_fixes.py
+++ b/tests/test_review_fixes.py
@@ -53,7 +53,7 @@ class TestSiteDPreserveInsWrapper:
         # Two runs inside w:ins, replace all text -> ins_elem gets fully removed
         # Replacement should still be inside a w:ins
         xml_path = temp_xml(
-            '<w:p><w:ins w:id="1" w:author="A" w:date="2024-01-01T00:00:00Z">'
+            '<w:p><w:ins w:id="1" w:author="Test Author" w:date="2024-01-01T00:00:00Z">'
             "<w:r><w:t>AB</w:t></w:r><w:r><w:t>CD</w:t></w:r></w:ins></w:p>"
         )
         mgr = _make_manager(xml_path)
@@ -94,7 +94,7 @@ class TestRemoveFromInsertionPreservesSiblingWt:
         # which spans the first run's two w:t nodes, then the second run's w:t is safe.
         # Instead: put KEEP after the matched nodes so the text map is "REMOVEALSOKEEP".
         xml_path = temp_xml(
-            '<w:p><w:ins w:id="1" w:author="A" w:date="2024-01-01T00:00:00Z">'
+            '<w:p><w:ins w:id="1" w:author="Test Author" w:date="2024-01-01T00:00:00Z">'
             "<w:r><w:t>REMOVE</w:t></w:r>"
             "<w:r><w:t>ALSO</w:t><w:t>KEEP</w:t></w:r>"
             "</w:ins></w:p>"
@@ -109,7 +109,7 @@ class TestRemoveFromInsertionPreservesSiblingWt:
     def test_truncated_nodes_get_xml_space_preserve(self, temp_xml):
         # Multi-node removal where first/last nodes are truncated
         xml_path = temp_xml(
-            '<w:p><w:ins w:id="1" w:author="A" w:date="2024-01-01T00:00:00Z">'
+            '<w:p><w:ins w:id="1" w:author="Test Author" w:date="2024-01-01T00:00:00Z">'
             "<w:r><w:t>xxAB</w:t></w:r>"
             "<w:r><w:t>CDyy</w:t></w:r>"
             "</w:ins></w:p>"
@@ -185,7 +185,7 @@ class TestSiteDAttributeInjection:
         # When replacing text across runs inside <w:ins>, the new run should get
         # w:rsidR injected by DocxXMLEditor's attribute injection.
         xml_path = temp_xml(
-            '<w:p><w:ins w:id="1" w:author="A" w:date="2024-01-01T00:00:00Z">'
+            '<w:p><w:ins w:id="1" w:author="Test Author" w:date="2024-01-01T00:00:00Z">'
             "<w:r><w:t>AB</w:t></w:r><w:r><w:t>CD</w:t></w:r></w:ins></w:p>"
         )
         mgr = _make_manager(xml_path)
@@ -203,7 +203,7 @@ class TestSiteDAttributeInjection:
         # When ins_elem stays in DOM (partial removal), the inserted run should
         # also get attribute injection.
         xml_path = temp_xml(
-            '<w:p><w:ins w:id="1" w:author="A" w:date="2024-01-01T00:00:00Z">'
+            '<w:p><w:ins w:id="1" w:author="Test Author" w:date="2024-01-01T00:00:00Z">'
             "<w:r><w:t>xxAB</w:t></w:r><w:r><w:t>CDyy</w:t></w:r></w:ins></w:p>"
         )
         mgr = _make_manager(xml_path)
@@ -292,7 +292,7 @@ class TestMixedStateMarkerPlacement:
         xml_path = temp_xml(
             "<w:p>"
             "<w:r><w:t>xxAB</w:t></w:r>"
-            '<w:ins w:id="1" w:author="A" w:date="2024-01-01T00:00:00Z">'
+            '<w:ins w:id="1" w:author="Test Author" w:date="2024-01-01T00:00:00Z">'
             "<w:r><w:t>CD</w:t></w:r></w:ins>"
             "</w:p>"
         )
@@ -311,7 +311,8 @@ class TestSingleNodeRemovalXmlSpaceAndGuard:
     def test_truncate_before_sets_xml_space(self, temp_xml):
         # Delete prefix from " Hello" inside ins -> after_text=" Hello"[len(""):] needs xml:space
         xml_path = temp_xml(
-            '<w:p><w:ins w:id="1" w:author="A" w:date="2024-01-01T00:00:00Z"><w:r><w:t>AB cd</w:t></w:r></w:ins></w:p>'
+            '<w:p><w:ins w:id="1" w:author="Test Author" w:date="2024-01-01T00:00:00Z">'
+            "<w:r><w:t>AB cd</w:t></w:r></w:ins></w:p>"
         )
         mgr = _make_manager(xml_path)
         mgr.suggest_deletion("AB")
@@ -325,7 +326,8 @@ class TestSingleNodeRemovalXmlSpaceAndGuard:
 
     def test_truncate_after_sets_xml_space(self, temp_xml):
         xml_path = temp_xml(
-            '<w:p><w:ins w:id="1" w:author="A" w:date="2024-01-01T00:00:00Z"><w:r><w:t>cd AB</w:t></w:r></w:ins></w:p>'
+            '<w:p><w:ins w:id="1" w:author="Test Author" w:date="2024-01-01T00:00:00Z">'
+            "<w:r><w:t>cd AB</w:t></w:r></w:ins></w:p>"
         )
         mgr = _make_manager(xml_path)
         mgr.suggest_deletion("AB")
@@ -339,7 +341,7 @@ class TestSingleNodeRemovalXmlSpaceAndGuard:
     def test_full_removal_preserves_run_with_tab(self, temp_xml):
         # Run has w:t + w:tab; removing w:t should keep run alive for the tab
         xml_path = temp_xml(
-            '<w:p><w:ins w:id="1" w:author="A" w:date="2024-01-01T00:00:00Z">'
+            '<w:p><w:ins w:id="1" w:author="Test Author" w:date="2024-01-01T00:00:00Z">'
             "<w:r><w:t>GONE</w:t><w:tab/></w:r>"
             "<w:r><w:t>STAY</w:t></w:r></w:ins></w:p>"
         )
@@ -495,7 +497,7 @@ class TestInsertPlacementMidNode:
         # Anchor inside an existing insertion: splice at the exact offset, no nested w:ins.
         mgr = _make_manager(
             temp_xml(
-                '<w:p><w:ins w:id="1" w:author="A" w:date="2024-01-01T00:00:00Z">'
+                '<w:p><w:ins w:id="1" w:author="Test Author" w:date="2024-01-01T00:00:00Z">'
                 "<w:r><w:t>Hello world</w:t></w:r></w:ins></w:p>"
             )
         )

--- a/tests/test_track_changes.py
+++ b/tests/test_track_changes.py
@@ -904,7 +904,7 @@ class TestDocumentWideEditsRealXml:
     """Real-XML edge-case coverage for the unified document-wide edit path."""
 
     NS = 'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"'
-    INS_ATTRS = 'w:id="1" w:author="A" w:date="2024-01-01T00:00:00Z"'
+    INS_ATTRS = 'w:id="1" w:author="Test Author" w:date="2024-01-01T00:00:00Z"'
 
     def _manager(self, tmp_path, body_xml):
         xml = f'<?xml version="1.0" encoding="utf-8"?><w:document {self.NS}><w:body>{body_xml}</w:body></w:document>'

--- a/tests/test_track_changes_coverage.py
+++ b/tests/test_track_changes_coverage.py
@@ -336,3 +336,55 @@ class TestReplaceSameContextInsAppendNoFirstChild:
         mgr.replace_text("XY", "NEW")
         text = _get_text_content(mgr)
         assert "NEW" in text
+
+
+class TestSplitInsAfterChildDescendant:
+    """_split_ins_after_child walks a descendant up to the direct child before splitting."""
+
+    def test_split_after_descendant_wt(self, temp_xml):
+        xml_path = temp_xml(
+            '<w:p><w:ins w:id="1" w:author="Other Author" w:date="2024-01-01T00:00:00Z">'
+            "<w:r><w:t>AB</w:t></w:r><w:r><w:t>CD</w:t></w:r></w:ins></w:p>"
+        )
+        mgr = _make_manager(xml_path)
+        ins = mgr.editor.dom.getElementsByTagName("w:ins")[0]
+        first_wt = ins.getElementsByTagName("w:t")[0]  # descendant, not direct child
+
+        mgr._split_ins_after_child(ins, first_wt)
+
+        ins_elems = mgr.editor.dom.getElementsByTagName("w:ins")
+        assert len(ins_elems) == 2
+        assert all(e.getAttribute("w:author") == "Other Author" for e in ins_elems)
+        assert ins_elems[0].getAttribute("w:id") != ins_elems[1].getAttribute("w:id")
+        halves = ["".join(wt.firstChild.data for wt in e.getElementsByTagName("w:t")) for e in ins_elems]
+        assert halves == ["AB", "CD"]
+
+
+class TestSplitForeignInsAtRunBoundaries:
+    """_split_foreign_ins_at run-boundary paths with text-node siblings between runs."""
+
+    def test_split_before_run_skips_text_siblings(self, temp_xml):
+        # Whitespace text node between the runs: the previous-element walk must skip it
+        xml_path = temp_xml(
+            '<w:p><w:ins w:id="1" w:author="Other Author" w:date="2024-01-01T00:00:00Z">'
+            "<w:r><w:t>AB</w:t></w:r> <w:r><w:t>CD</w:t></w:r></w:ins></w:p>"
+        )
+        mgr = _make_manager(xml_path)
+        cd_wt = mgr.editor.dom.getElementsByTagName("w:ins")[0].getElementsByTagName("w:t")[1]
+
+        boundary = mgr._split_foreign_ins_at(cd_wt, 0)
+
+        assert boundary is not None
+        assert boundary.tagName == "w:r"
+        assert boundary.getElementsByTagName("w:t")[0].firstChild.data == "AB"
+
+    def test_split_at_content_start_returns_none(self, temp_xml):
+        # Only a text node precedes the run: the split point is the very start
+        xml_path = temp_xml(
+            '<w:p><w:ins w:id="1" w:author="Other Author" w:date="2024-01-01T00:00:00Z">'
+            " <w:r><w:t>CD</w:t></w:r></w:ins></w:p>"
+        )
+        mgr = _make_manager(xml_path)
+        cd_wt = mgr.editor.dom.getElementsByTagName("w:ins")[0].getElementsByTagName("w:t")[0]
+
+        assert mgr._split_foreign_ins_at(cd_wt, 0) is None

--- a/tests/test_track_changes_coverage.py
+++ b/tests/test_track_changes_coverage.py
@@ -64,7 +64,8 @@ class TestSuggestDeletionInsideInsRemovesEntireIns:
 
     def test_delete_entire_single_wt_inside_ins(self, temp_xml):
         xml_path = temp_xml(
-            '<w:p><w:ins w:id="1" w:author="A" w:date="2024-01-01T00:00:00Z"><w:r><w:t>Hello</w:t></w:r></w:ins></w:p>'
+            '<w:p><w:ins w:id="1" w:author="Test Author" w:date="2024-01-01T00:00:00Z">'
+            "<w:r><w:t>Hello</w:t></w:r></w:ins></w:p>"
         )
         mgr = _make_manager(xml_path)
         mgr.suggest_deletion("Hello")
@@ -107,7 +108,7 @@ class TestReplaceSameContextAllInsideIns:
     def test_replace_across_runs_all_inside_ins_no_remaining(self, temp_xml):
         # Two runs inside w:ins, replace spanning both fully -> empties ins, appends
         xml_path = temp_xml(
-            '<w:p><w:ins w:id="1" w:author="A" w:date="2024-01-01T00:00:00Z">'
+            '<w:p><w:ins w:id="1" w:author="Test Author" w:date="2024-01-01T00:00:00Z">'
             "<w:r><w:t>AB</w:t></w:r><w:r><w:t>CD</w:t></w:r></w:ins></w:p>"
         )
         mgr = _make_manager(xml_path)
@@ -124,7 +125,7 @@ class TestReplaceMixedStateNoDelFound:
         # After _remove_from_insertion, no w:del exists, so insert after marker (line 499).
         xml_path = temp_xml(
             "<w:p>"
-            '<w:ins w:id="1" w:author="A" w:date="2024-01-01T00:00:00Z">'
+            '<w:ins w:id="1" w:author="Test Author" w:date="2024-01-01T00:00:00Z">'
             "<w:r><w:t>Hello</w:t></w:r></w:ins>"
             "<w:r><w:t> world</w:t></w:r>"
             "</w:p>"
@@ -141,7 +142,8 @@ class TestRemoveFromInsertionMiddleSplit:
 
     def test_remove_middle_from_single_node_ins(self, temp_xml):
         xml_path = temp_xml(
-            '<w:p><w:ins w:id="1" w:author="A" w:date="2024-01-01T00:00:00Z"><w:r><w:t>ABCDE</w:t></w:r></w:ins></w:p>'
+            '<w:p><w:ins w:id="1" w:author="Test Author" w:date="2024-01-01T00:00:00Z">'
+            "<w:r><w:t>ABCDE</w:t></w:r></w:ins></w:p>"
         )
         mgr = _make_manager(xml_path)
         # Delete "BCD" from middle of "ABCDE" inside w:ins
@@ -159,9 +161,9 @@ class TestRemoveFromInsertionSoleWtRemovesIns:
 
     def test_cross_boundary_delete_entire_ins_sole_wt(self, temp_xml):
         xml_path = temp_xml(
-            '<w:p><w:ins w:id="1" w:author="A" w:date="2024-01-01T00:00:00Z">'
+            '<w:p><w:ins w:id="1" w:author="Test Author" w:date="2024-01-01T00:00:00Z">'
             "<w:r><w:t>AB</w:t></w:r></w:ins>"
-            '<w:ins w:id="2" w:author="A" w:date="2024-01-01T00:00:00Z">'
+            '<w:ins w:id="2" w:author="Test Author" w:date="2024-01-01T00:00:00Z">'
             "<w:r><w:t>CD</w:t></w:r></w:ins></w:p>"
         )
         mgr = _make_manager(xml_path)
@@ -177,7 +179,7 @@ class TestRemoveFromInsertionMultiWtRemoveJustNode:
     def test_remove_one_wt_from_multi_wt_ins_via_cross_boundary(self, temp_xml):
         # Two w:t nodes in same ins, delete one entirely via cross-boundary
         xml_path = temp_xml(
-            '<w:p><w:ins w:id="1" w:author="A" w:date="2024-01-01T00:00:00Z">'
+            '<w:p><w:ins w:id="1" w:author="Test Author" w:date="2024-01-01T00:00:00Z">'
             "<w:r><w:t>AB</w:t></w:r>"
             "<w:r><w:t>CD</w:t></w:r>"
             "</w:ins></w:p>"
@@ -197,7 +199,7 @@ class TestRemoveFromInsertionMultiNodeNoBeforeNoAfter:
     def test_multi_node_removal_no_before_no_after(self, temp_xml):
         # Three runs inside w:ins, delete spanning all three fully
         xml_path = temp_xml(
-            '<w:p><w:ins w:id="1" w:author="A" w:date="2024-01-01T00:00:00Z">'
+            '<w:p><w:ins w:id="1" w:author="Test Author" w:date="2024-01-01T00:00:00Z">'
             "<w:r><w:t>AB</w:t></w:r>"
             "<w:r><w:t>CD</w:t></w:r>"
             "<w:r><w:t>EF</w:t></w:r>"
@@ -211,7 +213,7 @@ class TestRemoveFromInsertionMultiNodeNoBeforeNoAfter:
     def test_multi_node_removal_with_before_and_after(self, temp_xml):
         # Three runs inside w:ins, delete middle portion spanning all three
         xml_path = temp_xml(
-            '<w:p><w:ins w:id="1" w:author="A" w:date="2024-01-01T00:00:00Z">'
+            '<w:p><w:ins w:id="1" w:author="Test Author" w:date="2024-01-01T00:00:00Z">'
             "<w:r><w:t>xxAB</w:t></w:r>"
             "<w:r><w:t>CD</w:t></w:r>"
             "<w:r><w:t>EFyy</w:t></w:r>"
@@ -280,7 +282,7 @@ class TestInsertNearMatchInsideInsBeforePosition:
 
     def test_insert_before_cross_boundary_inside_ins(self, temp_xml):
         xml_path = temp_xml(
-            '<w:p><w:ins w:id="1" w:author="A" w:date="2024-01-01T00:00:00Z">'
+            '<w:p><w:ins w:id="1" w:author="Test Author" w:date="2024-01-01T00:00:00Z">'
             "<w:r><w:t>Hello </w:t></w:r><w:r><w:t>world</w:t></w:r></w:ins></w:p>"
         )
         mgr = _make_manager(xml_path)
@@ -309,7 +311,7 @@ class TestDeleteMixedState:
         xml_path = temp_xml(
             "<w:p>"
             "<w:r><w:t>Hello </w:t></w:r>"
-            '<w:ins w:id="1" w:author="A" w:date="2024-01-01T00:00:00Z">'
+            '<w:ins w:id="1" w:author="Test Author" w:date="2024-01-01T00:00:00Z">'
             "<w:r><w:t>world</w:t></w:r></w:ins>"
             "</w:p>"
         )
@@ -327,7 +329,7 @@ class TestReplaceSameContextInsAppendNoFirstChild:
     def test_replace_all_inside_ins_removes_then_appends(self, temp_xml):
         # Two runs both inside ins, replace entire content.
         xml_path = temp_xml(
-            '<w:p><w:ins w:id="1" w:author="A" w:date="2024-01-01T00:00:00Z">'
+            '<w:p><w:ins w:id="1" w:author="Test Author" w:date="2024-01-01T00:00:00Z">'
             "<w:r><w:t>X</w:t></w:r><w:r><w:t>Y</w:t></w:r></w:ins></w:p>"
         )
         mgr = _make_manager(xml_path)


### PR DESCRIPTION
## Summary

Fixes repo-local **ISSUES.md item 19** (not a GitHub issue number): editing text that sits inside *another* author's pending `<w:ins>` silently rewrote their proposal in place — crediting our words to them and destroying their change history on accept/reject.

All six destructive edit sites in `RevisionManager` now dispatch on insertion ownership (exact `w:author` string match against the editor's author; a missing/empty author fails safe as foreign):

- **Delete** inside a foreign insertion nests a `<w:del>` under our authorship inside their `<w:ins>` — Word's own representation for deleting another reviewer's pending text.
- **Replace** produces that nested deletion plus our own *sibling* `<w:ins>` carrying the replacement, splitting the foreign ins when trailing content follows.
- **Insert** with an anchor mid-insertion splits the foreign `<w:ins>` into two identity-preserving halves (author/date copied, fresh ids) with our `<w:ins>` between; boundary anchors become plain siblings. Never splices into their run and never nests `w:ins` in `w:ins` (invalid OOXML).

Our own pending insertions keep the historical in-place editing behavior, and `accept_all(author=...)` / `reject_all(author=...)` resolve each author's changes independently in every combination.

## Implementation notes

- Seven new helpers on `RevisionManager` (`_owns_ins`, `_ins_identity_attrs`, `_group_positions_by_ins`, `_delete_from_ins_positions`, `_split_ins_after_child`, `_split_foreign_ins_at`, `_insert_own_ins_within_foreign_ins`); nested deletions reuse the existing `_delete_regular_segment` machinery rather than a parallel implementation.
- `_delete_regular_segment` now returns `(first_del_id, last_del)` so foreign paths can anchor replacements; the all-inside-ins replace/delete paths report real change ids instead of `-1`.
- Identity preservation relies on the attribute stamper only filling *missing* attributes — recreated foreign halves carry explicit `w:author`/`w:date`/`w16du:dateUtc`, receiving only a fresh `w:id`.

## Testing

- 37 new tests in `tests/test_foreign_ins_edits.py`: delete/replace/insert patterns inside foreign insertions, mixed-state straddles, adjacent own+foreign insertions, authorless-ins fail-safe, the full per-author accept/reject resolution matrix, and Document-level two-author integration flows.
- Existing fixtures aligned to the editor's author in 5 test files where they exercise the own-insertion path (previously the code never compared authors).
- Full suite: **839 passed, 2 skipped** (baseline 802 + 37 new, zero regressions); `ruff check` and `ruff format` clean.

## Docs

`docs/api.md` (replace/delete/insert_after/insert_before) and `skills/docx/SKILL.md` now describe multi-author behavior.