### PR TITLE
Workspace hardening: atomic meta.json, write-ahead dirty hook, advisory session lock

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -26,6 +26,7 @@ Open a Word document for editing.
 **Raises:**
 
 - `WorkspaceSyncError`: If the source `.docx` was modified since the workspace was created, or if a leftover workspace holds unsaved changes from a previous session (one that saved to a different path, or whose save failed, and never closed). Pass `force_recreate=True` to discard the workspace and re-unpack from the current source. The workspace is never deleted silently. The error message includes the workspace path.
+- `WorkspaceLockedError`: If a live session — another process, or an unclosed `Document` in this one — already holds the document's workspace. Close the other session, or pass `force_recreate=True` to take the workspace over and discard its unsaved edits. Locks left by dead processes are reclaimed silently.
 - `WorkspaceError`: If the workspace directory cannot be created (e.g. the base is not writable), the home directory backing the default cache cannot be determined, or an existing workspace was unpacked from a different document. The message names the override to set.
 
 **Example:**

--- a/docs/api.md
+++ b/docs/api.md
@@ -687,9 +687,7 @@ from docx_editor.exceptions import WorkspaceSyncError
 
 ### `WorkspaceLockedError`
 
-Raised when opening a document whose workspace is locked by a live session — another process (or another `Document` object in the same process) already has it open. Two sessions sharing one workspace would silently overwrite each other's saves. Close the other session, or pass `force_recreate=True` to take the workspace over and discard its unsaved edits. Locks left behind by dead processes are reclaimed automatically and never raise.
-
-Attributes: `pid` (the PID recorded in the lock file, or `None` if unreadable) and `lock_path` (the lock file that blocked the open).
+Raised when opening a document whose workspace is locked by a live session — another process (or another `Document` object in the same process) already has it open. Two sessions sharing one workspace would silently overwrite each other's saves. Close the other session, or pass `force_recreate=True` to take the workspace over and discard its unsaved edits. Locks left behind by dead processes are reclaimed automatically and never raise. The exception carries `pid` and `lock_path` attributes.
 
 ```python
 from docx_editor.exceptions import WorkspaceLockedError

--- a/docs/api.md
+++ b/docs/api.md
@@ -555,7 +555,7 @@ doc.save("contract_v2.docx")  # Save to new path
 
 #### `close(cleanup=True)`
 
-Close the document and clean up workspace.
+Close the document and clean up workspace. Releases the advisory workspace lock in both cleanup modes — closing is what frees the document for another session to open (see [`WorkspaceLockedError`](#workspacelockederror)).
 
 **Parameters:**
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -683,3 +683,18 @@ Raised when the workspace is out of sync with the source document: the source ch
 ```python
 from docx_editor.exceptions import WorkspaceSyncError
 ```
+
+### `WorkspaceLockedError`
+
+Raised when opening a document whose workspace is locked by a live session — another process (or another `Document` object in the same process) already has it open. Two sessions sharing one workspace would silently overwrite each other's saves. Close the other session, or pass `force_recreate=True` to take the workspace over and discard its unsaved edits. Locks left behind by dead processes are reclaimed automatically and never raise.
+
+Attributes: `pid` (the PID recorded in the lock file, or `None` if unreadable) and `lock_path` (the lock file that blocked the open).
+
+```python
+from docx_editor.exceptions import WorkspaceLockedError
+
+try:
+    doc = Document.open("contract.docx")
+except WorkspaceLockedError as e:
+    print(f"Held by pid {e.pid}")
+```

--- a/docx_editor/__init__.py
+++ b/docx_editor/__init__.py
@@ -51,6 +51,7 @@ from .exceptions import (
     TextNotFoundError,
     WorkspaceError,
     WorkspaceExistsError,
+    WorkspaceLockedError,
     WorkspaceSyncError,
     XMLError,
 )
@@ -82,6 +83,7 @@ __all__ = [
     "InvalidDocumentError",
     "WorkspaceError",
     "WorkspaceExistsError",
+    "WorkspaceLockedError",
     "WorkspaceSyncError",
     "XMLError",
     "NodeNotFoundError",

--- a/docx_editor/comments.py
+++ b/docx_editor/comments.py
@@ -5,6 +5,7 @@ Provides CommentManager for creating and managing document comments.
 
 import html
 import shutil
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -65,6 +66,8 @@ class CommentManager:
         document_editor: DocxXMLEditor,
         author: str,
         initials: str,
+        *,
+        on_write: Callable[[], None] | None = None,
     ):
         """Initialize with workspace path and document editor.
 
@@ -73,12 +76,17 @@ class CommentManager:
             document_editor: DocxXMLEditor for word/document.xml
             author: Author name for new comments
             initials: Author initials for new comments
+            on_write: Optional write-ahead callback (e.g.
+                Workspace.mark_dirty) invoked before any comment-file write
+                touches the workspace on disk — both editor flushes and
+                template copies
         """
         self.workspace_path = workspace_path
         self.word_path = workspace_path / "word"
         self.document_editor = document_editor
         self.author = author
         self.initials = initials
+        self._on_write = on_write
 
         # Comment file paths
         self.comments_path = self.word_path / "comments.xml"
@@ -102,6 +110,7 @@ class CommentManager:
                 rsid=self.document_editor.rsid,
                 author=self.author,
                 initials=self.initials,
+                on_save=self._on_write,
             )
         return self._editors[path_str]
 
@@ -635,8 +644,15 @@ class CommentManager:
     # ==================== Private: XML File Creation ====================
 
     def _ensure_comment_file(self, path: Path, template_name: str) -> None:
-        """Ensure a comment XML file exists, creating from template if needed."""
+        """Ensure a comment XML file exists, creating from template if needed.
+
+        Runs during add_comment(), i.e. after open — a post-open workspace
+        write, so it is write-ahead flagged like any editor flush, even though
+        the copied template holds no user content yet.
+        """
         if not path.exists():
+            if self._on_write is not None:
+                self._on_write()
             shutil.copy(TEMPLATE_DIR / template_name, path)
 
     def _add_to_comments_xml(self, comment_id: int, para_id: str, text: str, timestamp: str) -> None:

--- a/docx_editor/comments.py
+++ b/docx_editor/comments.py
@@ -78,8 +78,10 @@ class CommentManager:
             initials: Author initials for new comments
             on_write: Optional write-ahead callback (e.g.
                 Workspace.mark_dirty) invoked before any comment-file write
-                touches the workspace on disk — both editor flushes and
-                template copies
+                touches the workspace on disk. Broader than XMLEditor's
+                ``on_save`` (which it is wired into for editor flushes) —
+                hence the different name — because it also covers non-editor
+                writes like template copies
         """
         self.workspace_path = workspace_path
         self.word_path = workspace_path / "word"

--- a/docx_editor/document.py
+++ b/docx_editor/document.py
@@ -128,6 +128,10 @@ class Document:
                 The message includes the workspace path. Pass
                 force_recreate=True to discard the workspace and re-unpack from
                 the current source.
+            WorkspaceLockedError: If a live session — another process, or an
+                unclosed Document in this one — already holds the document's
+                workspace. Close the other session, or pass force_recreate=True
+                to take the workspace over, discarding its unsaved edits.
 
         Example:
             doc = Document.open("contract.docx")

--- a/docx_editor/document.py
+++ b/docx_editor/document.py
@@ -57,12 +57,16 @@ class Document:
         self._workspace = workspace
         self._closed = False
 
-        # Create the document editor
+        # Create the document editor. Every post-open workspace write goes
+        # through an editor (or the comment manager's template copies), so
+        # routing mark_dirty through their write-ahead hooks enforces the
+        # dirty-flag contract mechanically at the write layer.
         self._document_editor = DocxXMLEditor(
             workspace.document_xml_path,
             rsid=workspace.rsid,
             author=workspace.author,
             initials=workspace.initials,
+            on_save=workspace.mark_dirty,
         )
 
         # Initialize managers
@@ -72,6 +76,7 @@ class Document:
             self._document_editor,
             workspace.author,
             workspace.initials,
+            on_write=workspace.mark_dirty,
         )
 
         # Setup tracking infrastructure
@@ -921,7 +926,18 @@ class Document:
             raise ValueError("Document is closed")
 
     def _setup_tracking(self) -> None:
-        """Set up tracked changes infrastructure in the document."""
+        """Set up tracked changes infrastructure in the document.
+
+        Runs at every open. Its writes (people.xml, [Content_Types].xml,
+        document.xml.rels, settings.xml rsids) deliberately do NOT mark the
+        workspace dirty: they are deterministic bookkeeping that an adopting
+        session re-produces identically (each helper checks before adding; the
+        rsid comes from meta), not unsaved user content. Marking dirty here
+        would flag every workspace the moment it is opened, so any session
+        that crashed without editing would force force_recreate on the next
+        open with no data-loss risk behind it. All post-open writes DO mark
+        dirty first — see the on_save/on_write hooks in __init__.
+        """
         # Ensure people.xml exists
         people_path = self._workspace.word_path / "people.xml"
         if not people_path.exists():
@@ -1071,6 +1087,7 @@ class Document:
             rels_path,
             rsid=self._workspace.rsid,
             author=self._workspace.author,
+            on_save=self._workspace.mark_dirty,
         )
 
         # Check if already exists
@@ -1125,6 +1142,7 @@ class Document:
             content_types_path,
             rsid=self._workspace.rsid,
             author=self._workspace.author,
+            on_save=self._workspace.mark_dirty,
         )
 
         # Check if already exists

--- a/docx_editor/document.py
+++ b/docx_editor/document.py
@@ -901,6 +901,9 @@ class Document:
     def close(self, cleanup: bool = True) -> None:
         """Close the document and clean up workspace.
 
+        Releases the advisory workspace lock in both cleanup modes — closing
+        is what frees the document for another session to open.
+
         Args:
             cleanup: If True, delete the workspace folder
 

--- a/docx_editor/exceptions.py
+++ b/docx_editor/exceptions.py
@@ -44,6 +44,34 @@ class WorkspaceSyncError(WorkspaceError):
     pass
 
 
+class WorkspaceLockedError(WorkspaceError):
+    """Raised when a live session already holds a document's workspace lock.
+
+    Two sessions sharing one workspace silently overwrite each other's edits
+    (last save wins), so opening a document whose advisory lock file names a
+    still-running process is refused — whether that process is another one or
+    the caller's own (two Document objects on one workspace clobber each other
+    either way). A lock left behind by a dead process is reclaimed silently
+    and never raises. ``force_recreate=True`` discards the workspace and its
+    lock regardless.
+
+    Attributes:
+        pid: PID recorded in the lock file, or None if it could not be read.
+        lock_path: The lock file that blocked the open.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        pid: int | None = None,
+        lock_path: Path | None = None,
+    ):
+        self.pid = pid
+        self.lock_path = lock_path
+        super().__init__(message)
+
+
 class SessionError(DocxEditError):
     """Raised when there's an error with a persistent session kernel."""
 

--- a/docx_editor/ooxml/pack.py
+++ b/docx_editor/ooxml/pack.py
@@ -19,9 +19,11 @@ from ..exceptions import DocumentOpenError
 
 # Workspace-root paths that must not be packed into the output.
 # meta.json is workspace bookkeeping (see Workspace.META_FILE); packing it makes
-# Word flag the document as "unreadable content" on open. Paths are workspace-root
-# relative — a hypothetical subpart literally named "meta.json" is unaffected.
-EXCLUDED_PATHS = {Path("meta.json")}
+# Word flag the document as "unreadable content" on open. meta.json.tmp is
+# Workspace._save_meta's atomic-write staging file — a crash can orphan it.
+# Paths are workspace-root relative — a hypothetical subpart literally named
+# "meta.json" is unaffected.
+EXCLUDED_PATHS = {Path("meta.json"), Path("meta.json.tmp")}
 
 # The promotion temp file is named ".<destination name>.<8 random chars>.tmp"; this
 # is everything in that shape except the destination's own name.

--- a/docx_editor/session.py
+++ b/docx_editor/session.py
@@ -22,6 +22,7 @@ from queue import Empty
 from typing import TYPE_CHECKING, Literal
 
 from .exceptions import SessionError
+from .workspace import _pid_alive
 
 if TYPE_CHECKING:
     from jupyter_client import BlockingKernelClient
@@ -87,26 +88,6 @@ def _read_pid(connection_file: Path) -> int | None:
         return int(_pid_file(connection_file).read_text(encoding="utf-8"))
     except (OSError, ValueError):
         return None
-
-
-def _pid_alive(pid: int) -> bool:
-    """True if the process is still running (POSIX only).
-
-    Reaps first: when the kernel is our own child (library use, as opposed to the
-    CLI where it is reparented to init), an exited kernel lingers as a zombie and
-    os.kill(pid, 0) keeps succeeding on it forever.
-    """
-    try:
-        if os.waitpid(pid, os.WNOHANG)[0] == pid:
-            return False
-    except (ChildProcessError, OSError):
-        pass  # Not our child — normal for the CLI.
-
-    try:
-        os.kill(pid, 0)
-    except OSError:
-        return False
-    return True
 
 
 def start_session(connection_file: Path = DEFAULT_CONNECTION_FILE, timeout: float = 30.0) -> int:

--- a/docx_editor/session.py
+++ b/docx_editor/session.py
@@ -219,11 +219,13 @@ def stop_session(connection_file: Path = DEFAULT_CONNECTION_FILE, timeout: float
     pid = _read_pid(connection_file)
     if pid is not None and os.name == "posix":
         deadline = time.monotonic() + timeout
-        while time.monotonic() < deadline and _pid_alive(pid):
+        # reap=True: the kernel may be this process's own child (library use),
+        # and only reaping detects its exit — a zombie otherwise polls as alive.
+        while time.monotonic() < deadline and _pid_alive(pid, reap=True):
             time.sleep(0.05)
         # Only signal a kernel that answered us: an unacknowledged PID may be stale
         # (crash, reboot) and since recycled to an unrelated process.
-        if acknowledged and _pid_alive(pid):
+        if acknowledged and _pid_alive(pid, reap=True):
             os.kill(pid, signal.SIGTERM)
 
     connection_file.unlink(missing_ok=True)

--- a/docx_editor/workspace.py
+++ b/docx_editor/workspace.py
@@ -210,6 +210,8 @@ class Workspace:
             WorkspaceSyncError: If create=True and an existing workspace holds
                 unsaved changes from a previous session, or the source document
                 changed on disk since the workspace was created
+            WorkspaceLockedError: If a live session already holds this
+                document's workspace (see _acquire_lock)
         """
         # Keep the name the caller actually opened. If they opened a symlink, that is
         # the name Word was told to open — and therefore the name its ~$ owner file

--- a/docx_editor/workspace.py
+++ b/docx_editor/workspace.py
@@ -14,6 +14,7 @@ import os
 import secrets
 import shutil
 import sys
+import weakref
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -114,7 +115,7 @@ def _file_sha256(path: Path) -> str:
     return digest.hexdigest()
 
 
-def _pid_alive(pid: int) -> bool:
+def _pid_alive(pid: int, *, reap: bool = False) -> bool:
     """True if the process is still running.
 
     Decides whether a workspace lock (or a session pid file — see session.py)
@@ -127,9 +128,14 @@ def _pid_alive(pid: int) -> bool:
     the CTRL events calls TerminateProcess and would kill the process being
     checked — so the process is queried via the win32 API instead.
 
-    On POSIX, reaps first: when the pid is this process's own child (e.g. a
-    session kernel it spawned), an exited child lingers as a zombie and
-    ``os.kill(pid, 0)`` keeps succeeding on it forever.
+    Args:
+        pid: Process ID to probe.
+        reap: On POSIX, reap the pid first if it is this process's own exited
+            child — otherwise a zombie keeps ``os.kill(pid, 0)`` succeeding
+            forever. Only pass True when the caller owns that child (as
+            session.py does for its kernel): ``os.waitpid`` on an arbitrary
+            pid would steal the exit status of another component's child.
+            Without reaping, a zombie child conservatively reads as alive.
     """
     if os.name == "nt":  # pragma: no cover - CI is POSIX
         import ctypes
@@ -160,11 +166,12 @@ def _pid_alive(pid: int) -> bool:
         finally:
             kernel32.CloseHandle(handle)
 
-    try:
-        if os.waitpid(pid, os.WNOHANG)[0] == pid:
-            return False
-    except (ChildProcessError, OSError):
-        pass  # Not our child — normal for a pid from another process.
+    if reap:
+        try:
+            if os.waitpid(pid, os.WNOHANG)[0] == pid:
+                return False
+        except (ChildProcessError, OSError):
+            pass  # Not our child — normal for a pid from another process.
 
     try:
         os.kill(pid, 0)
@@ -173,6 +180,22 @@ def _pid_alive(pid: int) -> bool:
     except OSError:
         return False
     return True
+
+
+def _release_lock_file(lock_path: Path, token: str) -> None:
+    """Unlink ``lock_path`` if it still holds ``token`` (ownership-aware).
+
+    Module-level so weakref.finalize can call it without keeping the
+    Workspace alive: a session dropped without close() frees its own lock at
+    garbage collection (or interpreter exit) instead of locking its process
+    out of the document until restart. A SIGKILLed process still leaves the
+    file behind; the liveness probe in _acquire_lock reclaims that case.
+    """
+    try:
+        if lock_path.read_text(encoding="utf-8") == token:
+            lock_path.unlink(missing_ok=True)
+    except OSError:
+        pass
 
 
 class Workspace:
@@ -266,6 +289,7 @@ class Workspace:
         # even when a force_recreate takeover happens within one process.
         self._lock_token = f"{os.getpid()}:{secrets.token_hex(8)}"
         self._lock_acquired = False
+        self._lock_finalizer: weakref.finalize | None = None
         try:
             # The shared cache base must exist to hold the sidecar (same mkdir
             # _create_workspace performs; owner-only, see there).
@@ -421,9 +445,21 @@ class Workspace:
                 if self._read_lock_content() == stale_content:
                     self._lock_path.unlink(missing_ok=True)
                 continue
-            with os.fdopen(fd, "w", encoding="utf-8") as f:
-                f.write(self._lock_token)
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as f:
+                    f.write(self._lock_token)
+            except OSError:
+                # The O_EXCL create succeeded but the token write failed
+                # (e.g. disk full): remove the empty file rather than orphan
+                # a lock that belongs to nobody.
+                self._lock_path.unlink(missing_ok=True)
+                raise
             self._lock_acquired = True
+            # Safety net for sessions dropped without close(): release the
+            # lock at garbage collection, or this process could never reopen
+            # (nor rescue) the document — the lock names its own live pid, so
+            # the staleness probe would never reclaim it.
+            self._lock_finalizer = weakref.finalize(self, _release_lock_file, self._lock_path, self._lock_token)
             return
 
         # Both attempts found a fresh lock after reclaiming a stale one:
@@ -445,13 +481,16 @@ class Workspace:
         new session's lock — and the pid alone cannot tell them apart when
         both live in one process. Release is independent of workspace cleanup:
         close(cleanup=False) keeps the workspace but must still free it for
-        the next session. No __del__ counterpart — a killed process leaves the
-        file behind by design; the staleness probe in _acquire_lock reclaims
-        it.
+        the next session. A session dropped without close() is covered by the
+        weakref finalizer registered at acquire time; a killed process leaves
+        the file behind by design, and the staleness probe in _acquire_lock
+        reclaims it.
         """
         if self._lock_acquired:
-            if self._read_lock_content() == self._lock_token:
-                self._lock_path.unlink(missing_ok=True)
+            if self._lock_finalizer is not None:
+                self._lock_finalizer()  # ownership-checked unlink; runs once
+            else:  # pragma: no cover - acquire always registers the finalizer
+                _release_lock_file(self._lock_path, self._lock_token)
             self._lock_acquired = False
 
     @classmethod
@@ -761,7 +800,10 @@ class Workspace:
         return output_path.resolve() == self.source_path
 
     def close(self, cleanup: bool = True) -> None:
-        """Close the workspace.
+        """Close the workspace and release its advisory lock.
+
+        The lock is released in both cleanup modes — closing is what frees
+        the document for the next session (see WorkspaceLockedError).
 
         Args:
             cleanup: If True, delete the workspace folder

--- a/docx_editor/workspace.py
+++ b/docx_editor/workspace.py
@@ -99,6 +99,15 @@ def owner_file_candidates(path: str | Path) -> list[Path]:
     return candidates
 
 
+def _file_sha256(path: Path) -> str:
+    """Streamed sha256 hex digest of a file's content."""
+    digest = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 16), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
 def _pid_alive(pid: int) -> bool:
     """True if the process is still running.
 
@@ -487,6 +496,7 @@ class Workspace:
             "source_path": str(self.source_path),
             "source_mtime": source_stat.st_mtime,
             "source_size": source_stat.st_size,
+            "source_sha256": _file_sha256(self.source_path),
             "created_at": datetime.now(timezone.utc).isoformat(),
             "author": self._author,
             "initials": self._author[0].upper() if self._author else "",
@@ -665,15 +675,18 @@ class Workspace:
         if not success:
             raise WorkspaceError(f"Failed to pack document to {output_path}")
 
-        # Update source_mtime/source_size if saving to the original location.
-        # overwrites_source uses os.path.samefile (see _is_source), so a different
-        # name for the same file — including through a symlink — still refreshes the
-        # workspace's stat, or the next open() would report a stale workspace. Both
-        # mtime and size are updated because sync_check() compares both.
+        # Update the recorded source fingerprint if saving to the original
+        # location. overwrites_source uses os.path.samefile (see _is_source), so
+        # a different name for the same file — including through a symlink —
+        # still refreshes it, or the next open() would report a stale workspace.
+        # mtime/size are refreshed alongside the hash: sync_check() needs size
+        # for its cheap reject, and legacy library versions reading this meta
+        # compare mtime+size only.
         if overwrites_source:
             saved_stat = output_path.stat()
             self.meta["source_mtime"] = saved_stat.st_mtime
             self.meta["source_size"] = saved_stat.st_size
+            self.meta["source_sha256"] = _file_sha256(output_path)
             # The source now holds everything the workspace holds — the
             # workspace is no longer ahead of it, so adoption is safe again.
             self.meta["dirty"] = False
@@ -722,6 +735,12 @@ class Workspace:
     def sync_check(self) -> bool:
         """Check if the workspace is in sync with the source document.
 
+        Metas that record ``source_sha256`` compare content: size first (a
+        cheap reject), then the hash. A touch/copy that rewrites identical
+        bytes no longer counts as an external edit, and a same-size content
+        swap — which mtime+size provably cannot catch — now does. Legacy metas
+        without the key keep the original mtime+size comparison.
+
         Returns:
             True if in sync, False if source has changed
         """
@@ -729,6 +748,11 @@ class Workspace:
             return False
 
         source_stat = self.source_path.stat()
+        recorded_sha256 = self.meta.get("source_sha256")
+        if recorded_sha256 is not None:
+            if self.meta.get("source_size") != source_stat.st_size:
+                return False
+            return _file_sha256(self.source_path) == recorded_sha256
         return (
             self.meta.get("source_mtime") == source_stat.st_mtime
             and self.meta.get("source_size") == source_stat.st_size

--- a/docx_editor/workspace.py
+++ b/docx_editor/workspace.py
@@ -114,9 +114,10 @@ class Workspace:
         meta: Dictionary containing workspace metadata
     """
 
-    # If you rename META_FILE, also update EXCLUDED_PATHS in ooxml/pack.py —
-    # otherwise the renamed file will be packed into the .docx and Word will
-    # flag it as "unreadable content" (issue #8).
+    # If you rename META_FILE, also update EXCLUDED_PATHS in ooxml/pack.py
+    # (both the file and its _save_meta ".tmp" twin) — otherwise the renamed
+    # file will be packed into the .docx and Word will flag it as "unreadable
+    # content" (issue #8).
     META_FILE = "meta.json"
 
     meta: dict[str, Any]
@@ -350,10 +351,27 @@ class Workspace:
             return None
 
     def _save_meta(self) -> None:
-        """Save metadata to meta.json."""
+        """Save metadata to meta.json atomically.
+
+        Written to a temp file in the same directory, fsynced, then renamed
+        over meta.json, so no crash can leave a truncated meta.json — a
+        truncated file destroys the write-ahead dirty flag and makes the next
+        open fail with a misleading WorkspaceExistsError (issue #22). The
+        fixed temp name assumes one writer per workspace (one live session);
+        EXCLUDED_PATHS in ooxml/pack.py keeps a crash-orphaned temp out of
+        the packed document.
+        """
         meta_path = self.workspace_path / self.META_FILE
-        with open(meta_path, "w", encoding="utf-8") as f:
-            json.dump(self.meta, f, indent=2)
+        tmp_path = meta_path.with_name(meta_path.name + ".tmp")
+        try:
+            with open(tmp_path, "w", encoding="utf-8") as f:
+                json.dump(self.meta, f, indent=2)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp_path, meta_path)
+        finally:
+            # A failed write leaves only the intact old meta.json behind.
+            tmp_path.unlink(missing_ok=True)
 
     def mark_dirty(self) -> None:
         """Persist that the workspace may hold content not saved to the source.

--- a/docx_editor/workspace.py
+++ b/docx_editor/workspace.py
@@ -23,6 +23,7 @@ from .exceptions import (
     InvalidDocumentError,
     WorkspaceError,
     WorkspaceExistsError,
+    WorkspaceLockedError,
     WorkspaceSyncError,
 )
 from .ooxml import pack_document, unpack_document
@@ -98,6 +99,59 @@ def owner_file_candidates(path: str | Path) -> list[Path]:
     return candidates
 
 
+def _pid_alive(pid: int) -> bool:
+    """True if the process is still running.
+
+    Decides whether a workspace lock (or a session pid file — see session.py)
+    refers to a live process or a stale leftover. On any ambiguous probe the
+    answer errs toward "alive": a false positive refuses adoption, which
+    force_recreate can override; a false negative would reclaim a live
+    session's lock.
+
+    On Windows, ``os.kill(pid, sig)`` is not a probe — any signal other than
+    the CTRL events calls TerminateProcess and would kill the process being
+    checked — so the process is queried via the win32 API instead.
+
+    On POSIX, reaps first: when the pid is this process's own child (e.g. a
+    session kernel it spawned), an exited child lingers as a zombie and
+    ``os.kill(pid, 0)`` keeps succeeding on it forever.
+    """
+    if os.name == "nt":  # pragma: no cover - CI is POSIX
+        import ctypes
+
+        PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+        STILL_ACTIVE = 259
+        ERROR_ACCESS_DENIED = 5
+
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        handle = kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+        if not handle:
+            # Access denied: the process exists but belongs to someone else.
+            # Any other failure (e.g. invalid parameter): no such process.
+            return ctypes.get_last_error() == ERROR_ACCESS_DENIED
+        try:
+            exit_code = ctypes.c_ulong()
+            if not kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code)):
+                return True  # query failed: assume alive
+            return exit_code.value == STILL_ACTIVE
+        finally:
+            kernel32.CloseHandle(handle)
+
+    try:
+        if os.waitpid(pid, os.WNOHANG)[0] == pid:
+            return False
+    except (ChildProcessError, OSError):
+        pass  # Not our child — normal for a pid from another process.
+
+    try:
+        os.kill(pid, 0)
+    except PermissionError:
+        return True  # exists, just owned by another user
+    except OSError:
+        return False
+    return True
+
+
 class Workspace:
     """Manages the per-document workspace folder.
 
@@ -169,47 +223,80 @@ class Workspace:
         # Set author (default to system user)
         self._author = author or getpass.getuser()
 
-        if create:
-            if self.workspace_path.exists():
-                # Check if it's stale or matches current document
-                existing_meta = self._load_meta()
-                if existing_meta:
-                    self._check_provenance(existing_meta)
-                    self.meta = existing_meta
-                    # Checked before staleness: when both hold, the unsaved edits
-                    # are the data-loss-relevant fact to surface, not the mtime.
-                    if existing_meta.get("dirty"):
-                        raise WorkspaceSyncError(
-                            f"Workspace {self.workspace_path} holds unsaved changes from a "
-                            f"previous session. Adopting it would carry those edits into "
-                            f"this session and the next save would write them into "
-                            f"{self.source_path}. Use force_recreate=True (or delete the "
-                            f"workspace) to discard them, or "
-                            f"Workspace(source, create=False).save(destination=...) to "
-                            f"rescue them first."
-                        )
-                    # Same staleness predicate as save(), so a workspace can never
-                    # open clean here and then fail sync_check() later at save time.
-                    if not self.sync_check():
-                        raise WorkspaceSyncError(
-                            f"Document has changed since workspace was created. "
-                            f"Delete {self.workspace_path} or use force_recreate=True"
-                        )
-                    # Workspace is valid, just load it
-                    return
-                else:
-                    raise WorkspaceExistsError(f"Workspace already exists: {self.workspace_path}")
+        # One live session per workspace: acquire the advisory lock before the
+        # adopt/create branch, so a concurrent open conflicts here instead of
+        # silently sharing the workspace and racing last-save-wins. The lock is
+        # a sidecar of the workspace dir — it cannot live inside it, because
+        # the adopt-vs-create branch below keys on the dir's existence (and a
+        # workspace-root file would need a pack exclusion). Both create modes
+        # lock: the create=False rescue flow reads the workspace and writes
+        # meta, so it must conflict with a live session too. Acquiring before
+        # the dirty/staleness checks means a live holder masks those errors —
+        # the correct priority: it is actively using the workspace.
+        self._lock_path = self.workspace_path.with_name(self.workspace_path.name + ".lock")
+        self._lock_acquired = False
+        try:
+            # The shared cache base must exist to hold the sidecar (same mkdir
+            # _create_workspace performs; owner-only, see there).
+            self.workspace_path.parent.mkdir(parents=True, mode=0o700, exist_ok=True)
+            self._acquire_lock()
+        except OSError as exc:
+            # Lock *contention* raises WorkspaceLockedError (not OSError) and
+            # propagates past this clause; only filesystem failures land here.
+            raise WorkspaceError(
+                f"Cannot create workspace at {self.workspace_path}: {exc}. "
+                f"Set DOCX_EDITOR_WORKSPACE_DIR to a writable absolute path, "
+                f"or pass workspace_dir=."
+            ) from exc
 
-            self._create_workspace()
-        else:
-            # Load existing workspace
-            if not self.workspace_path.exists():
-                raise WorkspaceError(f"Workspace not found: {self.workspace_path}")
-            loaded_meta = self._load_meta()
-            if not loaded_meta:
-                raise WorkspaceError(f"Invalid workspace (no meta.json): {self.workspace_path}")
-            self._check_provenance(loaded_meta)
-            self.meta = loaded_meta
+        try:
+            if create:
+                if self.workspace_path.exists():
+                    # Check if it's stale or matches current document
+                    existing_meta = self._load_meta()
+                    if existing_meta:
+                        self._check_provenance(existing_meta)
+                        self.meta = existing_meta
+                        # Checked before staleness: when both hold, the unsaved edits
+                        # are the data-loss-relevant fact to surface, not the mtime.
+                        if existing_meta.get("dirty"):
+                            raise WorkspaceSyncError(
+                                f"Workspace {self.workspace_path} holds unsaved changes from a "
+                                f"previous session. Adopting it would carry those edits into "
+                                f"this session and the next save would write them into "
+                                f"{self.source_path}. Use force_recreate=True (or delete the "
+                                f"workspace) to discard them, or "
+                                f"Workspace(source, create=False).save(destination=...) to "
+                                f"rescue them first."
+                            )
+                        # Same staleness predicate as save(), so a workspace can never
+                        # open clean here and then fail sync_check() later at save time.
+                        if not self.sync_check():
+                            raise WorkspaceSyncError(
+                                f"Document has changed since workspace was created. "
+                                f"Delete {self.workspace_path} or use force_recreate=True"
+                            )
+                        # Workspace is valid, just load it
+                        return
+                    else:
+                        raise WorkspaceExistsError(f"Workspace already exists: {self.workspace_path}")
+
+                self._create_workspace()
+            else:
+                # Load existing workspace
+                if not self.workspace_path.exists():
+                    raise WorkspaceError(f"Workspace not found: {self.workspace_path}")
+                loaded_meta = self._load_meta()
+                if not loaded_meta:
+                    raise WorkspaceError(f"Invalid workspace (no meta.json): {self.workspace_path}")
+                self._check_provenance(loaded_meta)
+                self.meta = loaded_meta
+        except BaseException:
+            # A failed __init__ hands the caller no object to close(); without
+            # this release the process would lock itself out of its own
+            # retry/rescue (e.g. reopening after a WorkspaceSyncError).
+            self._release_lock()
+            raise
 
     def _check_provenance(self, meta: dict[str, Any]) -> None:
         """Refuse to adopt a workspace that was unpacked from a different document.
@@ -229,6 +316,79 @@ class Workspace:
                 f"({recorded!r}, expected {str(self.source_path)!r}). "
                 f"Delete it or use force_recreate=True."
             )
+
+    def _read_lock_pid(self) -> int | None:
+        """PID recorded in the lock file, or None if absent/unreadable/corrupt."""
+        try:
+            return int(self._lock_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            return None
+
+    def _acquire_lock(self) -> None:
+        """Create the sidecar lock file holding this process's PID, exclusively.
+
+        A lock whose recorded process is still alive raises
+        WorkspaceLockedError; a dead or unreadable one is stale and reclaimed.
+        This is advisory protection against *accidental* concurrent opens, not
+        a hardened mutex: between probing a dead holder and unlinking its
+        stale file, another process may have reclaimed the lock, and the
+        unlink then removes that fresh lock. The O_EXCL retry bound means the
+        loser of that microsecond race errors out rather than proceeding, so
+        two sessions never both hold the lock.
+
+        Raises:
+            WorkspaceLockedError: A live process holds the lock, or two
+                reclaim attempts lost the creation race.
+        """
+        for _ in range(2):
+            try:
+                fd = os.open(self._lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+            except FileExistsError:
+                holder = self._read_lock_pid()
+                if holder is not None and _pid_alive(holder):
+                    if holder == os.getpid():
+                        hint = "this process already has the document open — close() the other Document/Workspace first"
+                    else:
+                        hint = (
+                            f"close the session in process {holder} first, or use "
+                            f"force_recreate=True to take the workspace over and "
+                            f"discard its unsaved edits"
+                        )
+                    raise WorkspaceLockedError(
+                        f"Workspace {self.workspace_path} is locked by a live session "
+                        f"(pid {holder}, lock file {self._lock_path}): {hint}.",
+                        pid=holder,
+                        lock_path=self._lock_path,
+                    ) from None
+                # Dead process or unreadable content: stale — reclaim and retry.
+                self._lock_path.unlink(missing_ok=True)
+                continue
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(str(os.getpid()))
+            self._lock_acquired = True
+            return
+
+        # Both attempts found a fresh lock after reclaiming a stale one:
+        # another process won the re-creation race.
+        raise WorkspaceLockedError(
+            f"Workspace {self.workspace_path} was locked by another session while "
+            f"reclaiming a stale lock ({self._lock_path}). Retry, or close the "
+            f"competing session.",
+            pid=self._read_lock_pid(),
+            lock_path=self._lock_path,
+        )
+
+    def _release_lock(self) -> None:
+        """Remove the sidecar lock file if this instance acquired it.
+
+        Independent of workspace cleanup: close(cleanup=False) keeps the
+        workspace but must still free it for the next session. No __del__
+        counterpart — a killed process leaves the file behind by design, and
+        the staleness probe in _acquire_lock reclaims it.
+        """
+        if self._lock_acquired:
+            self._lock_path.unlink(missing_ok=True)
+            self._lock_acquired = False
 
     @classmethod
     def _resolve_workspace_path(cls, source_path: Path, workspace_dir: str | Path | None) -> Path:
@@ -384,9 +544,15 @@ class Workspace:
         unchanged). The flag is cleared only by a successful save() back to the
         source.
 
-        Document.save() and Workspace.save() both call this themselves; callers
-        that mutate workspace files directly must call it before touching disk,
-        or a crash before save() leaves the divergence unflagged.
+        Document.save() and Workspace.save() both call this themselves, and
+        Document wires it as the write-ahead hook of every editor it
+        constructs (XMLEditor's ``on_save``, CommentManager's ``on_write``),
+        so editor-mediated flushes honor the contract mechanically. The
+        exception is open-time tracking setup, which deliberately bypasses the
+        flag — see Document._setup_tracking(). Code that writes workspace
+        files directly (no editor in between) must still call this before
+        touching disk, or a crash before save() leaves the divergence
+        unflagged.
         """
         if not self.meta.get("dirty"):
             self.meta["dirty"] = True
@@ -538,6 +704,9 @@ class Workspace:
         # _create_workspace() recreates it on demand.
         if cleanup and self.workspace_path.exists():
             shutil.rmtree(self.workspace_path)
+        # Released in both cleanup modes: a kept workspace must still be
+        # adoptable by the next session.
+        self._release_lock()
 
     def get_xml_path(self, relative_path: str) -> Path:
         """Get the full path to an XML file in the workspace.
@@ -594,9 +763,14 @@ class Workspace:
         source_path = Path(source_path).resolve()
         workspace_path = cls._resolve_workspace_path(source_path, workspace_dir)
 
-        if not workspace_path.exists():
-            return False
+        removed = False
+        if workspace_path.exists():
+            # As in close(), the shared base directory is left in place.
+            shutil.rmtree(workspace_path)
+            removed = True
 
-        # As in close(), the shared base directory is left in place.
-        shutil.rmtree(workspace_path)
-        return True
+        # The advisory lock sidecar goes with the workspace — even one held by
+        # a live (possibly stuck) session — keeping force_recreate the
+        # universal escape hatch.
+        workspace_path.with_name(workspace_path.name + ".lock").unlink(missing_ok=True)
+        return removed

--- a/docx_editor/workspace.py
+++ b/docx_editor/workspace.py
@@ -448,18 +448,19 @@ class Workspace:
             try:
                 with os.fdopen(fd, "w", encoding="utf-8") as f:
                     f.write(self._lock_token)
-            except OSError:
-                # The O_EXCL create succeeded but the token write failed
-                # (e.g. disk full): remove the empty file rather than orphan
-                # a lock that belongs to nobody.
+                # Safety net for sessions dropped without close(): release
+                # the lock at garbage collection, or this process could never
+                # reopen (nor rescue) the document — the lock names its own
+                # live pid, so the staleness probe would never reclaim it.
+                self._lock_finalizer = weakref.finalize(self, _release_lock_file, self._lock_path, self._lock_token)
+            except BaseException:
+                # The O_EXCL create succeeded but the token write or the
+                # finalizer registration failed (disk full, MemoryError):
+                # remove the file rather than orphan a lock naming this live
+                # pid, which the staleness probe could never reclaim.
                 self._lock_path.unlink(missing_ok=True)
                 raise
             self._lock_acquired = True
-            # Safety net for sessions dropped without close(): release the
-            # lock at garbage collection, or this process could never reopen
-            # (nor rescue) the document — the lock names its own live pid, so
-            # the staleness probe would never reclaim it.
-            self._lock_finalizer = weakref.finalize(self, _release_lock_file, self._lock_path, self._lock_token)
             return
 
         # Both attempts found a fresh lock after reclaiming a stale one:

--- a/docx_editor/workspace.py
+++ b/docx_editor/workspace.py
@@ -11,6 +11,7 @@ import getpass
 import hashlib
 import json
 import os
+import secrets
 import shutil
 import sys
 from datetime import datetime, timezone
@@ -27,6 +28,11 @@ from .exceptions import (
     WorkspaceSyncError,
 )
 from .ooxml import pack_document, unpack_document
+
+# One retry after reclaiming a stale lock; losing the O_EXCL race twice means a
+# live competitor, not another stale file (same pattern as _TEMP_NAME_ATTEMPTS
+# in ooxml/pack.py).
+_LOCK_ACQUIRE_ATTEMPTS = 2
 
 
 def _cache_root_from_env(name: str) -> Path | None:
@@ -132,12 +138,20 @@ def _pid_alive(pid: int) -> bool:
         STILL_ACTIVE = 259
         ERROR_ACCESS_DENIED = 5
 
-        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)  # type: ignore[attr-defined]
+        # Explicit signatures: ctypes defaults every restype to c_int, which
+        # truncates a pointer-sized HANDLE on 64-bit Windows.
+        kernel32.OpenProcess.restype = ctypes.c_void_p
+        kernel32.OpenProcess.argtypes = (ctypes.c_ulong, ctypes.c_int, ctypes.c_ulong)
+        kernel32.GetExitCodeProcess.restype = ctypes.c_int
+        kernel32.GetExitCodeProcess.argtypes = (ctypes.c_void_p, ctypes.POINTER(ctypes.c_ulong))
+        kernel32.CloseHandle.restype = ctypes.c_int
+        kernel32.CloseHandle.argtypes = (ctypes.c_void_p,)
         handle = kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
         if not handle:
             # Access denied: the process exists but belongs to someone else.
             # Any other failure (e.g. invalid parameter): no such process.
-            return ctypes.get_last_error() == ERROR_ACCESS_DENIED
+            return ctypes.get_last_error() == ERROR_ACCESS_DENIED  # type: ignore[attr-defined]
         try:
             exit_code = ctypes.c_ulong()
             if not kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code)):
@@ -206,12 +220,14 @@ class Workspace:
         Raises:
             DocumentNotFoundError: If the source document doesn't exist
             InvalidDocumentError: If the file is not a .docx file
+            WorkspaceLockedError: If a live session already holds this
+                document's workspace (see _acquire_lock). Checked first: a
+                live holder masks the sync/exists errors below until it
+                closes.
             WorkspaceExistsError: If workspace exists and create=True
             WorkspaceSyncError: If create=True and an existing workspace holds
                 unsaved changes from a previous session, or the source document
                 changed on disk since the workspace was created
-            WorkspaceLockedError: If a live session already holds this
-                document's workspace (see _acquire_lock)
         """
         # Keep the name the caller actually opened. If they opened a symlink, that is
         # the name Word was told to open — and therefore the name its ~$ owner file
@@ -245,6 +261,10 @@ class Workspace:
         # the dirty/staleness checks means a live holder masks those errors —
         # the correct priority: it is actively using the workspace.
         self._lock_path = self.workspace_path.with_name(self.workspace_path.name + ".lock")
+        # pid + random token: the pid feeds the liveness probe; the token
+        # identifies this specific instance so release stays ownership-aware
+        # even when a force_recreate takeover happens within one process.
+        self._lock_token = f"{os.getpid()}:{secrets.token_hex(8)}"
         self._lock_acquired = False
         try:
             # The shared cache base must exist to hold the sidecar (same mkdir
@@ -328,34 +348,58 @@ class Workspace:
                 f"Delete it or use force_recreate=True."
             )
 
-    def _read_lock_pid(self) -> int | None:
-        """PID recorded in the lock file, or None if absent/unreadable/corrupt."""
+    def _read_lock_content(self) -> str | None:
+        """Raw lock-file content, or None if the file is absent or unreadable."""
         try:
-            return int(self._lock_path.read_text(encoding="utf-8"))
-        except (OSError, ValueError):
+            return self._lock_path.read_text(encoding="utf-8")
+        except OSError:
             return None
 
-    def _acquire_lock(self) -> None:
-        """Create the sidecar lock file holding this process's PID, exclusively.
+    @staticmethod
+    def _parse_lock_pid(content: str | None) -> int | None:
+        """PID from ``<pid>:<token>`` lock content (bare ``<pid>`` also parses).
 
-        A lock whose recorded process is still alive raises
-        WorkspaceLockedError; a dead or unreadable one is stale and reclaimed.
-        This is advisory protection against *accidental* concurrent opens, not
-        a hardened mutex: between probing a dead holder and unlinking its
-        stale file, another process may have reclaimed the lock, and the
-        unlink then removes that fresh lock. The O_EXCL retry bound means the
-        loser of that microsecond race errors out rather than proceeding, so
-        two sessions never both hold the lock.
+        Non-positive values count as corrupt: probing them would be dangerous
+        (``os.waitpid(-1)`` reaps an arbitrary child; ``os.kill(0/-N, 0)``
+        signals whole process groups), so they read as "no holder" and the
+        lock is reclaimed.
+        """
+        if content is None:
+            return None
+        try:
+            pid = int(content.split(":", 1)[0])
+        except ValueError:
+            return None
+        return pid if pid > 0 else None
+
+    def _read_lock_pid(self) -> int | None:
+        """PID recorded in the lock file, or None if absent/unreadable/corrupt."""
+        return self._parse_lock_pid(self._read_lock_content())
+
+    def _acquire_lock(self) -> None:
+        """Create the sidecar lock file naming this session, exclusively.
+
+        The file holds ``<pid>:<random token>``: the pid drives the liveness
+        probe, the token makes release ownership-aware (see _release_lock).
+        A lock naming a live process raises WorkspaceLockedError; a dead or
+        unreadable one is stale and reclaimed. This is advisory protection
+        against *accidental* concurrent opens, not a hardened mutex: the
+        lock's content is re-checked right before a stale file is unlinked,
+        which narrows — but cannot close — the window in which a racing
+        process's fresh lock is removed instead. A lost race degrades to the
+        pre-lock behavior (two sessions sharing a workspace); it cannot
+        corrupt data beyond that.
 
         Raises:
-            WorkspaceLockedError: A live process holds the lock, or two
+            WorkspaceLockedError: A live process holds the lock, or the
                 reclaim attempts lost the creation race.
         """
-        for _ in range(2):
+        for _ in range(_LOCK_ACQUIRE_ATTEMPTS):
             try:
                 fd = os.open(self._lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
             except FileExistsError:
-                holder = self._read_lock_pid()
+                stale_content = self._read_lock_content()
+                holder = self._parse_lock_pid(stale_content)
                 if holder is not None and _pid_alive(holder):
                     if holder == os.getpid():
                         hint = "this process already has the document open — close() the other Document/Workspace first"
@@ -371,11 +415,14 @@ class Workspace:
                         pid=holder,
                         lock_path=self._lock_path,
                     ) from None
-                # Dead process or unreadable content: stale — reclaim and retry.
-                self._lock_path.unlink(missing_ok=True)
+                # Dead process or unreadable content: stale — reclaim and
+                # retry, unless another process already replaced the lock
+                # since it was read (see docstring: narrowed, not airtight).
+                if self._read_lock_content() == stale_content:
+                    self._lock_path.unlink(missing_ok=True)
                 continue
             with os.fdopen(fd, "w", encoding="utf-8") as f:
-                f.write(str(os.getpid()))
+                f.write(self._lock_token)
             self._lock_acquired = True
             return
 
@@ -390,15 +437,21 @@ class Workspace:
         )
 
     def _release_lock(self) -> None:
-        """Remove the sidecar lock file if this instance acquired it.
+        """Remove the sidecar lock file if this instance still owns it.
 
-        Independent of workspace cleanup: close(cleanup=False) keeps the
-        workspace but must still free it for the next session. No __del__
-        counterpart — a killed process leaves the file behind by design, and
-        the staleness probe in _acquire_lock reclaims it.
+        Ownership is verified by token, not just the _lock_acquired flag:
+        after a force_recreate takeover (Workspace.delete removes even a live
+        session's lock), the superseded session's close() must not unlink the
+        new session's lock — and the pid alone cannot tell them apart when
+        both live in one process. Release is independent of workspace cleanup:
+        close(cleanup=False) keeps the workspace but must still free it for
+        the next session. No __del__ counterpart — a killed process leaves the
+        file behind by design; the staleness probe in _acquire_lock reclaims
+        it.
         """
         if self._lock_acquired:
-            self._lock_path.unlink(missing_ok=True)
+            if self._read_lock_content() == self._lock_token:
+                self._lock_path.unlink(missing_ok=True)
             self._lock_acquired = False
 
     @classmethod
@@ -717,11 +770,13 @@ class Workspace:
         # shared (and may be a caller-supplied one via workspace_dir=/
         # DOCX_EDITOR_WORKSPACE_DIR), so it is left alone even when empty —
         # _create_workspace() recreates it on demand.
-        if cleanup and self.workspace_path.exists():
-            shutil.rmtree(self.workspace_path)
-        # Released in both cleanup modes: a kept workspace must still be
-        # adoptable by the next session.
-        self._release_lock()
+        try:
+            if cleanup and self.workspace_path.exists():
+                shutil.rmtree(self.workspace_path)
+        finally:
+            # Released in both cleanup modes, and even if rmtree fails: a
+            # kept (or half-removed) workspace must still be adoptable.
+            self._release_lock()
 
     def get_xml_path(self, relative_path: str) -> Path:
         """Get the full path to an XML file in the workspace.

--- a/docx_editor/xml_editor.py
+++ b/docx_editor/xml_editor.py
@@ -9,6 +9,7 @@ import io
 import random
 import re
 import zlib
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -434,16 +435,21 @@ class XMLEditor:
         dom: Parsed DOM tree with parse_position attributes on elements
     """
 
-    def __init__(self, xml_path: str | Path):
+    def __init__(self, xml_path: str | Path, *, on_save: Callable[[], None] | None = None):
         """Initialize with path to XML file and parse with line number tracking.
 
         Args:
             xml_path: Path to XML file to edit (str or Path)
+            on_save: Optional callback save() invokes immediately before
+                writing the file — a write-ahead hook (e.g.
+                Workspace.mark_dirty) so bookkeeping reaches disk even if the
+                write itself crashes.
 
         Raises:
             FileNotFoundError: If the XML file does not exist
         """
         self.xml_path = Path(xml_path)
+        self._on_save = on_save
         if not self.xml_path.exists():
             raise FileNotFoundError(f"XML file not found: {xml_path}")
 
@@ -713,8 +719,12 @@ class XMLEditor:
         """Save the edited XML back to the file.
 
         Serializes the DOM tree and writes it back to the original file path,
-        preserving the original encoding (ascii or utf-8).
+        preserving the original encoding (ascii or utf-8). The on_save hook
+        (if any) fires first, before the file is touched, so its write-ahead
+        bookkeeping is on disk even if the write crashes.
         """
+        if self._on_save is not None:
+            self._on_save()
         content = self.dom.toxml(encoding=self.encoding)
         self.xml_path.write_bytes(content)
 
@@ -757,7 +767,15 @@ class DocxXMLEditor(XMLEditor):
     - w:id (for w:ins and w:del elements)
     """
 
-    def __init__(self, xml_path: str | Path, rsid: str, author: str, initials: str = ""):
+    def __init__(
+        self,
+        xml_path: str | Path,
+        rsid: str,
+        author: str,
+        initials: str = "",
+        *,
+        on_save: Callable[[], None] | None = None,
+    ):
         """Initialize with required RSID and optional author.
 
         Args:
@@ -765,8 +783,10 @@ class DocxXMLEditor(XMLEditor):
             rsid: RSID to automatically apply to new elements
             author: Author name for tracked changes and comments
             initials: Author initials for comments
+            on_save: Forwarded to XMLEditor — called by save() just before
+                the file is written
         """
-        super().__init__(xml_path)
+        super().__init__(xml_path, on_save=on_save)
         self.rsid = rsid
         self.author = author
         self.initials = initials or author[0].upper() if author else ""

--- a/skills/docx/SKILL.md
+++ b/skills/docx/SKILL.md
@@ -610,6 +610,7 @@ Rules:
 - The session is non-interactive: `input()` (and anything reading stdin) raises `StdinNotImplementedError` rather than hanging.
 - `doc.save()` raises `WorkspaceSyncError` if the file changed on disk while the session held it open (e.g. the user edited it in Word). Ask the user before retrying with `doc.save(force=True)` — force overwrites their changes.
 - A session that saved to a different path (or whose save failed) and never called `doc.close()` leaves the workspace flagged as holding unsaved changes; the next `Document.open()` of the same source raises `WorkspaceSyncError` instead of silently carrying those edits over. Recover with `Document.open(path, force_recreate=True)`.
+- `Document.open()` raises `WorkspaceLockedError` if a live session (another process, or an unclosed `Document` in this one) already holds the document's workspace. Close the other session, or use `Document.open(path, force_recreate=True)` to take the workspace over, discarding its unsaved edits. Stale locks from dead processes are reclaimed automatically.
 - For a single edit, a one-off script is still fine — session mode pays off with repeated operations.
 
 ### Complementary Tools

--- a/tests/test_comments.py
+++ b/tests/test_comments.py
@@ -416,6 +416,25 @@ class TestCommentManagerInternalMethods:
 
         doc.close()
 
+    def test_ensure_comment_file_without_write_hook(self, clean_workspace):
+        """on_write is optional: a manager built without the hook must still
+        create comment files from templates (None skips the write-ahead call)."""
+        from docx_editor.comments import CommentManager
+
+        doc = Document.open(clean_workspace)
+        try:
+            manager = CommentManager(
+                doc._workspace.workspace_path,
+                doc._document_editor,
+                doc.author,
+                "T",
+            )
+            assert not manager.comments_path.exists()
+            manager._ensure_comment_file(manager.comments_path, "comments.xml")
+            assert manager.comments_path.exists()
+        finally:
+            doc.close()
+
     def test_get_next_comment_id_after_adding_comments(self, clean_workspace):
         """Test _get_next_comment_id after adding comments."""
         doc = Document.open(clean_workspace)

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -11,6 +11,19 @@ from docx_editor.exceptions import DocumentOpenError, WorkspaceSyncError
 from docx_editor.workspace import Workspace
 
 
+def _simulate_process_exit(doc):
+    """Drop the document's advisory lock as if its process had died.
+
+    The adoption regressions below simulate "RUN 1 exited without close()"
+    inside a single test process. A real dead session leaves a lock naming a
+    dead pid, which the next open silently reclaims (covered in
+    test_workspace.py); in here the pid is this very process — alive — so the
+    lock must be dropped explicitly or RUN 2 sees WorkspaceLockedError instead
+    of what it would actually hit after a crash.
+    """
+    doc._workspace._release_lock()
+
+
 class TestDocumentOpen:
     """Tests for opening documents."""
 
@@ -122,6 +135,7 @@ class TestStaleWorkspaceAdoption:
         doc.replace("fox", "cat", paragraph=find_ref(doc, "fox"))
         doc.save(temp_dir / "reviewed.docx")
         workspace_path = doc.workspace_path
+        _simulate_process_exit(doc)
         del doc  # no close()
 
         # RUN 2: the untouched source must refuse the diverged workspace.
@@ -141,6 +155,7 @@ class TestStaleWorkspaceAdoption:
         doc = Document.open(clean_workspace, author="Run One")
         doc.replace("fox", "cat", paragraph=find_ref(doc, "fox"))
         doc.save()
+        _simulate_process_exit(doc)
         del doc  # no close()
 
         doc2 = Document.open(clean_workspace, author="Run Two")
@@ -152,6 +167,7 @@ class TestStaleWorkspaceAdoption:
         """Opening writes tracking infrastructure (people.xml, rsid) into the
         workspace; that alone must not count as unsaved changes."""
         doc = Document.open(clean_workspace, author="Run One")
+        _simulate_process_exit(doc)
         del doc  # no edits, no save, no close()
 
         doc2 = Document.open(clean_workspace, author="Run Two")
@@ -174,6 +190,7 @@ class TestStaleWorkspaceAdoption:
                 doc.save()
         finally:
             owner_stub.unlink()
+        _simulate_process_exit(doc)
         del doc  # no close()
 
         with pytest.raises(WorkspaceSyncError, match="unsaved changes"):
@@ -192,6 +209,7 @@ class TestStaleWorkspaceAdoption:
             meta = json.load(f)
         assert meta["source_mtime"] == clean_workspace.stat().st_mtime
         assert meta["dirty"] is False
+        _simulate_process_exit(doc)
         del doc  # no close()
 
         doc2 = Document.open(clean_workspace, author="Run Two")

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -727,13 +727,11 @@ class TestDocumentFindText:
 
 class TestDocumentSaveStaleness:
     def test_document_save_raises_on_external_change(self, temp_docx):
-        import os
-
         from docx_editor.exceptions import WorkspaceSyncError
 
         doc = Document.open(temp_docx, author="Test")
-        stat = temp_docx.stat()
-        os.utime(temp_docx, (stat.st_atime, stat.st_mtime + 10))
+        # Simulate an external edit: change the source file's content.
+        temp_docx.write_bytes(temp_docx.read_bytes() + b"\x00")
         try:
             with pytest.raises(WorkspaceSyncError):
                 doc.save()

--- a/tests/test_ooxml.py
+++ b/tests/test_ooxml.py
@@ -225,6 +225,19 @@ class TestPack:
         assert "meta.json" not in names
         assert "word/meta.json" in names
 
+    def test_pack_excludes_meta_json_tmp(self, simple_docx, temp_dir):
+        """A meta.json.tmp orphaned by a crash mid-_save_meta must not be packed."""
+        unpacked = temp_dir / "unpacked"
+        unpack_document(simple_docx, unpacked)
+        (unpacked / "meta.json.tmp").write_text('{"author": "te')
+
+        output_path = temp_dir / "output.docx"
+        pack_document(unpacked, output_path)
+
+        with zipfile.ZipFile(output_path, "r") as zf:
+            names = zf.namelist()
+        assert "meta.json.tmp" not in names
+
     def test_pack_deterministic_output(self, simple_docx, temp_dir):
         """Packing the same directory twice must produce byte-identical ZIPs."""
         unpack_document(simple_docx, temp_dir / "unpacked")

--- a/tests/test_open_document_guard.py
+++ b/tests/test_open_document_guard.py
@@ -149,6 +149,23 @@ class TestOpenDocumentGuard:
         doc.close()
 
 
+def _deny_docx_replace(message):
+    """A stand-in for os.replace that denies only .docx promotions.
+
+    pack.os is the global os module, shared with Workspace._save_meta's atomic
+    meta.json replace — denying every replace would crash meta bookkeeping
+    before the code under test (the pack-time promotion) even runs.
+    """
+    real_replace = os.replace
+
+    def deny(src, dst, *args, **kwargs):
+        if str(dst).endswith(".docx"):
+            raise PermissionError(message)
+        return real_replace(src, dst, *args, **kwargs)
+
+    return deny
+
+
 class TestPermissionErrorMapping:
     """Only a denied *replace*, and only on Windows, means "the document is open"."""
 
@@ -156,11 +173,7 @@ class TestPermissionErrorMapping:
         """On Windows, Word holding the destination surfaces as a PermissionError here."""
         original_bytes = clean_workspace.read_bytes()
         monkeypatch.setattr(pack.sys, "platform", "win32")
-
-        def deny(*args, **kwargs):
-            raise PermissionError("Word has the file open")
-
-        monkeypatch.setattr(pack.os, "replace", deny)
+        monkeypatch.setattr(pack.os, "replace", _deny_docx_replace("Word has the file open"))
 
         doc = Document.open(clean_workspace)
         with pytest.raises(DocumentOpenError):
@@ -180,11 +193,7 @@ class TestPermissionErrorMapping:
         agent to go ask the user to close a document nobody has open.
         """
         monkeypatch.setattr(pack.sys, "platform", "win32")
-
-        def deny(*args, **kwargs):
-            raise PermissionError("directory is read-only")
-
-        monkeypatch.setattr(pack.os, "replace", deny)
+        monkeypatch.setattr(pack.os, "replace", _deny_docx_replace("directory is read-only"))
 
         doc = Document.open(clean_workspace)
         with pytest.raises(PermissionError) as exc:
@@ -199,11 +208,7 @@ class TestPermissionErrorMapping:
         means a sticky-bit directory, an immutable file, or an SELinux denial.
         """
         monkeypatch.setattr(pack.sys, "platform", "linux")
-
-        def deny(*args, **kwargs):
-            raise PermissionError("sticky-bit directory")
-
-        monkeypatch.setattr(pack.os, "replace", deny)
+        monkeypatch.setattr(pack.os, "replace", _deny_docx_replace("sticky-bit directory"))
 
         doc = Document.open(clean_workspace)
         with pytest.raises(PermissionError):

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1047,6 +1047,62 @@ class TestWorkspaceLock:
         proc.wait()  # reaped by wait(): dead even as our own child
         assert _pid_alive(proc.pid) is False
 
+    @pytest.mark.skipif(not Path("/proc").exists(), reason="needs /proc to observe zombie state")
+    def test_zombie_child_reads_alive_unless_reaping(self):
+        """Without reap=True the probe must not waitpid an arbitrary pid — that
+        would steal the exit status of another component's child. The zombie
+        conservatively reads as alive; only the owning caller reaps."""
+        import time
+
+        proc = subprocess.Popen([sys.executable, "-c", "pass"])
+        try:
+            deadline = time.monotonic() + 10
+            while time.monotonic() < deadline:
+                state = Path(f"/proc/{proc.pid}/stat").read_text().rsplit(")", 1)[1].split()[0]
+                if state == "Z":
+                    break
+                time.sleep(0.05)
+            else:
+                pytest.fail("child never became a zombie")
+
+            assert _pid_alive(proc.pid) is True  # unreaped: conservative
+            assert _pid_alive(proc.pid, reap=True) is False  # owner may reap
+        finally:
+            proc.wait()  # no-op if the reap above already collected it
+
+    def test_dropped_session_lock_is_freed_on_gc(self, temp_docx):
+        """A session dropped without close() must not lock its own process out
+        of the document forever — the lock names a live pid, so the staleness
+        probe would never reclaim it. The GC finalizer releases it."""
+        import gc
+
+        doc = Document.open(temp_docx, author="Test")
+        doc.save()  # workspace clean, so the reopen below adopts
+        del doc  # dropped without close()
+        gc.collect()  # refcounting already freed it on CPython; be explicit
+
+        doc2 = Document.open(temp_docx, author="Test")  # must not raise
+        doc2.close()
+
+    def test_dropped_dirty_session_is_rescuable_in_process(self, temp_docx, temp_dir):
+        """The rescue path documented by WorkspaceSyncError must work in the
+        same process after the dirty session is dropped without close()."""
+        import gc
+
+        doc = Document.open(temp_docx, author="Test")
+        doc.add_comment("fox", "unsaved edit")  # marks the workspace dirty
+        del doc
+        gc.collect()
+
+        # The dirty refusal (not a lock error) is what the user must see...
+        with pytest.raises(WorkspaceSyncError, match="unsaved changes"):
+            Document.open(temp_docx, author="Test")
+        # ...and its advertised rescue hatch must actually work.
+        rescue = Workspace(temp_docx, create=False)
+        out = rescue.save(destination=temp_dir / "rescued.docx")
+        assert out.exists()
+        rescue.close()
+
 
 class TestAtomicMetaSave:
     """_save_meta() must never leave a truncated meta.json (issue #22)."""

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1103,6 +1103,70 @@ class TestWorkspaceLock:
         assert out.exists()
         rescue.close()
 
+    def test_double_close_is_idempotent(self, temp_docx):
+        """A second close() finds the lock already released and the workspace
+        already gone — both must be silent no-ops."""
+        ws = Workspace(temp_docx, author="Test")
+        ws.close()
+        ws.close()
+        assert not self._lock_path(ws).exists()
+
+    @pytest.mark.skipif(
+        os.name != "posix" or os.geteuid() == 0,
+        reason="chmod 000 only denies reads on POSIX as non-root",
+    )
+    def test_unreadable_lock_file_is_reclaimed(self, temp_docx):
+        """A lock whose content cannot be read has no provable live holder —
+        it counts as stale and is reclaimed, like corrupt content."""
+        ws = Workspace(temp_docx, author="Test")
+        ws.close(cleanup=False)
+        lock = self._lock_path(ws)
+        lock.write_text("123:abc")
+        lock.chmod(0)
+
+        ws2 = Workspace(temp_docx, author="Test")  # must not raise
+        try:
+            assert self._lock_pid(self._lock_path(ws2)) == str(os.getpid())
+        finally:
+            ws2.close()
+
+    def test_lost_reclaim_race_raises_locked(self, temp_docx, monkeypatch):
+        """If the lock content keeps changing between the stale read and the
+        reclaim re-check, another process is actively re-creating it — after
+        both attempts the open must give up with WorkspaceLockedError instead
+        of unlinking a competitor's fresh lock or looping forever."""
+        ws = Workspace(temp_docx, author="Test")
+        lock = self._lock_path(ws)
+        ws.close(cleanup=True)
+        lock.write_text("placeholder")  # so O_EXCL keeps failing
+
+        reads = iter(f"not-a-pid-{n}" for n in range(10))
+        monkeypatch.setattr(Workspace, "_read_lock_content", lambda self: next(reads))
+
+        try:
+            with pytest.raises(WorkspaceLockedError, match="reclaiming"):
+                Workspace(temp_docx, author="Test")
+        finally:
+            monkeypatch.undo()
+            lock.unlink()
+
+    def test_failed_token_write_removes_lock_file(self, temp_docx, monkeypatch):
+        """If the token write fails right after the O_EXCL create, the file
+        must be removed: an orphaned lock would name this live pid, which the
+        staleness probe could never reclaim."""
+
+        def boom(fd, *args, **kwargs):
+            os.close(fd)
+            raise RuntimeError("simulated fdopen failure")
+
+        monkeypatch.setattr("docx_editor.workspace.os.fdopen", boom)
+        with pytest.raises(RuntimeError, match="simulated"):
+            Workspace(temp_docx, author="Test")
+        monkeypatch.undo()
+
+        # Were the lock orphaned, this open would raise WorkspaceLockedError.
+        Workspace(temp_docx, author="Test").close()
+
 
 class TestAtomicMetaSave:
     """_save_meta() must never leave a truncated meta.json (issue #22)."""

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -48,6 +48,7 @@ class TestWorkspaceCreation:
         assert "source_path" in meta
         assert "source_mtime" in meta
         assert "source_size" in meta
+        assert "source_sha256" in meta
         assert "created_at" in meta
         assert "author" in meta
         assert "rsid" in meta
@@ -609,9 +610,8 @@ class TestWorkspaceLocationHardening:
 class TestSaveStaleness:
     def test_save_raises_when_source_changed_externally(self, temp_docx):
         ws = Workspace(temp_docx, author="Test")
-        # Simulate an external edit: bump the source file's mtime.
-        stat = temp_docx.stat()
-        os.utime(temp_docx, (stat.st_atime, stat.st_mtime + 10))
+        # Simulate an external edit: change the source file's content.
+        temp_docx.write_bytes(temp_docx.read_bytes() + b"\x00")
         try:
             with pytest.raises(WorkspaceSyncError, match="changed on disk"):
                 ws.save()
@@ -620,8 +620,7 @@ class TestSaveStaleness:
 
     def test_save_force_overwrites_changed_source(self, temp_docx):
         ws = Workspace(temp_docx, author="Test")
-        stat = temp_docx.stat()
-        os.utime(temp_docx, (stat.st_atime, stat.st_mtime + 10))
+        temp_docx.write_bytes(temp_docx.read_bytes() + b"\x00")
         try:
             result = ws.save(force=True)
             assert result == temp_docx.resolve()
@@ -632,8 +631,7 @@ class TestSaveStaleness:
 
     def test_save_to_other_destination_ignores_stale_source(self, temp_docx, temp_dir):
         ws = Workspace(temp_docx, author="Test")
-        stat = temp_docx.stat()
-        os.utime(temp_docx, (stat.st_atime, stat.st_mtime + 10))
+        temp_docx.write_bytes(temp_docx.read_bytes() + b"\x00")
         try:
             out = ws.save(destination=temp_dir / "elsewhere.docx")
             assert out.exists()
@@ -680,6 +678,67 @@ class TestSaveStaleness:
         # And the documented recovery (drop the workspace) works.
         Workspace.delete(temp_docx)
         Workspace(temp_docx, author="Test").close()
+
+
+class TestSha256Staleness:
+    """Content-hash staleness detection in sync_check() (issue #22 follow-up)."""
+
+    def test_same_size_same_mtime_content_swap_is_detected(self, temp_docx):
+        """The case mtime+size provably cannot catch: same-length content swap
+        with the timestamp restored."""
+        ws = Workspace(temp_docx, author="Test")
+        ws.close(cleanup=False)
+
+        original = bytearray(temp_docx.read_bytes())
+        stat_before = temp_docx.stat()
+        original[-1] ^= 0xFF  # flip one byte, length unchanged
+        temp_docx.write_bytes(bytes(original))
+        os.utime(temp_docx, (stat_before.st_atime, stat_before.st_mtime))
+
+        with pytest.raises(WorkspaceSyncError):
+            Workspace(temp_docx, author="Test")
+
+        Workspace.delete(temp_docx)
+
+    def test_touch_with_identical_content_is_not_stale(self, temp_docx):
+        """An mtime bump over identical bytes (touch, cloud-sync re-download)
+        is not an external edit — the workspace adopts."""
+        ws = Workspace(temp_docx, author="Test")
+        ws.close(cleanup=False)
+
+        stat = temp_docx.stat()
+        os.utime(temp_docx, (stat.st_atime, stat.st_mtime + 10))
+
+        ws2 = Workspace(temp_docx, author="Test")  # must not raise
+        ws2.close()
+
+    def test_legacy_meta_without_sha256_uses_mtime_size(self, temp_docx):
+        """meta.json written before the hash existed keeps the old semantics:
+        an mtime-only bump still reads as stale."""
+        ws = Workspace(temp_docx, author="Test")
+        ws.close(cleanup=False)
+
+        meta_path = ws.workspace_path / "meta.json"
+        meta = json.loads(meta_path.read_text())
+        del meta["source_sha256"]
+        meta_path.write_text(json.dumps(meta))
+
+        stat = temp_docx.stat()
+        os.utime(temp_docx, (stat.st_atime, stat.st_mtime + 10))
+
+        with pytest.raises(WorkspaceSyncError):
+            Workspace(temp_docx, author="Test")
+
+        Workspace.delete(temp_docx)
+
+    def test_save_to_source_refreshes_sha256(self, temp_docx):
+        ws = Workspace(temp_docx, author="Test")
+        try:
+            ws.save()
+            meta = json.loads((ws.workspace_path / "meta.json").read_text())
+            assert meta["source_sha256"] == hashlib.sha256(temp_docx.read_bytes()).hexdigest()
+        finally:
+            ws.close()
 
 
 class TestDirtyWorkspace:

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -9,7 +9,9 @@ import sys
 from pathlib import Path
 
 import pytest
+from conftest import find_ref
 
+from docx_editor.document import Document
 from docx_editor.exceptions import (
     DocumentNotFoundError,
     InvalidDocumentError,
@@ -748,6 +750,41 @@ class TestDirtyWorkspace:
             assert self._meta_on_disk(ws)["dirty"] is True
         finally:
             ws.close()
+
+    def test_fresh_document_open_does_not_mark_dirty(self, temp_docx):
+        """Open-time tracking setup writes (people.xml, settings, rels) are
+        deterministic bookkeeping — they must not flag the workspace, or every
+        crashed-but-unedited session would force force_recreate at next open."""
+        doc = Document.open(temp_docx, author="Test")
+        try:
+            assert self._meta_on_disk(doc)["dirty"] is False
+        finally:
+            doc.close(cleanup=False)
+
+        # And the untouched workspace still adopts.
+        Document.open(temp_docx, author="Test").close()
+
+    def test_in_memory_edit_does_not_mark_dirty(self, temp_docx):
+        """DOM edits die with the process — only disk writes need the flag."""
+        doc = Document.open(temp_docx, author="Test")
+        try:
+            doc.replace("fox", "cat", paragraph=find_ref(doc, "fox"))
+            assert self._meta_on_disk(doc)["dirty"] is False
+
+            doc.save()  # flag set write-ahead, cleared by the in-place save
+            assert self._meta_on_disk(doc)["dirty"] is False
+        finally:
+            doc.close()
+
+    def test_add_comment_marks_dirty_before_save(self, temp_docx):
+        """add_comment() copies comment templates into the workspace on disk —
+        a post-open write, so it is flagged even though save() hasn't run."""
+        doc = Document.open(temp_docx, author="Test")
+        try:
+            doc.add_comment("fox", "needs review")
+            assert self._meta_on_disk(doc)["dirty"] is True
+        finally:
+            doc.close()
 
     def test_pre_upgrade_meta_without_dirty_key_adopts(self, temp_docx):
         """meta.json written before the flag existed must adopt exactly as before."""

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -5,6 +5,7 @@ import json
 import os
 import re
 import stat
+import subprocess
 import sys
 from pathlib import Path
 
@@ -16,9 +17,10 @@ from docx_editor.exceptions import (
     DocumentNotFoundError,
     InvalidDocumentError,
     WorkspaceError,
+    WorkspaceLockedError,
     WorkspaceSyncError,
 )
-from docx_editor.workspace import Workspace, _default_cache_dir
+from docx_editor.workspace import Workspace, _default_cache_dir, _pid_alive
 
 
 class TestWorkspaceCreation:
@@ -800,6 +802,152 @@ class TestDirtyWorkspace:
 
         ws2 = Workspace(temp_docx, author="Test")  # must not raise
         ws2.close()
+
+
+class TestWorkspaceLock:
+    """Advisory per-workspace lock against concurrent opens (issue #24)."""
+
+    def _lock_path(self, ws):
+        return ws.workspace_path.with_name(ws.workspace_path.name + ".lock")
+
+    def test_second_open_in_same_process_is_refused(self, temp_docx):
+        ws = Workspace(temp_docx, author="Test")
+        try:
+            with pytest.raises(WorkspaceLockedError) as exc_info:
+                Workspace(temp_docx, author="Test")
+            assert exc_info.value.pid == os.getpid()
+            assert "close()" in str(exc_info.value)
+        finally:
+            ws.close()
+
+    def test_lock_holds_pid_and_close_releases_it(self, temp_docx):
+        ws = Workspace(temp_docx, author="Test")
+        lock = self._lock_path(ws)
+        assert lock.read_text() == str(os.getpid())
+
+        ws.close(cleanup=False)  # workspace kept — the lock must still go
+        assert not lock.exists()
+
+        Workspace(temp_docx, author="Test").close()  # and reopen adopts freely
+
+    def test_rescue_create_false_conflicts_with_live_session(self, temp_docx):
+        """The create=False rescue flow reads the workspace and writes meta, so
+        it must respect a live session's lock like any other open."""
+        ws = Workspace(temp_docx, author="Test")
+        try:
+            with pytest.raises(WorkspaceLockedError):
+                Workspace(temp_docx, create=False)
+        finally:
+            ws.close()
+
+    def test_failed_init_releases_lock(self, temp_docx):
+        """Every __init__ failure path must release the lock, or the process
+        locks itself out of its own retry/rescue."""
+        ws = Workspace(temp_docx, author="Test")
+        ws.close(cleanup=False)
+        temp_docx.write_bytes(temp_docx.read_bytes() + b"\x00")  # now stale
+
+        # Were the lock leaked by the first failure, the second attempt would
+        # raise WorkspaceLockedError instead of the real, actionable error.
+        with pytest.raises(WorkspaceSyncError):
+            Workspace(temp_docx, author="Test")
+        with pytest.raises(WorkspaceSyncError):
+            Workspace(temp_docx, author="Test")
+
+        Workspace.delete(temp_docx)
+
+    @pytest.mark.skipif(os.name != "posix", reason="PID 1 is only guaranteed foreign-and-alive on POSIX")
+    def test_foreign_live_pid_blocks_open(self, temp_docx):
+        ws = Workspace(temp_docx, author="Test")
+        ws.close(cleanup=False)
+        lock = self._lock_path(ws)
+        lock.write_text("1")  # init/launchd: alive, not ours, unkillable
+
+        with pytest.raises(WorkspaceLockedError) as exc_info:
+            Workspace(temp_docx, author="Test")
+        assert exc_info.value.pid == 1
+        assert exc_info.value.lock_path == lock
+
+        Workspace.delete(temp_docx)
+
+    def test_stale_lock_from_dead_process_is_reclaimed(self, temp_docx):
+        proc = subprocess.Popen([sys.executable, "-c", "pass"])
+        proc.wait()  # reaped: the pid is gone
+
+        ws = Workspace(temp_docx, author="Test")
+        ws.close(cleanup=False)
+        self._lock_path(ws).write_text(str(proc.pid))
+
+        ws2 = Workspace(temp_docx, author="Test")  # reclaims silently
+        try:
+            assert self._lock_path(ws2).read_text() == str(os.getpid())
+        finally:
+            ws2.close()
+
+    def test_corrupt_lock_content_is_reclaimed(self, temp_docx):
+        ws = Workspace(temp_docx, author="Test")
+        ws.close(cleanup=False)
+        self._lock_path(ws).write_text("not-a-pid")
+
+        ws2 = Workspace(temp_docx, author="Test")
+        try:
+            assert self._lock_path(ws2).read_text() == str(os.getpid())
+        finally:
+            ws2.close()
+
+    def test_two_processes_conflict(self, temp_docx):
+        """A second OS process is refused while the first holds the document."""
+        script = (
+            "import sys\n"
+            "from docx_editor.workspace import Workspace\n"
+            "ws = Workspace(sys.argv[1], author='Child')\n"
+            "print('READY', flush=True)\n"
+            "sys.stdin.read()\n"  # hold the lock until the parent is done
+        )
+        proc = subprocess.Popen(
+            [sys.executable, "-c", script, str(temp_docx)],
+            stdout=subprocess.PIPE,
+            stdin=subprocess.PIPE,
+            text=True,
+        )
+        try:
+            assert proc.stdout.readline().strip() == "READY"
+            with pytest.raises(WorkspaceLockedError) as exc_info:
+                Workspace(temp_docx, author="Parent")
+            assert exc_info.value.pid == proc.pid
+        finally:
+            proc.kill()
+            proc.wait()
+
+    @pytest.mark.skipif(os.name != "posix", reason="PID 1 is only guaranteed foreign-and-alive on POSIX")
+    def test_force_recreate_takes_over_foreign_live_lock(self, temp_docx):
+        """force_recreate is the universal escape hatch — it must break even a
+        live foreign lock, and the new session ends up holding its own."""
+        ws = Workspace(temp_docx, author="Test")
+        ws.close(cleanup=False)
+        lock = self._lock_path(ws)
+        lock.write_text("1")
+
+        doc = Document.open(temp_docx, author="Test", force_recreate=True)
+        try:
+            assert lock.read_text() == str(os.getpid())
+        finally:
+            doc.close()
+
+    def test_delete_removes_lock_sidecar(self, temp_docx):
+        ws = Workspace(temp_docx, author="Test")
+        lock = self._lock_path(ws)
+        assert lock.exists()
+
+        Workspace.delete(temp_docx)
+        assert not lock.exists()
+
+    def test_pid_alive_probe(self):
+        assert _pid_alive(os.getpid()) is True
+
+        proc = subprocess.Popen([sys.executable, "-c", "pass"])
+        proc.wait()  # reaped by wait(): dead even as our own child
+        assert _pid_alive(proc.pid) is False
 
 
 class TestAtomicMetaSave:

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -763,3 +763,49 @@ class TestDirtyWorkspace:
 
         ws2 = Workspace(temp_docx, author="Test")  # must not raise
         ws2.close()
+
+
+class TestAtomicMetaSave:
+    """_save_meta() must never leave a truncated meta.json (issue #22)."""
+
+    def test_crash_mid_write_preserves_previous_meta(self, temp_docx, monkeypatch):
+        """A crash mid-write leaves the old meta.json intact — including the
+        write-ahead dirty flag, which a truncated file would destroy."""
+        ws = Workspace(temp_docx, author="Test")
+        try:
+            ws.mark_dirty()  # dirty: true is now on disk
+
+            def exploding_dump(obj, fp, **kwargs):
+                fp.write("{ truncated garbage")
+                raise RuntimeError("simulated crash mid-write")
+
+            monkeypatch.setattr("docx_editor.workspace.json.dump", exploding_dump)
+            with pytest.raises(RuntimeError, match="simulated crash"):
+                ws._save_meta()
+            monkeypatch.undo()
+
+            with open(ws.workspace_path / "meta.json") as f:
+                meta = json.load(f)  # still parses: the old file was never touched
+            assert meta["dirty"] is True
+            assert not (ws.workspace_path / "meta.json.tmp").exists()
+        finally:
+            ws.close()
+
+    def test_failed_write_leaves_workspace_adoptable(self, temp_docx, monkeypatch):
+        """After a crashed meta write, the next open must not see a corrupt
+        workspace (the pre-fix symptom was a misleading WorkspaceExistsError)."""
+        ws = Workspace(temp_docx, author="Test")
+
+        def exploding_dump(obj, fp, **kwargs):
+            fp.write("{ truncated garbage")
+            raise RuntimeError("simulated crash mid-write")
+
+        monkeypatch.setattr("docx_editor.workspace.json.dump", exploding_dump)
+        with pytest.raises(RuntimeError):
+            ws.meta["last_saved"] = "whenever"
+            ws._save_meta()
+        monkeypatch.undo()
+        ws.close(cleanup=False)
+
+        ws2 = Workspace(temp_docx, author="Test")  # adopts the intact meta
+        ws2.close()

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -869,6 +869,11 @@ class TestWorkspaceLock:
     def _lock_path(self, ws):
         return ws.workspace_path.with_name(ws.workspace_path.name + ".lock")
 
+    @staticmethod
+    def _lock_pid(lock):
+        """PID part of the "<pid>:<token>" lock content."""
+        return lock.read_text().split(":", 1)[0]
+
     def test_second_open_in_same_process_is_refused(self, temp_docx):
         ws = Workspace(temp_docx, author="Test")
         try:
@@ -882,7 +887,7 @@ class TestWorkspaceLock:
     def test_lock_holds_pid_and_close_releases_it(self, temp_docx):
         ws = Workspace(temp_docx, author="Test")
         lock = self._lock_path(ws)
-        assert lock.read_text() == str(os.getpid())
+        assert self._lock_pid(lock) == str(os.getpid())
 
         ws.close(cleanup=False)  # workspace kept — the lock must still go
         assert not lock.exists()
@@ -939,18 +944,21 @@ class TestWorkspaceLock:
 
         ws2 = Workspace(temp_docx, author="Test")  # reclaims silently
         try:
-            assert self._lock_path(ws2).read_text() == str(os.getpid())
+            assert self._lock_pid(self._lock_path(ws2)) == str(os.getpid())
         finally:
             ws2.close()
 
-    def test_corrupt_lock_content_is_reclaimed(self, temp_docx):
+    @pytest.mark.parametrize("content", ["not-a-pid", "0", "-1"])
+    def test_corrupt_lock_content_is_reclaimed(self, temp_docx, content):
+        """Unparseable and non-positive pids are corrupt, not holders — probing
+        them would be dangerous (waitpid(-1) reaps an arbitrary child)."""
         ws = Workspace(temp_docx, author="Test")
         ws.close(cleanup=False)
-        self._lock_path(ws).write_text("not-a-pid")
+        self._lock_path(ws).write_text(content)
 
         ws2 = Workspace(temp_docx, author="Test")
         try:
-            assert self._lock_path(ws2).read_text() == str(os.getpid())
+            assert self._lock_pid(self._lock_path(ws2)) == str(os.getpid())
         finally:
             ws2.close()
 
@@ -970,6 +978,7 @@ class TestWorkspaceLock:
             text=True,
         )
         try:
+            assert proc.stdout is not None  # stdout=PIPE guarantees it
             assert proc.stdout.readline().strip() == "READY"
             with pytest.raises(WorkspaceLockedError) as exc_info:
                 Workspace(temp_docx, author="Parent")
@@ -989,9 +998,39 @@ class TestWorkspaceLock:
 
         doc = Document.open(temp_docx, author="Test", force_recreate=True)
         try:
-            assert lock.read_text() == str(os.getpid())
+            assert self._lock_pid(lock) == str(os.getpid())
         finally:
             doc.close()
+
+    def test_superseded_session_close_keeps_new_lock(self, temp_docx):
+        """After a force_recreate takeover, the superseded session's close()
+        must not release the new session's lock (release is token-aware)."""
+        ws_old = Workspace(temp_docx, author="Test")
+        doc_new = Document.open(temp_docx, author="Test", force_recreate=True)
+        try:
+            ws_old.close(cleanup=False)  # superseded; must not unlink
+
+            lock = self._lock_path(ws_old)
+            assert lock.exists()
+            with pytest.raises(WorkspaceLockedError):  # new session still holds
+                Workspace(temp_docx, author="Test")
+        finally:
+            doc_new.close()
+
+    def test_close_releases_lock_even_if_cleanup_fails(self, temp_docx, monkeypatch):
+        ws = Workspace(temp_docx, author="Test")
+        lock = self._lock_path(ws)
+
+        def boom(path):
+            raise OSError("simulated rmtree failure")
+
+        monkeypatch.setattr("docx_editor.workspace.shutil.rmtree", boom)
+        with pytest.raises(OSError, match="simulated"):
+            ws.close()
+        monkeypatch.undo()
+
+        assert not lock.exists()
+        Workspace.delete(temp_docx)
 
     def test_delete_removes_lock_sidecar(self, temp_docx):
         ws = Workspace(temp_docx, author="Test")

--- a/tests/test_xml_editor.py
+++ b/tests/test_xml_editor.py
@@ -138,6 +138,39 @@ class TestXMLEditorInit:
         assert editor.encoding == "ascii"
 
 
+class TestOnSaveHook:
+    """Tests for the write-ahead on_save hook (issue #23)."""
+
+    def test_on_save_fires_before_file_write(self, sample_xml_file):
+        """The hook must fire write-ahead: at callback time the file still
+        holds its old bytes, so bookkeeping lands even if the write crashes."""
+        original = sample_xml_file.read_bytes()
+        seen = []
+        editor = XMLEditor(sample_xml_file, on_save=lambda: seen.append(sample_xml_file.read_bytes()))
+
+        editor.save()
+
+        assert seen == [original]
+        assert sample_xml_file.read_bytes() != original  # save itself did write
+
+    def test_docx_editor_forwards_on_save(self, docx_xml_file):
+        calls = []
+        editor = DocxXMLEditor(
+            docx_xml_file,
+            rsid="00AABBCC",
+            author="Test",
+            on_save=lambda: calls.append("fired"),
+        )
+
+        editor.save()
+
+        assert calls == ["fired"]
+
+    def test_save_without_hook_still_works(self, sample_xml_file):
+        editor = XMLEditor(sample_xml_file)
+        editor.save()  # must not raise
+
+
 class TestXMLEditorGetNode:
     """Tests for XMLEditor.get_node method."""
 


### PR DESCRIPTION
Implements ISSUES.md items 22, 23, and 24 as one coherent workspace-safety PR, plus the optional sha256 staleness upgrade.

## What changed

**Atomic meta.json (ISSUES.md 22).** `_save_meta()` stages to `meta.json.tmp` in the workspace, fsyncs, and `os.replace()`s over `meta.json` — a crash can no longer truncate it, which previously destroyed the write-ahead dirty flag and surfaced as a misleading `WorkspaceExistsError` on the next open. The temp name is excluded from packing so a crash orphan never lands inside a .docx.

**Write-ahead dirty hook (ISSUES.md 23).** `XMLEditor` gains an optional `on_save` callback fired immediately before each disk write; `CommentManager` gains `on_write` (also covering its template copies during `add_comment()`). `Document` wires `workspace.mark_dirty` into every editor it constructs, so the dirty-flag contract is enforced mechanically at the write layer. Policy, documented in `_setup_tracking()`: open-time tracking setup writes deliberately do **not** mark dirty (deterministic bookkeeping, re-produced identically on adoption); every post-open write does.

**Advisory session lock (ISSUES.md 24).** `Workspace.__init__` takes an exclusive sidecar lock (`<workspace>.lock`, `O_EXCL`, content `<pid>:<token>`) before the adopt/create branch, in both `create` modes. A lock naming a live process raises the new `WorkspaceLockedError` (with `pid`/`lock_path` attributes); dead or corrupt locks are reclaimed silently. Release is token-verified (a session superseded by `force_recreate` cannot unlink the new session's lock), happens on every `__init__` failure path, in `close()` (both cleanup modes, `finally`-protected), and via a `weakref` finalizer for sessions dropped without `close()` — so a process can never lock itself out of its own document. `Workspace.delete()` removes the sidecar, keeping `force_recreate` the universal escape hatch.

**sha256 staleness (optional item folded in).** meta records `source_sha256`; `sync_check()` compares size then content hash, so a same-size content swap is detected while a touch/re-download of identical bytes no longer counts as an external edit. Legacy metas without the key keep the old mtime+size behavior.

## Behavior changes to be aware of

- A second concurrent open of the same document — same process included — now raises `WorkspaceLockedError` instead of silently sharing the workspace (previously last-save-wins). Out-of-repo consumers that relied on double-opens need `close()` discipline; the error message says exactly what to do.
- A live lock holder masks dirty/staleness errors until it closes; after a crash the stale lock is reclaimed and the user still sees the actionable `WorkspaceSyncError`.
- An mtime-only touch of an unchanged source no longer reads as stale.
- `_pid_alive` moved from `session.py` to `workspace.py`, gained a Windows-safe probe (`os.kill(pid, 0)` on Windows would TerminateProcess the target), and its zombie-reaping is now opt-in (`reap=True`, used only by session.py which owns its kernel child).

## Review

Three multi-reviewer rounds (independent adversarial/consistency/dead-code reviewers, external codex pass, red-team verification of every finding, runtime stress-tests of the lock lifecycle including GC and interpreter-exit paths). All confirmed findings fixed in-branch; final round verdict: ship.

The Windows `_pid_alive` branch is `pragma: no cover` (CI is Linux-only) — it was desk-checked in review but deserves a look: explicit ctypes signatures, `ERROR_ACCESS_DENIED` treated as alive.

## Testing

`uv run pytest`: 777 passed, 8 skipped. `uv run ruff check`, `ruff format --check`, and `uv run ty check` all clean. New coverage: crash-mid-meta-write recovery, pack exclusion of the temp file, write-ahead hook ordering, dirty-flag semantics at document level, same-process/two-process lock conflicts, stale/corrupt/zombie lock reclaim, force_recreate takeover, GC-dropped session recovery and rescue, sha256 staleness matrix.