### PR TITLE
feat: report section index in ParagraphLocation (ISSUES.md #28)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -128,7 +128,7 @@ for start in range(1, count + 1, page_size):
 
 #### `get_paragraph_location(ref)`
 
-Report whether a paragraph lives in the document body or inside a table cell, whether it is a list item, and its heading context (style, outline level, and the chain of headings above it).
+Report whether a paragraph lives in the document body or inside a table cell, whether it is a list item, its heading context (style, outline level, and the chain of headings above it), and its section index.
 
 **Parameters:**
 
@@ -136,7 +136,7 @@ Report whether a paragraph lives in the document body or inside a table cell, wh
 
 **Returns:** `ParagraphLocation`. `location.in_table` is `False` for body paragraphs; `True` when the paragraph is inside a `<w:tc>` cell, in which case `location.table` carries the 1-based table index, row, `w:gridSpan`-aware logical column, and nesting depth. `location.list` is a `ListItem(num_id, ilvl)` for paragraphs carrying a direct `w:pPr/w:numPr`, `None` otherwise — raw values only: numbering inherited via a paragraph style is not resolved, and rendered display numbers (e.g. "7.2(a)") are not computed.
 
-`location.style` is the raw `w:pStyle` style id (e.g. `"Heading1"`), `None` when the paragraph carries no explicit style — no name resolution against `word/styles.xml`. `location.outline_level` is the 0-based outline level (`0` == Heading 1, so a document heading level is `outline_level + 1`): a direct `w:outlineLvl` on the paragraph wins, and the spec's `w:val="9"` marker means body text (`None`); otherwise the level defined by the paragraph's style applies, with `w:basedOn` inheritance chains resolved. `location.heading_path` is the chain of nearest preceding headings that contains the paragraph, outermost first (e.g. `("Chapter one", "Termination")`), built from each heading's current visible text; a heading's own path lists only its ancestors, never itself. Headings inside table cells participate in document order.
+`location.style` is the raw `w:pStyle` style id (e.g. `"Heading1"`), `None` when the paragraph carries no explicit style — no name resolution against `word/styles.xml`. `location.outline_level` is the 0-based outline level (`0` == Heading 1, so a document heading level is `outline_level + 1`): a direct `w:outlineLvl` on the paragraph wins, and the spec's `w:val="9"` marker means body text (`None`); otherwise the level defined by the paragraph's style applies, with `w:basedOn` inheritance chains resolved. `location.heading_path` is the chain of nearest preceding headings that contains the paragraph, outermost first (e.g. `("Chapter one", "Termination")`), built from each heading's current visible text; a heading's own path lists only its ancestors, never itself. Headings inside table cells participate in document order. `location.section` is the paragraph's 1-based section index: a paragraph carrying a direct `w:pPr/w:sectPr` closes a section and belongs to the section it closes, the next paragraph starts the following one, and the body-level `w:sectPr` defines the final section — single-section documents report `1` everywhere.
 
 **Example:**
 
@@ -150,13 +150,14 @@ if loc.list:
 if loc.outline_level is not None:
     print(f"heading level {loc.outline_level + 1}: style={loc.style}")
 print(" > ".join(loc.heading_path))  # e.g. "Chapter one > Termination"
+print(f"section {loc.section}")
 ```
 
 #### `list_paragraph_locations()`
 
-Batch counterpart to `get_paragraph_location()`: pair every paragraph with its structural location in one pass, precomputing table indices, style outline levels, and heading paths once instead of rescanning the document per ref.
+Batch counterpart to `get_paragraph_location()`: pair every paragraph with its structural location in one pass, precomputing table indexes, style outline levels, heading paths, and section indexes once instead of rescanning the document per ref.
 
-**Returns:** List of `(ref, ParagraphLocation)` tuples in document order, where `ref` is the same `P{index}#{hash}` token emitted by `list_paragraphs()`. Each location carries the same table, list, style, outline-level, and heading-path info as `get_paragraph_location()`.
+**Returns:** List of `(ref, ParagraphLocation)` tuples in document order, where `ref` is the same `P{index}#{hash}` token emitted by `list_paragraphs()`. Each location carries the same table, list, style, outline-level, heading-path, and section info as `get_paragraph_location()`.
 
 **Example:**
 

--- a/docx_editor/document.py
+++ b/docx_editor/document.py
@@ -25,6 +25,7 @@ from .xml_editor import (
     _build_table_index,
     _compute_heading_paths,
     _compute_paragraph_location,
+    _compute_section_indexes,
     build_text_map,
     compute_paragraph_hash,
 )
@@ -427,8 +428,14 @@ class Document:
         excludes itself. Headings inside table cells participate in
         document order.
 
-        Heading context is derived from whole-document scans on every
-        call; to locate many paragraphs, prefer
+        ``location.section`` is the paragraph's 1-based section index. A
+        paragraph carrying a direct ``w:pPr/w:sectPr`` closes a section
+        and belongs to the section it closes; the next paragraph starts
+        the following one. The body-level ``w:sectPr`` defines the final
+        section. Single-section documents report ``1`` everywhere.
+
+        Heading and section context is derived from whole-document scans
+        on every call; to locate many paragraphs, prefer
         :meth:`list_paragraph_locations`, which precomputes it once.
 
         Args:
@@ -442,7 +449,8 @@ class Document:
             ``location.list`` is a :class:`ListItem` for list paragraphs,
             ``None`` otherwise. ``location.style``,
             ``location.outline_level`` and ``location.heading_path`` carry
-            the paragraph's heading context as described above.
+            the paragraph's heading context, and ``location.section`` its
+            1-based section index, as described above.
 
         Raises:
             ValueError: If ``ref`` has an invalid format.
@@ -461,6 +469,7 @@ class Document:
             if loc.outline_level is not None:
                 print(f"heading level {loc.outline_level + 1}")
             print(f"under {' > '.join(loc.heading_path) or '(no heading)'}")
+            print(f"section {loc.section}")
         """
         self._ensure_open()
         parsed = ParagraphRef.parse(ref)
@@ -477,17 +486,19 @@ class Document:
             raise HashMismatchError(parsed.index, parsed.hash, actual_hash, preview)
         style_outlines = self._style_outline_map()
         heading_path = _compute_heading_paths(paragraphs[: parsed.index], style_outlines)[-1]
-        return _compute_paragraph_location(p, style_outlines=style_outlines, heading_path=heading_path)
+        section = _compute_section_indexes(paragraphs[: parsed.index])[-1]
+        return _compute_paragraph_location(p, style_outlines=style_outlines, heading_path=heading_path, section=section)
 
     def list_paragraph_locations(self) -> list[tuple[str, ParagraphLocation]]:
         """List every paragraph paired with its structural location.
 
         Batch counterpart to :meth:`get_paragraph_location`: precomputes
-        table indices, style outline levels, and heading paths once instead
-        of re-scanning the document per ref. Each entry is ``(ref,
-        location)`` where ``ref`` is the same ``"P{i}#{hash}"`` token
-        emitted by :meth:`list_paragraphs` (the part before ``|``) and
-        accepted by :meth:`get_paragraph_location` and the editing methods.
+        table indexes, style outline levels, heading paths, and section
+        indexes once instead of re-scanning the document per ref. Each
+        entry is ``(ref, location)`` where ``ref`` is the same
+        ``"P{i}#{hash}"`` token emitted by :meth:`list_paragraphs` (the
+        part before ``|``) and accepted by :meth:`get_paragraph_location`
+        and the editing methods.
 
         Returns:
             List of ``(ref, ParagraphLocation)`` tuples in document order.
@@ -496,9 +507,10 @@ class Document:
             ``location.list`` is a :class:`ListItem` for paragraphs with a
             direct ``w:pPr/w:numPr``, ``None`` otherwise (raw values; no
             style-inherited numbering, no rendered display numbers).
-            ``location.style``, ``location.outline_level`` and
-            ``location.heading_path`` carry the paragraph's heading context
-            with the same semantics as :meth:`get_paragraph_location`.
+            ``location.style``, ``location.outline_level``,
+            ``location.heading_path`` and ``location.section`` carry the
+            paragraph's heading and section context with the same
+            semantics as :meth:`get_paragraph_location`.
 
         Example:
             for ref, loc in doc.list_paragraph_locations():
@@ -508,6 +520,7 @@ class Document:
                 if loc.list:
                     print(f"{ref}: list numId={loc.list.num_id} level={loc.list.ilvl}")
                 print(f"{ref}: under {' > '.join(loc.heading_path) or '(no heading)'}")
+                print(f"{ref}: section {loc.section}")
         """
         self._ensure_open()
         dom = self._document_editor.dom
@@ -515,12 +528,15 @@ class Document:
         style_outlines = self._style_outline_map()
         paragraphs = dom.getElementsByTagName("w:p")
         heading_paths = _compute_heading_paths(paragraphs, style_outlines)
+        section_indexes = _compute_section_indexes(paragraphs)
         result = []
-        for i, (p, path) in enumerate(zip(paragraphs, heading_paths, strict=True), start=1):
+        for i, (p, path, section) in enumerate(zip(paragraphs, heading_paths, section_indexes, strict=True), start=1):
             ref = f"P{i}#{compute_paragraph_hash(p)}"
             result.append((
                 ref,
-                _compute_paragraph_location(p, table_index, style_outlines=style_outlines, heading_path=path),
+                _compute_paragraph_location(
+                    p, table_index, style_outlines=style_outlines, heading_path=path, section=section
+                ),
             ))
         return result
 

--- a/docx_editor/xml_editor.py
+++ b/docx_editor/xml_editor.py
@@ -178,9 +178,9 @@ class ListItem:
 class ParagraphLocation:
     """Structural location of a paragraph within the document body.
 
-    Reports table membership, list membership, and heading context. The
-    shape is intentionally extensible: future releases may add other
-    container kinds (header, footer, footnote), section index, etc., as
+    Reports table membership, list membership, heading context, and
+    section index. The shape is intentionally extensible: future releases
+    may add other container kinds (header, footer, footnote), etc., as
     plain optional field additions.
 
     ``list`` is the paragraph's raw numbering reference (see
@@ -200,6 +200,13 @@ class ParagraphLocation:
     contains this paragraph, outermost first (e.g. ``("Chapter one",
     "Termination")``), using each heading's current visible text. A
     heading's own path lists only its ancestors, never itself.
+
+    ``section`` is the paragraph's 1-based section index. A paragraph
+    whose ``w:pPr`` carries a direct ``w:sectPr`` closes a section — the
+    carrying paragraph belongs to the section it closes, and the next
+    paragraph starts the following one. The body-level ``w:sectPr``
+    defines the final section. Every paragraph belongs to exactly one
+    section; single-section documents report ``1`` everywhere.
     """
 
     table: TableCell | None
@@ -207,6 +214,7 @@ class ParagraphLocation:
     style: str | None = None
     outline_level: int | None = None
     heading_path: tuple[str, ...] = ()
+    section: int = 1
 
     @property
     def in_table(self) -> bool:
@@ -490,11 +498,31 @@ def _compute_heading_paths(paragraphs, style_outlines: dict[str, int]) -> list[t
     return paths
 
 
+def _compute_section_indexes(paragraphs) -> list[int]:
+    """1-based section index for each of ``paragraphs`` (document order).
+
+    A direct ``<w:pPr>/<w:sectPr>`` closes the current section — the
+    carrying paragraph still belongs to it; the next paragraph starts the
+    following section. The body-level ``<w:sectPr>`` (final section) needs
+    no handling: the running counter already names it. Direct-child walk
+    only, so ``<w:pPrChange>`` decoys are ignored.
+    """
+    indexes = []
+    section = 1
+    for p in paragraphs:
+        indexes.append(section)
+        ppr = _direct_child(p, "w:pPr")
+        if ppr is not None and _direct_child(ppr, "w:sectPr") is not None:
+            section += 1
+    return indexes
+
+
 def _compute_paragraph_location(
     paragraph,
     table_index: dict | None = None,
     style_outlines: dict[str, int] | None = None,
     heading_path: tuple[str, ...] = (),
+    section: int = 1,
 ) -> ParagraphLocation:
     """Compute the structural location of a ``<w:p>`` element.
 
@@ -511,8 +539,9 @@ def _compute_paragraph_location(
     ``style_outlines`` is an optional precomputed ``{style_id:
     outline_level}`` map (see :func:`_build_style_outline_map`) used to
     resolve style-defined outline levels; ``None`` behaves like ``{}``.
-    ``heading_path`` is threaded through verbatim — computing it needs
-    whole-document context (see :func:`_compute_heading_paths`).
+    ``heading_path`` and ``section`` are threaded through verbatim —
+    computing them needs whole-document context (see
+    :func:`_compute_heading_paths` and :func:`_compute_section_indexes`).
     """
     list_item = _extract_list_item(paragraph)
     style = _extract_style(paragraph)
@@ -520,14 +549,24 @@ def _compute_paragraph_location(
     tc = _innermost_ancestor(paragraph, "w:tc")
     if tc is None:
         return ParagraphLocation(
-            table=None, list=list_item, style=style, outline_level=outline_level, heading_path=heading_path
+            table=None,
+            list=list_item,
+            style=style,
+            outline_level=outline_level,
+            heading_path=heading_path,
+            section=section,
         )
     tr = _innermost_ancestor(tc, "w:tr")
     tbl = _innermost_ancestor(tr, "w:tbl") if tr is not None else None
     if tr is None or tbl is None:
         # Malformed table structure — tolerate by treating as body content.
         return ParagraphLocation(
-            table=None, list=list_item, style=style, outline_level=outline_level, heading_path=heading_path
+            table=None,
+            list=list_item,
+            style=style,
+            outline_level=outline_level,
+            heading_path=heading_path,
+            section=section,
         )
     if table_index is not None and tbl in table_index:
         index = table_index[tbl]
@@ -544,6 +583,7 @@ def _compute_paragraph_location(
         style=style,
         outline_level=outline_level,
         heading_path=heading_path,
+        section=section,
     )
 
 

--- a/skills/docx/SKILL.md
+++ b/skills/docx/SKILL.md
@@ -226,7 +226,8 @@ match = doc.find_text("30 days")
 # Get all visible text (inserted text included, deleted text excluded)
 visible = doc.get_visible_text()
 
-# Structural location: table cell, list item (raw numId/ilvl), and heading context
+# Structural location: table cell, list item (raw numId/ilvl), heading context,
+# and section index
 loc = doc.get_paragraph_location("P3#b2c4")
 if loc.table:
     print(f"table {loc.table.index} r{loc.table.row} c{loc.table.col}")
@@ -235,6 +236,7 @@ if loc.list:
 if loc.outline_level is not None:  # 0-based; 0 == Heading 1
     print(f"heading level {loc.outline_level + 1}: style={loc.style}")
 print(" > ".join(loc.heading_path))  # e.g. "Chapter one > Termination"
+print(loc.section)  # 1-based section index; sectPr-carrying paragraph closes its section
 
 # All edit methods return the new paragraph ref as a plain string.
 # Use it for follow-up edits on the same paragraph:

--- a/tests/test_paragraph_location.py
+++ b/tests/test_paragraph_location.py
@@ -14,6 +14,9 @@ Covers:
     (``w:basedOn`` chains resolved, ``w:val="9"`` = body text)
   * ``heading_path`` is the chain of nearest preceding headings, outermost
     first, excluding the paragraph itself
+  * ``section`` is the 1-based section index: a direct ``w:pPr/w:sectPr``
+    closes a section (the carrying paragraph belongs to the section it
+    closes); the body-level ``w:sectPr`` defines the final section
   * stale refs raise ``HashMismatchError``; out-of-range refs raise
     ``ParagraphIndexError``
 
@@ -211,6 +214,45 @@ def styled_docx(simple_docx, tmp_path) -> Path:
     """A .docx with heading-styled paragraphs (uses simple.docx's own styles.xml)."""
     dest = tmp_path / "styled.docx"
     replace_document_xml(simple_docx, dest, _build_styled_document_xml())
+    return dest
+
+
+def _build_sectioned_document_xml() -> str:
+    """Hand-written ``word/document.xml`` with three sections.
+
+    Layout (unique text snippets for ``_ref_for_text``):
+
+      "Intro one"     plain                          → section 1
+      "Close one"     w:pPr/w:sectPr                 → section 1 (closes it)
+      "Open two"      plain                          → section 2
+      "Cell in two"   table cell paragraph           → section 2
+      "Close two"     w:pPr/w:sectPr                 → section 2 (closes it)
+      "Tail three"    plain                          → section 3
+      body-level w:sectPr at end of w:body           (final section)
+    """
+    return (
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+        f"<w:document {_W_NS}>"
+        "<w:body>"
+        "<w:p><w:r><w:t>Intro one</w:t></w:r></w:p>"
+        "<w:p><w:pPr><w:sectPr/></w:pPr><w:r><w:t>Close one</w:t></w:r></w:p>"
+        "<w:p><w:r><w:t>Open two</w:t></w:r></w:p>"
+        "<w:tbl><w:tr><w:tc>"
+        "<w:p><w:r><w:t>Cell in two</w:t></w:r></w:p>"
+        "</w:tc></w:tr></w:tbl>"
+        "<w:p><w:pPr><w:sectPr/></w:pPr><w:r><w:t>Close two</w:t></w:r></w:p>"
+        "<w:p><w:r><w:t>Tail three</w:t></w:r></w:p>"
+        "<w:sectPr/>"
+        "</w:body>"
+        "</w:document>"
+    )
+
+
+@pytest.fixture
+def sectioned_docx(simple_docx, tmp_path) -> Path:
+    """A .docx with three sections split by paragraph-level ``w:sectPr``."""
+    dest = tmp_path / "sectioned.docx"
+    replace_document_xml(simple_docx, dest, _build_sectioned_document_xml())
     return dest
 
 
@@ -1094,3 +1136,80 @@ class TestListParagraphLocationsStyleInfo:
                 assert loc == doc.get_paragraph_location(ref)
             assert any(loc.outline_level is not None for _, loc in entries)
             assert any(loc.heading_path for _, loc in entries)
+
+
+class TestParagraphLocationSection:
+    """``location.section`` — 1-based section index from ``w:sectPr`` walks."""
+
+    def test_single_section_document_reports_one_everywhere(self, gridspan_docx):
+        """No paragraph-level ``w:sectPr`` → body, table, and nested-table
+        paragraphs all report section 1.
+        """
+        with Document.open(gridspan_docx) as doc:
+            for _, loc in doc.list_paragraph_locations():
+                assert loc.section == 1
+
+    def test_sections_split_at_sect_pr_boundaries(self, sectioned_docx):
+        expected = {
+            "Intro one": 1,
+            "Close one": 1,
+            "Open two": 2,
+            "Cell in two": 2,
+            "Close two": 2,
+            "Tail three": 3,
+        }
+        with Document.open(sectioned_docx) as doc:
+            for snippet, section in expected.items():
+                loc = doc.get_paragraph_location(_ref_for_text(doc, snippet))
+                assert loc.section == section, snippet
+
+    def test_carrying_paragraph_belongs_to_closed_section(self, sectioned_docx):
+        """A paragraph whose ``w:pPr`` carries the ``w:sectPr`` belongs to
+        the section it closes, not the next one.
+        """
+        with Document.open(sectioned_docx) as doc:
+            assert doc.get_paragraph_location(_ref_for_text(doc, "Close one")).section == 1
+            assert doc.get_paragraph_location(_ref_for_text(doc, "Close two")).section == 2
+
+    def test_table_paragraph_gets_enclosing_section(self, sectioned_docx):
+        with Document.open(sectioned_docx) as doc:
+            loc = doc.get_paragraph_location(_ref_for_text(doc, "Cell in two"))
+            assert loc.in_table is True
+            assert loc.section == 2
+
+    def test_stale_sect_pr_inside_p_pr_change_is_ignored(self, simple_docx, tmp_path):
+        """A ``w:sectPr`` found only inside a ``w:pPrChange`` revision record
+        must not close a section — direct-child walk regression guard.
+        """
+        body = (
+            '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+            f"<w:document {_W_NS}>"
+            "<w:body>"
+            "<w:p><w:pPr>"
+            '<w:pPrChange w:id="1" w:author="A" w:date="2026-01-01T00:00:00Z">'
+            "<w:pPr><w:sectPr/></w:pPr>"
+            "</w:pPrChange>"
+            "</w:pPr><w:r><w:t>Decoy paragraph</w:t></w:r></w:p>"
+            "<w:p><w:r><w:t>Following paragraph</w:t></w:r></w:p>"
+            "</w:body>"
+            "</w:document>"
+        )
+        dest = tmp_path / "sectpr-decoy.docx"
+        replace_document_xml(simple_docx, dest, body)
+        with Document.open(dest) as doc:
+            assert doc.get_paragraph_location(_ref_for_text(doc, "Decoy paragraph")).section == 1
+            assert doc.get_paragraph_location(_ref_for_text(doc, "Following paragraph")).section == 1
+
+    def test_dataclass_defaults_to_section_one(self):
+        assert ParagraphLocation(table=None).section == 1
+
+
+class TestListParagraphLocationsSectionInfo:
+    """Batch accessor carries the same section info as the per-call accessor."""
+
+    def test_equivalence_with_per_call_accessor(self, sectioned_docx):
+        with Document.open(sectioned_docx) as doc:
+            entries = doc.list_paragraph_locations()
+            for ref, loc in entries:
+                assert loc == doc.get_paragraph_location(ref)
+            assert [loc.section for _, loc in entries] == [1, 1, 2, 2, 2, 3]


### PR DESCRIPTION
## Summary

Adds a 1-based `section` field to `ParagraphLocation`, computed by walking paragraph-level `w:pPr/w:sectPr` boundaries in document order (ISSUES.md item 28 — not GitHub issue 28).

**Semantics** (per ECMA-376 §17.6.17):
- A paragraph carrying a direct `w:pPr/w:sectPr` closes a section and belongs to the section it closes; the next paragraph starts the following one.
- The body-level `w:sectPr` defines the final section — the running counter already names it, so it needs no special handling.
- Single-section documents report `1` everywhere.
- Direct-child walks keep `w:sectPr` inside `w:pPrChange` revision records from spoofing section boundaries.

**Both accessors report it**, mirroring the heading-path pattern from #42:
- `get_paragraph_location()` — prefix scan per call
- `list_paragraph_locations()` — single precomputed pass; batch/per-call equivalence is tested

## Changes
- `docx_editor/xml_editor.py` — `section: int = 1` field on `ParagraphLocation`; new `_compute_section_indexes()` helper; threaded through `_compute_paragraph_location()`
- `docx_editor/document.py` — both accessors compute and thread the section index
- `docs/api.md`, `skills/docx/SKILL.md` — documented semantics and examples
- `tests/test_paragraph_location.py` — 8 new tests: boundary splits, carrying-paragraph semantics, table-cell membership, `w:pPrChange` decoy guard, single-section default, dataclass default, batch equivalence

## Review
Multi-reviewer loop ran clean: no correctness findings survived red-team verification; two cosmetic docstring nits were fixed in-branch. One accepted trade-off noted: a `w:sectPr` inside a non-body paragraph (invalid OOXML that Word never emits) would bump the counter — consistent with the existing heading-path walk, left as documented direct-child contract.

## Testing
- `uv run pytest`: 875 passed, 2 skipped (includes merge with #44)
- `uv run ruff check .` / `ruff format --check .`: clean
- `uv run ty check`: no new diagnostics (5 pre-existing warnings in untouched test files)