### PR TITLE
fix: run-level w:rPr must not leak from drawing text boxes (ISSUES.md #31)

### DIFF
--- a/docx_editor/comments.py
+++ b/docx_editor/comments.py
@@ -21,12 +21,15 @@ from .xml_editor import (
     DocxXMLEditor,
     ParagraphRef,
     TextMapMatch,
+    _escape_xml,
     _generate_hex_id,
     build_text_map,
     compute_paragraph_hash,
     find_in_text_map,
+    get_rPr_xml,
     get_text_node_data,
     rebuild_run_fragments,
+    render_plain_wt,
 )
 
 # Path to template files
@@ -309,7 +312,7 @@ class CommentManager:
         markers is preserved, and so ``w:t`` nodes nested inside a drawing's
         text box are left untouched.
         """
-        rPr_xml = _get_rPr_xml(run)
+        rPr_xml = get_rPr_xml(run)
 
         def render_wt(wt) -> list[str]:
             wt_text = get_text_node_data(wt)
@@ -318,8 +321,7 @@ class CommentManager:
             parts: list[str] = []
 
             if not is_start_here and not is_end_here:
-                if wt_text:
-                    parts.append(f"<w:r>{rPr_xml}<w:t>{_escape_xml(wt_text)}</w:t></w:r>")
+                parts.extend(render_plain_wt(wt, rPr_xml))
             elif is_start_here and is_end_here:
                 before = wt_text[:start_offset]
                 matched = wt_text[start_offset : end_offset + 1]
@@ -725,27 +727,3 @@ def _find_ancestor_run(node) -> Element | None:
             return parent
         parent = parent.parentNode
     return None
-
-
-def _get_rPr_xml(run) -> str:
-    """Serialize ``run``'s direct ``w:rPr`` child, or empty string.
-
-    Iterates direct children so a nested ``w:rPr`` deep inside a ``w:drawing``
-    text-box descendant is not picked up by mistake.
-    """
-    for child in run.childNodes:
-        if child.nodeType == child.ELEMENT_NODE and getattr(child, "tagName", "") == "w:rPr":
-            return child.toxml()
-    return ""
-
-
-def _escape_xml(text: str) -> str:
-    """Escape text for safe XML inclusion."""
-    return (
-        text
-        .replace("&", "&amp;")
-        .replace("<", "&lt;")
-        .replace(">", "&gt;")
-        .replace('"', "&quot;")
-        .replace("'", "&apos;")
-    )

--- a/docx_editor/track_changes.py
+++ b/docx_editor/track_changes.py
@@ -24,11 +24,14 @@ from .xml_editor import (
     TextMap,
     TextMapMatch,
     TextPosition,
+    _escape_xml,
     build_text_map,
     compute_paragraph_hash,
     find_in_text_map,
+    get_rPr_xml,
     get_text_node_data,
     rebuild_run_fragments,
+    render_plain_wt,
 )
 
 
@@ -590,12 +593,8 @@ class RevisionManager:
         if not text_map.positions:
             # Empty paragraph — append insertion
             # Get rPr from any existing run, or use empty
-            rPr_xml = ""
             runs = paragraph.getElementsByTagName("w:r")
-            if runs:
-                rPr_elems = runs[0].getElementsByTagName("w:rPr")
-                if rPr_elems:
-                    rPr_xml = rPr_elems[0].toxml()
+            rPr_xml = get_rPr_xml(runs[0]) if runs else ""
 
             ins_xml = f"<w:ins><w:r>{rPr_xml}<w:t>{_escape_xml(text)}</w:t></w:r></w:ins>"
             # Insert before w:sectPr if present, else append
@@ -826,11 +825,7 @@ class RevisionManager:
             run = run.parentNode
         if not run:
             return None, ""
-        rPr_xml = ""
-        rPr_elems = run.getElementsByTagName("w:rPr")
-        if rPr_elems:
-            rPr_xml = rPr_elems[0].toxml()
-        return run, rPr_xml
+        return run, get_rPr_xml(run)
 
     def _get_node_text(self, node) -> str:
         """Get text content of a w:t node by concatenating ALL child text nodes.
@@ -1027,9 +1022,7 @@ class RevisionManager:
                         fragments.append(f"<w:r>{run_rPr}<w:t>{_escape_xml(after)}</w:t></w:r>")
                 else:
                     # Unmatched sibling — preserve
-                    wt_text = self._get_node_text(wt)
-                    if wt_text:
-                        fragments.append(f"<w:r>{run_rPr}<w:t>{_escape_xml(wt_text)}</w:t></w:r>")
+                    fragments.extend(render_plain_wt(wt, run_rPr))
                 return fragments
 
             # Emit the run's children in document order (w:t split around the
@@ -1380,10 +1373,7 @@ class RevisionManager:
                 _set_xml_space_preserve(first_node)
                 run = self._find_ancestor(first_node, "w:r")
                 if ins_elem and run:
-                    rPr_xml = ""
-                    rPr_elems = run.getElementsByTagName("w:rPr")
-                    if rPr_elems:
-                        rPr_xml = rPr_elems[0].toxml()
+                    rPr_xml = get_rPr_xml(run)
                     after_xml = f"<w:ins><w:r>{rPr_xml}<w:t>{_escape_xml(after_text)}</w:t></w:r></w:ins>"
                     self.editor.insert_after(ins_elem, after_xml)
         else:
@@ -1484,10 +1474,7 @@ class RevisionManager:
                 fragments: list[str] = []
                 if id(wt) not in run_info["nodes"]:
                     # Unmatched sibling — preserve as-is
-                    wt_text = self._get_node_text(wt)
-                    if wt_text:
-                        fragments.append(f"<w:r>{run_rPr}<w:t>{_escape_xml(wt_text)}</w:t></w:r>")
-                    return fragments
+                    return render_plain_wt(wt, run_rPr)
 
                 ng = run_info["nodes"][id(wt)]
                 node_text = self._get_node_text(ng["node"])
@@ -1580,9 +1567,7 @@ class RevisionManager:
                         fragments.append(f"<w:r>{rp_xml}<w:t>{_escape_xml(after)}</w:t></w:r>")
                 else:
                     # Unmatched sibling — preserve
-                    wt_text = self._get_node_text(wt)
-                    if wt_text:
-                        fragments.append(f"<w:r>{run_rPr}<w:t>{_escape_xml(wt_text)}</w:t></w:r>")
+                    fragments.extend(render_plain_wt(wt, run_rPr))
                 return fragments
 
             # Emit the run's children in document order (matched w:t as
@@ -1734,9 +1719,7 @@ class RevisionManager:
                     fragments.append(f"<w:r>{rPr_xml}<w:t>{_escape_xml(after_text)}</w:t></w:r>")
             else:
                 # Preserve unmatched sibling w:t
-                wt_text = self._get_node_text(wt)
-                if wt_text:
-                    fragments.append(f"<w:r>{rPr_xml}<w:t>{_escape_xml(wt_text)}</w:t></w:r>")
+                fragments.extend(render_plain_wt(wt, rPr_xml))
             return fragments
 
         nodes = self.editor.replace_node(run, "".join(rebuild_run_fragments(run, rPr_xml, render_wt)))
@@ -1960,15 +1943,3 @@ def _tokenize_words(text: str) -> list[str]:
 def _set_xml_space_preserve(wt_elem) -> None:
     """Set xml:space='preserve' on a w:t element to preserve whitespace."""
     wt_elem.setAttribute("xml:space", "preserve")
-
-
-def _escape_xml(text: str) -> str:
-    """Escape text for safe XML inclusion."""
-    return (
-        text
-        .replace("&", "&amp;")
-        .replace("<", "&lt;")
-        .replace(">", "&gt;")
-        .replace('"', "&quot;")
-        .replace("'", "&apos;")
-    )

--- a/docx_editor/xml_editor.py
+++ b/docx_editor/xml_editor.py
@@ -449,7 +449,8 @@ def _build_style_outline_map(styles_dom) -> dict[str, int]:
     """
     raw: dict[str, tuple[int | None, bool, str | None]] = {}
     for style in styles_dom.getElementsByTagName("w:style"):
-        if style.getAttribute("w:type") != "paragraph":
+        # A missing w:type defaults to "paragraph" per ECMA-376
+        if style.getAttribute("w:type") not in ("", "paragraph"):
             continue
         style_id = style.getAttribute("w:styleId")
         if not style_id:
@@ -635,6 +636,42 @@ def rebuild_run_fragments(run, rPr_xml: str, render_wt: Callable[[Element], list
             continue
         fragments.extend(render_wt(child))
     return fragments
+
+
+def _escape_xml(text: str) -> str:
+    """Escape text for safe XML inclusion."""
+    return (
+        text
+        .replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+        .replace("'", "&apos;")
+    )
+
+
+def get_rPr_xml(run) -> str:
+    """Serialize ``run``'s direct ``w:rPr`` child, or empty string.
+
+    Iterates direct children so a nested ``w:rPr`` deep inside a ``w:drawing``
+    text-box descendant is not picked up by mistake.
+    """
+    for child in run.childNodes:
+        if child.nodeType == child.ELEMENT_NODE and getattr(child, "tagName", "") == "w:rPr":
+            return child.toxml()
+    return ""
+
+
+def render_plain_wt(wt, rPr_xml: str) -> list[str]:
+    """Render an unmatched ``w:t`` node as a plain run fragment carrying ``rPr_xml``.
+
+    The shared preserve-as-is step for ``render_wt`` callbacks passed to
+    :func:`rebuild_run_fragments` — nodes with no text yield no fragment.
+    """
+    wt_text = get_text_node_data(wt)
+    if not wt_text:
+        return []
+    return [f"<w:r>{rPr_xml}<w:t>{_escape_xml(wt_text)}</w:t></w:r>"]
 
 
 def build_text_map(paragraph, view: Literal["accepted", "original"] = "accepted") -> TextMap:

--- a/docx_editor/xml_editor.py
+++ b/docx_editor/xml_editor.py
@@ -438,8 +438,9 @@ def _extract_outline_level(paragraph, style: str | None, style_outlines: dict[st
 def _build_style_outline_map(styles_dom) -> dict[str, int]:
     """Map paragraph-style ids to their effective 0-based outline level.
 
-    One pass over ``<w:style w:type="paragraph">`` elements collects each
-    style's own ``<w:pPr>/<w:outlineLvl>`` and its ``w:basedOn`` parent; a
+    One pass over ``<w:style>`` elements whose type is ``paragraph`` or
+    unspecified (the ECMA-376 default) collects each style's own
+    ``<w:pPr>/<w:outlineLvl>`` and its ``w:basedOn`` parent; a
     second pass resolves ``basedOn`` chains (visited-set cycle guard) so a
     custom style based on e.g. ``Heading1`` without restating the level
     inherits it. A *present* ``w:outlineLvl`` terminates the chain even

--- a/tests/test_paragraph_location.py
+++ b/tests/test_paragraph_location.py
@@ -1092,6 +1092,46 @@ class TestStyleOutlineBasedOnChain:
             assert loc.outline_level is None
 
 
+class TestStyleMissingTypeDefaultsToParagraph:
+    """A ``w:style`` without ``w:type`` defaults to *paragraph* (ECMA-376)."""
+
+    _STYLES_XML = (
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+        f"<w:styles {_W_NS}>"
+        # No w:type attribute — must still contribute its outline level.
+        '<w:style w:styleId="TypelessHead">'
+        '<w:name w:val="Typeless Head"/>'
+        '<w:pPr><w:outlineLvl w:val="2"/></w:pPr>'
+        "</w:style>"
+        "</w:styles>"
+    )
+
+    _DOCUMENT_XML = (
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+        f"<w:document {_W_NS}>"
+        "<w:body>"
+        f"<w:p>{_p_style('TypelessHead')}<w:r><w:t>Typeless heading</w:t></w:r></w:p>"
+        "</w:body>"
+        "</w:document>"
+    )
+
+    @pytest.fixture
+    def typeless_docx(self, simple_docx, tmp_path) -> Path:
+        dest = tmp_path / "typeless-style.docx"
+        replace_docx_parts(
+            simple_docx,
+            dest,
+            {"word/document.xml": self._DOCUMENT_XML, "word/styles.xml": self._STYLES_XML},
+        )
+        return dest
+
+    def test_typeless_style_resolves_outline_level(self, typeless_docx):
+        with Document.open(typeless_docx) as doc:
+            loc = doc.get_paragraph_location(_ref_for_text(doc, "Typeless heading"))
+            assert loc.style == "TypelessHead"
+            assert loc.outline_level == 2
+
+
 class TestMissingStylesPart:
     """A document without ``word/styles.xml`` degrades gracefully."""
 

--- a/tests/test_run_child_order.py
+++ b/tests/test_run_child_order.py
@@ -285,7 +285,7 @@ class TestTextboxNoDuplication:
         assert "boxed" in drawings[0].toxml()
 
 
-def _has_direct_rpr(run) -> bool:
+def _has_direct_rPr(run) -> bool:
     """True if ``run`` has a direct w:rPr child."""
     return any(c.nodeType == c.ELEMENT_NODE and c.tagName == "w:rPr" for c in run.childNodes)
 
@@ -323,7 +323,7 @@ class TestNestedRPrNoLeak:
         assert paragraph.toxml().count("<w:b/>") == 1
         assert "<w:b/>" in mgr.editor.dom.getElementsByTagName("w:drawing")[0].toxml()
         for run in _top_level_runs(paragraph):
-            assert not _has_direct_rpr(run)
+            assert not _has_direct_rPr(run)
 
     def test_empty_paragraph_insert_does_not_inherit_textbox_rpr(self, temp_xml):
         """Insert into a paragraph with no visible text: the created <w:ins>
@@ -343,4 +343,4 @@ class TestNestedRPrNoLeak:
         ins_elems = [c for c in paragraph.childNodes if c.nodeType == c.ELEMENT_NODE and c.tagName == "w:ins"]
         assert len(ins_elems) == 1
         for run in _top_level_runs(paragraph):
-            assert not _has_direct_rpr(run)
+            assert not _has_direct_rPr(run)

--- a/tests/test_run_child_order.py
+++ b/tests/test_run_child_order.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import pytest
 
 from docx_editor.track_changes import RevisionManager
-from docx_editor.xml_editor import DocxXMLEditor
+from docx_editor.xml_editor import DocxXMLEditor, compute_paragraph_hash
 
 NS = 'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"'
 AUTHOR = "Test Author"
@@ -283,3 +283,64 @@ class TestTextboxNoDuplication:
         drawings = mgr.editor.dom.getElementsByTagName("w:drawing")
         assert len(drawings) == 1
         assert "boxed" in drawings[0].toxml()
+
+
+def _has_direct_rpr(run) -> bool:
+    """True if ``run`` has a direct w:rPr child."""
+    return any(c.nodeType == c.ELEMENT_NODE and c.tagName == "w:rPr" for c in run.childNodes)
+
+
+def _top_level_runs(paragraph) -> list:
+    """Direct runs of ``paragraph`` plus runs under direct w:ins/w:del wrappers."""
+    runs = []
+    for child in paragraph.childNodes:
+        if child.nodeType != child.ELEMENT_NODE:
+            continue
+        if child.tagName == "w:r":
+            runs.append(child)
+        elif child.tagName in ("w:ins", "w:del"):
+            runs.extend(r for r in child.childNodes if r.nodeType == r.ELEMENT_NODE and r.tagName == "w:r")
+    return runs
+
+
+class TestNestedRPrNoLeak:
+    """A w:rPr nested inside a drawing's text box must not leak into rebuilt
+    top-level runs when the outer run has no direct rPr (ISSUES.md #31)."""
+
+    def test_replace_does_not_inherit_textbox_rpr(self, temp_xml):
+        xml_path = temp_xml(
+            "<w:p><w:r><w:t>x</w:t>"
+            "<w:drawing><w:txbxContent><w:p><w:r><w:rPr><w:b/></w:rPr><w:t>boxed</w:t></w:r></w:p></w:txbxContent></w:drawing>"
+            "<w:t>y</w:t></w:r></w:p>"
+        )
+        mgr = _make_manager(xml_path)
+
+        mgr.replace_text("x", "X")
+
+        paragraph = mgr.editor.dom.getElementsByTagName("w:p")[0]
+        assert paragraph_tokens(mgr) == ["DEL(x)", "INS(X)", "DRAWING", "y"]
+        # The bold prop stays inside the drawing's text box — nowhere else.
+        assert paragraph.toxml().count("<w:b/>") == 1
+        assert "<w:b/>" in mgr.editor.dom.getElementsByTagName("w:drawing")[0].toxml()
+        for run in _top_level_runs(paragraph):
+            assert not _has_direct_rpr(run)
+
+    def test_empty_paragraph_insert_does_not_inherit_textbox_rpr(self, temp_xml):
+        """Insert into a paragraph with no visible text: the created <w:ins>
+        run must not adopt the drawing's nested rPr."""
+        xml_path = temp_xml(
+            "<w:p><w:r>"
+            "<w:drawing><w:txbxContent><w:p><w:r><w:rPr><w:b/></w:rPr></w:r></w:p></w:txbxContent></w:drawing>"
+            "</w:r></w:p>"
+        )
+        mgr = _make_manager(xml_path)
+        paragraph = mgr.editor.dom.getElementsByTagName("w:p")[0]
+        ref = f"P1#{compute_paragraph_hash(paragraph)}"
+
+        mgr.rewrite_paragraph(ref, "inserted")
+
+        assert paragraph.toxml().count("<w:b/>") == 1
+        ins_elems = [c for c in paragraph.childNodes if c.nodeType == c.ELEMENT_NODE and c.tagName == "w:ins"]
+        assert len(ins_elems) == 1
+        for run in _top_level_runs(paragraph):
+            assert not _has_direct_rpr(run)

--- a/tests/test_xml_editor.py
+++ b/tests/test_xml_editor.py
@@ -1,6 +1,8 @@
 """Tests for XMLEditor and DocxXMLEditor classes."""
 
+import defusedxml.minidom
 import pytest
+from conftest import NS
 
 from docx_editor.exceptions import MultipleNodesFoundError, NodeNotFoundError
 from docx_editor.xml_editor import (
@@ -8,6 +10,8 @@ from docx_editor.xml_editor import (
     XMLEditor,
     _generate_hex_id,
     _generate_rsid,
+    get_rPr_xml,
+    render_plain_wt,
 )
 
 
@@ -794,6 +798,47 @@ class TestHelperFunctions:
         int(rsid, 16)
         # Should be uppercase
         assert rsid == rsid.upper()
+
+
+def _parse_run(xml: str):
+    """Parse XML string and return the first w:r element."""
+    doc = defusedxml.minidom.parseString(f"<root {NS}>{xml}</root>")
+    return doc.getElementsByTagName("w:r")[0]
+
+
+class TestRunFragmentHelpers:
+    """Tests for get_rPr_xml and render_plain_wt."""
+
+    def test_get_rpr_xml_direct_child(self):
+        run = _parse_run("<w:r><w:rPr><w:b/></w:rPr><w:t>hi</w:t></w:r>")
+        assert get_rPr_xml(run) == "<w:rPr><w:b/></w:rPr>"
+
+    def test_get_rpr_xml_no_rpr(self):
+        run = _parse_run("<w:r><w:t>hi</w:t></w:r>")
+        assert get_rPr_xml(run) == ""
+
+    def test_get_rpr_xml_ignores_descendant_rpr(self):
+        """An rPr nested inside a drawing's text box is not the run's own."""
+        run = _parse_run(
+            "<w:r><w:drawing><w:txbxContent><w:p><w:r><w:rPr><w:b/></w:rPr>"
+            "<w:t>boxed</w:t></w:r></w:p></w:txbxContent></w:drawing></w:r>"
+        )
+        assert get_rPr_xml(run) == ""
+
+    def test_render_plain_wt_with_text(self):
+        run = _parse_run("<w:r><w:t>hi</w:t></w:r>")
+        wt = run.getElementsByTagName("w:t")[0]
+        assert render_plain_wt(wt, "<w:rPr><w:b/></w:rPr>") == ["<w:r><w:rPr><w:b/></w:rPr><w:t>hi</w:t></w:r>"]
+
+    def test_render_plain_wt_empty_node_yields_nothing(self):
+        run = _parse_run("<w:r><w:t></w:t></w:r>")
+        wt = run.getElementsByTagName("w:t")[0]
+        assert render_plain_wt(wt, "") == []
+
+    def test_render_plain_wt_escapes_special_characters(self):
+        run = _parse_run("<w:r><w:t>a &amp; b &lt; c</w:t></w:r>")
+        wt = run.getElementsByTagName("w:t")[0]
+        assert render_plain_wt(wt, "") == ["<w:r><w:t>a &amp; b &lt; c</w:t></w:r>"]
 
 
 class TestDocxXMLEditorAttributeInjectionExtended:

--- a/tests/test_xml_editor.py
+++ b/tests/test_xml_editor.py
@@ -1,8 +1,7 @@
 """Tests for XMLEditor and DocxXMLEditor classes."""
 
-import defusedxml.minidom
 import pytest
-from conftest import NS
+from conftest import parse_paragraph
 
 from docx_editor.exceptions import MultipleNodesFoundError, NodeNotFoundError
 from docx_editor.xml_editor import (
@@ -802,8 +801,7 @@ class TestHelperFunctions:
 
 def _parse_run(xml: str):
     """Parse XML string and return the first w:r element."""
-    doc = defusedxml.minidom.parseString(f"<root {NS}>{xml}</root>")
-    return doc.getElementsByTagName("w:r")[0]
+    return parse_paragraph(f"<w:p>{xml}</w:p>").getElementsByTagName("w:r")[0]
 
 
 class TestRunFragmentHelpers:


### PR DESCRIPTION
## Summary

Fixes the rPr correctness bug tracked as **ISSUES.md #31** (repo-local issue list — not GitHub issue 31) plus the render_wt dedup that rode along with it.

### Bug fix
`run.getElementsByTagName("w:rPr")` searches **all descendants**, so when an outer run had no `w:rPr` but contained a `w:drawing` whose text-box run did, the inner run's formatting leaked into rebuilt fragments. Three sites in `track_changes.py` (`_get_run_info`, the `_rewrite_insert_at` empty-paragraph branch, the foreign-`w:ins` middle-split) now use the new `get_rPr_xml()`, which iterates direct children only.

### Consolidation
- `_escape_xml` was defined verbatim in both `track_changes.py` and `comments.py` — moved to `xml_editor.py`, re-imported (existing test imports keep working).
- New `render_plain_wt()` replaces five copy-pasted preserve-plain-`w:t` branches across the `render_wt` closures in both modules.
- `comments.py::_get_rPr_xml` promoted to `xml_editor.py::get_rPr_xml` (it was already the correct reference implementation).

### Behavior change (intended, spec-conformant)
`_build_style_outline_map` now treats a `w:style` with **no** `w:type` attribute as a paragraph style (ECMA-376 default) instead of skipping it, so typeless styles carrying `w:outlineLvl` now contribute outline levels.

Net −41 lines in `docx_editor/`, +148 lines of tests. Target release: 0.5.1 (no version bump here).

## Tests

- `TestNestedRPrNoLeak` — regression coverage for both bug paths (replace via `_get_run_info`, insert into a visually-empty paragraph); all new behavior tests fail against the old code.
- `TestRunFragmentHelpers` — unit tests for `get_rPr_xml` / `render_plain_wt` (direct child / none / descendant-only, empty node, escaping).
- `TestStyleMissingTypeDefaultsToParagraph` — typeless style resolves `outline_level`.
- Full suite: 949 passed, 2 skipped. `ruff check` / `ruff format --check` clean. `ty check` exit 0, diagnostics byte-identical to baseline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved comment and tracked-change rendering to preserve text formatting consistently.
  - Prevented formatting from nested text boxes from leaking into surrounding runs.
  - Correctly handles paragraph styles without an explicit type attribute.
  - Ensured special characters and empty text nodes are rendered safely.

- **Tests**
  - Added coverage for nested formatting, typeless paragraph styles, XML rendering, and tracked-text updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->