### PR TITLE
docs: sync SKILL.md and api.md with the real API (ISSUES.md #32)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -204,7 +204,7 @@ Find text in the document, including text spanning XML element boundaries.
 **Parameters:**
 
 - `text` (str): Text to search for
-- `occurrence` (int): Which occurrence to return, counted document-wide. Defaults to 0.
+- `occurrence` (int): Which occurrence to return, counted document-wide, 0-based (0 = first). Defaults to 0.
 
 **Returns:** [`SearchResult`](#searchresult), or None if not found
 
@@ -248,7 +248,7 @@ Replace text with tracked changes. When the target sits inside another author's 
 - `find` (str): Text to find and replace
 - `replace_with` (str): Replacement text
 - `paragraph` (str): Paragraph reference from `list_paragraphs()`, such as `P2#f3c1`
-- `occurrence` (int): Which occurrence within the paragraph. Defaults to 0.
+- `occurrence` (int): Which occurrence within the paragraph, 0-based (0 = first). Defaults to 0.
 
 **Returns:** Updated paragraph reference (str)
 
@@ -267,7 +267,7 @@ Mark text as deleted with tracked changes. Deleting text inside another author's
 
 - `text` (str): Text to mark as deleted
 - `paragraph` (str): Paragraph reference from `list_paragraphs()`, such as `P2#f3c1`
-- `occurrence` (int): Which occurrence within the paragraph. Defaults to 0.
+- `occurrence` (int): Which occurrence within the paragraph, 0-based (0 = first). Defaults to 0.
 
 **Returns:** Updated paragraph reference (str)
 
@@ -286,7 +286,7 @@ Insert text after anchor with tracked changes. An anchor inside another author's
 - `anchor` (str): Text to find as insertion point
 - `text` (str): Text to insert after the anchor
 - `paragraph` (str): Paragraph reference from `list_paragraphs()`, such as `P2#f3c1`
-- `occurrence` (int): Which occurrence within the paragraph. Defaults to 0.
+- `occurrence` (int): Which occurrence within the paragraph, 0-based (0 = first). Defaults to 0.
 
 **Returns:** Updated paragraph reference (str)
 
@@ -305,7 +305,7 @@ Insert text before anchor with tracked changes. Foreign pending insertions are t
 - `anchor` (str): Text to find as insertion point
 - `text` (str): Text to insert before the anchor
 - `paragraph` (str): Paragraph reference from `list_paragraphs()`, such as `P2#f3c1`
-- `occurrence` (int): Which occurrence within the paragraph. Defaults to 0.
+- `occurrence` (int): Which occurrence within the paragraph, 0-based (0 = first). Defaults to 0.
 
 **Returns:** Updated paragraph reference (str)
 
@@ -332,15 +332,17 @@ Rewrite a paragraph using tracked changes generated from a word-level diff.
 ref = doc.rewrite_paragraph("P2#f3c1", "Payment is due within 60 days after invoice receipt.")
 ```
 
-#### `batch_edit(operations)`
+#### `batch_edit(operations, *, dry_run=False)`
 
-Apply multiple edits after validating paragraph hashes up front.
+Apply multiple edits after validating paragraph hashes up front. If any hash is
+stale, the entire batch is rejected before any edits are applied.
 
 **Parameters:**
 
 - `operations` (list[EditOperation]): Edit operations to apply
+- `dry_run` (bool): If True, validate every operation without applying any edits and return one [`EditValidationResult`](#editvalidationresult) per operation, in input order; the document is left unchanged. Each operation is validated independently against the current document — sequential effects between multiple operations on the same paragraph are **not** simulated. Defaults to False.
 
-**Returns:** Updated paragraph references in input order (list[str])
+**Returns:** Updated paragraph references in input order (list[str]); with `dry_run=True`, a list[[`EditValidationResult`](#editvalidationresult)] instead
 
 **Example:**
 
@@ -351,10 +353,22 @@ new_refs = doc.batch_edit([
     EditOperation.replace("old", "new", paragraph="P2#f3c1"),
     EditOperation.delete("remove this", paragraph="P5#d4e5"),
 ])
+
+# Pre-flight the batch, then apply
+results = doc.batch_edit(ops, dry_run=True)
+if all(r.valid for r in results):
+    new_refs = doc.batch_edit(ops)
 ```
 
 Prefer the typed constructors ([`EditOperation`](#editoperation)) — they validate
 arguments when the operation is built, so mistakes fail fast instead of at apply time.
+
+Multiple operations on the same paragraph apply sequentially in input order:
+each operation's find/anchor text and `occurrence` resolve against the
+paragraph's visible text as left by the previous operations in the batch (a
+tracked delete removes text from that view; an insert adds to it). Across
+different paragraphs, operations are applied in reverse document order — a
+behavior that keeps one `list_paragraphs()` snapshot valid for the whole batch.
 
 #### `batch_rewrite(rewrites)`
 
@@ -377,21 +391,27 @@ new_refs = doc.batch_rewrite([
 
 ### Comment Methods
 
-#### `add_comment(anchor_text, comment)`
+#### `add_comment(anchor_text, comment, *, paragraph=None, occurrence=0)`
 
-Add a comment anchored to specific text.
+Add a comment anchored to specific text. Anchors are located with the same
+visible-text search used by `count_matches()` and the tracked-change edit
+methods, so anchors that span `w:t` run boundaries (formatting changes,
+smart-quote splits, `w:ins` wrappers) are found.
 
 **Parameters:**
 
 - `anchor_text` (str): Text to attach the comment to
 - `comment` (str): The comment content
+- `paragraph` (str, optional): Paragraph reference (e.g. `P3#a7b2`) to scope the search. `None` searches the whole document. Defaults to None.
+- `occurrence` (int): Which occurrence to anchor to, 0-based (0 = first). Defaults to 0.
 
-**Returns:** The comment ID (int)
+**Returns:** The comment ID (int). IDs are allocated sequentially starting at 0 in a document with no existing comments — always use the returned ID rather than guessing.
 
 **Example:**
 
 ```python
-doc.add_comment("Section 5", "Please review this section")
+cid = doc.add_comment("Section 5", "Please review this section")
+doc.add_comment("term", "Note on the 2nd 'term'", paragraph="P3#a7b2", occurrence=1)
 ```
 
 #### `reply_to_comment(comment_id, reply)`
@@ -487,6 +507,7 @@ Accept a revision by ID.
 
 - For insertions: keeps the inserted content
 - For deletions: permanently removes the deleted content
+- Nested revisions: accepting an insertion unwraps it in place, so a deletion another author nested inside it survives as an independent pending deletion
 
 **Parameters:**
 
@@ -506,6 +527,7 @@ Reject a revision by ID.
 
 - For insertions: removes the inserted content
 - For deletions: restores the deleted content
+- Nested revisions: rejecting an insertion removes everything inside it — deletions another author nested inside it disappear with it
 
 **Parameters:**
 
@@ -554,7 +576,7 @@ count = doc.reject_all(author="OtherUser")
 
 ### Save and Close Methods
 
-#### `save(path=None, validate=False)`
+#### `save(path=None, validate=False, force=False)`
 
 Save the document.
 
@@ -562,6 +584,7 @@ Save the document.
 
 - `path` (str | Path, optional): Output path. Defaults to original source path.
 - `validate` (bool): If True, validate with LibreOffice before saving. Defaults to False.
+- `force` (bool): If True, skip save-time safety checks. By default `save()` refuses to overwrite the source if it changed on disk since it was opened (raising `WorkspaceSyncError`), or to write a destination that appears open in Word — a `~$` owner file exists next to it (raising [`DocumentOpenError`](#documentopenerror)). Pass `force=True` only for a confirmed-stale lock left by a crashed session. Defaults to False.
 
 **Returns:** Path to the saved document (Path)
 
@@ -578,6 +601,8 @@ doc.save("contract_v2.docx")  # Save to new path
 
 Close the document and clean up workspace. Releases the advisory workspace lock in both cleanup modes — closing is what frees the document for another session to open (see [`WorkspaceLockedError`](#workspacelockederror)).
 
+> **Warning:** closing without saving discards unsaved edits. There is no dirty check: `close()` (the default `cleanup=True`, including normal context-manager exit) deletes the workspace and everything not yet written by `save()` is silently lost. `close(cleanup=False)` keeps the workspace on disk, but a later `Document.open()` of the same source raises `WorkspaceSyncError` if it holds unsaved changes, rather than silently carrying them over.
+
 **Parameters:**
 
 - `cleanup` (bool): If True, delete the workspace folder. Defaults to True.
@@ -585,7 +610,8 @@ Close the document and clean up workspace. Releases the advisory workspace lock 
 **Example:**
 
 ```python
-doc.close()  # Clean up workspace
+doc.save()   # persist edits first —
+doc.close()  # close() alone discards anything unsaved
 doc.close(cleanup=False)  # Keep workspace for inspection
 ```
 
@@ -593,7 +619,9 @@ doc.close(cleanup=False)  # Keep workspace for inspection
 
 ## Comment
 
-Represents a document comment.
+Represents a document comment. IDs are allocated sequentially starting at 0 in
+a document with no existing comments — always use the ID returned by
+`add_comment()` / `reply_to_comment()` rather than assuming a numbering scheme.
 
 ```python
 from docx_editor import Comment
@@ -687,7 +715,7 @@ from docx_editor import EditOperation
 All constructors also take:
 
 - `paragraph` (str): Paragraph reference from `list_paragraphs()`, such as `P2#f3c1`
-- `occurrence` (int): Which occurrence within the paragraph. Defaults to 0. Must be >= 0.
+- `occurrence` (int): Which occurrence within the paragraph, 0-based (0 = first). Defaults to 0. Must be >= 0.
 
 **Raises:** `ValueError` at construction time if the paragraph ref is malformed,
 `occurrence` is negative, a search-target argument (`find`, delete `text`,
@@ -704,6 +732,37 @@ new_refs = doc.batch_edit([
     EditOperation.delete("obsolete clause", paragraph="P5#d4e5"),
     EditOperation.insert_after("Section 5", " (as amended)", paragraph="P7#b1c2"),
 ])
+```
+
+---
+
+## EditValidationResult
+
+The outcome of validating one `EditOperation` in a `batch_edit(ops, dry_run=True)`
+call. One result is returned per operation, in input order.
+
+```python
+from docx_editor import EditValidationResult
+```
+
+### Attributes
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `index` | int | 0-based position of the operation in the input list |
+| `paragraph` | str or None | The operation's paragraph ref (`None` if it was missing) |
+| `valid` | bool | True if the operation would apply cleanly |
+| `error` | str or None | Human-readable reason when not valid |
+
+### Example
+
+```python
+results = doc.batch_edit(ops, dry_run=True)
+for r in results:
+    if not r.valid:
+        print(f"op {r.index} on {r.paragraph}: {r.error}")
+if all(r.valid for r in results):
+    new_refs = doc.batch_edit(ops)
 ```
 
 ---
@@ -812,6 +871,19 @@ Raised when the workspace is out of sync with the source document: the source ch
 
 ```python
 from docx_editor.exceptions import WorkspaceSyncError
+```
+
+### `DocumentOpenError`
+
+Raised by `save()` when the destination appears open in another program. Word writes a `~$` owner (lock) file next to any document it has open; if that stub exists at save time, saving would race Word's own writes, so `save()` refuses unless `force=True`. Also raised when the OS denies the final replace (on Windows, Word holding the file open is exactly this case) — `force=True` cannot suppress that one. The exception carries `path` (the destination) and `owner_file` (the `~$` file that triggered the guard, or `None` when the OS denied the replace) attributes.
+
+```python
+from docx_editor.exceptions import DocumentOpenError
+
+try:
+    doc.save()
+except DocumentOpenError as e:
+    print(f"Close {e.path} in Word first (lock: {e.owner_file})")
 ```
 
 ### `WorkspaceLockedError`

--- a/docs/api.md
+++ b/docs/api.md
@@ -25,7 +25,7 @@ Open a Word document for editing.
 
 **Raises:**
 
-- `WorkspaceSyncError`: If the source `.docx` was modified since the workspace was created, or if a leftover workspace holds unsaved changes from a previous session (one that saved to a different path, or whose save failed, and never closed). Pass `force_recreate=True` to discard the workspace and re-unpack from the current source. The workspace is never deleted silently. The error message includes the workspace path.
+- `WorkspaceSyncError`: If the source `.docx` was modified since the workspace was created, or if a leftover workspace holds unsaved changes from a previous session — any session that made edits without a final successful `save()` back to the source (it saved to a different path, its save failed, or it closed with `close(cleanup=False)`). Pass `force_recreate=True` to discard the workspace and re-unpack from the current source. The workspace is never deleted silently. The error message includes the workspace path.
 - `WorkspaceLockedError`: If a live session — another process, or an unclosed `Document` in this one — already holds the document's workspace. Close the other session, or pass `force_recreate=True` to take the workspace over and discard its unsaved edits. Locks left by dead processes are reclaimed silently.
 - `WorkspaceError`: If the workspace directory cannot be created (e.g. the base is not writable), the home directory backing the default cache cannot be determined, or an existing workspace was unpacked from a different document. The message names the override to set.
 
@@ -612,7 +612,9 @@ Close the document and clean up workspace. Releases the advisory workspace lock 
 ```python
 doc.save()   # persist edits first —
 doc.close()  # close() alone discards anything unsaved
-doc.close(cleanup=False)  # Keep workspace for inspection
+
+# Or, instead of the above: keep the workspace on disk for inspection
+doc.close(cleanup=False)
 ```
 
 ---

--- a/docs/api.md
+++ b/docs/api.md
@@ -342,17 +342,17 @@ stale, the entire batch is rejected before any edits are applied.
 - `operations` (list[EditOperation]): Edit operations to apply
 - `dry_run` (bool): If True, validate every operation without applying any edits and return one [`EditValidationResult`](#editvalidationresult) per operation, in input order; the document is left unchanged. Each operation is validated independently against the current document — sequential effects between multiple operations on the same paragraph are **not** simulated. Defaults to False.
 
-**Returns:** Updated paragraph references in input order (list[str]); with `dry_run=True`, a list[[`EditValidationResult`](#editvalidationresult)] instead
+**Returns:** Updated paragraph references in input order (list[str]); with `dry_run=True`, a list of [`EditValidationResult`](#editvalidationresult) instead
 
 **Example:**
 
 ```python
 from docx_editor import EditOperation
 
-new_refs = doc.batch_edit([
+ops = [
     EditOperation.replace("old", "new", paragraph="P2#f3c1"),
     EditOperation.delete("remove this", paragraph="P5#d4e5"),
-])
+]
 
 # Pre-flight the batch, then apply
 results = doc.batch_edit(ops, dry_run=True)
@@ -584,7 +584,7 @@ Save the document.
 
 - `path` (str | Path, optional): Output path. Defaults to original source path.
 - `validate` (bool): If True, validate with LibreOffice before saving. Defaults to False.
-- `force` (bool): If True, skip save-time safety checks. By default `save()` refuses to overwrite the source if it changed on disk since it was opened (raising `WorkspaceSyncError`), or to write a destination that appears open in Word — a `~$` owner file exists next to it (raising [`DocumentOpenError`](#documentopenerror)). Pass `force=True` only for a confirmed-stale lock left by a crashed session. Defaults to False.
+- `force` (bool): If True, skip save-time safety checks. By default `save()` refuses to overwrite the source if it changed on disk since it was opened (raising [`WorkspaceSyncError`](#workspacesyncerror)), or to write a destination that appears open in Word — a `~$` owner file exists next to it (raising [`DocumentOpenError`](#documentopenerror)). Pass `force=True` only for a confirmed-stale lock left by a crashed session. Defaults to False.
 
 **Returns:** Path to the saved document (Path)
 
@@ -757,6 +757,12 @@ from docx_editor import EditValidationResult
 ### Example
 
 ```python
+from docx_editor import EditOperation
+
+ops = [
+    EditOperation.replace("old", "new", paragraph="P2#f3c1"),
+    EditOperation.delete("remove this", paragraph="P5#d4e5"),
+]
 results = doc.batch_edit(ops, dry_run=True)
 for r in results:
     if not r.valid:

--- a/skills/docx/SKILL.md
+++ b/skills/docx/SKILL.md
@@ -29,6 +29,7 @@ What do you need to do?
     - Tracked changes (redlining)
     - Comments (add, reply, resolve)
     - Accept/reject revisions
+    - Review received redlines (see "Reviewing someone else's redlines")
 ```
 
 ## Reading and analyzing content
@@ -187,7 +188,9 @@ with Document.open("contract.docx", author=author) as doc:
 
     doc.save()  # Overwrites original
     # or doc.save("reviewed.docx")  # Save to new file
-# Workspace is cleaned up automatically on normal exit
+# Workspace is cleaned up automatically on normal exit — WITHOUT saving.
+# There is no dirty check: unsaved edits are silently discarded, so always
+# call save() before the block ends.
 # On exception, the workspace is preserved for inspection in the user cache
 # dir (~/.cache/docx-editor/<hash>/ on Linux; error messages print the exact path)
 ```
@@ -198,8 +201,8 @@ Without context manager:
 doc = Document.open("contract.docx", author=author)
 refs = doc.list_paragraphs()
 # ... edits using paragraph references ...
-doc.save()
-doc.close()
+doc.save()   # save first —
+doc.close()  # close() deletes the workspace without saving; unsaved edits are lost
 ```
 
 ### Track Changes API
@@ -226,22 +229,35 @@ match = doc.find_text("30 days")
 # Get all visible text (inserted text included, deleted text excluded)
 visible = doc.get_visible_text()
 
+# Inverse view: deleted text included, inserted text excluded. Read-only —
+# refs, hashes, and edits keep working on the visible view. For revisions
+# inside paragraphs this equals what reject_all() would leave.
+original = doc.get_original_text()
+
 # Structural location: table cell, list item (raw numId/ilvl), heading context,
-# and section index
+# and section index. Base conventions are MIXED — read the comments:
 loc = doc.get_paragraph_location("P3#b2c4")
-if loc.table:
+if loc.table:  # table.index, row, col are all 1-based
     print(f"table {loc.table.index} r{loc.table.row} c{loc.table.col}")
-if loc.list:
+if loc.list:  # ilvl is 0-based (0 == top level)
     print(f"list numId={loc.list.num_id} level={loc.list.ilvl}")
-if loc.outline_level is not None:  # 0-based; 0 == Heading 1
+if loc.outline_level is not None:  # 0-based; 0 == Heading 1; None == body text
     print(f"heading level {loc.outline_level + 1}: style={loc.style}")
 print(" > ".join(loc.heading_path))  # e.g. "Chapter one > Termination"
 print(loc.section)  # 1-based section index; sectPr-carrying paragraph closes its section
+
+# One-pass batch variant: [(ref, ParagraphLocation), ...] for every paragraph
+locations = doc.list_paragraph_locations()
 
 # All edit methods return the new paragraph ref as a plain string.
 # Use it for follow-up edits on the same paragraph:
 new_ref = doc.replace("30 days", "60 days", paragraph="P2#f3c1")
 doc.replace("net", "gross", paragraph=new_ref)  # chain without list_paragraphs()
+
+# occurrence is 0-based everywhere (0 = first, the default). Edit methods and
+# add_comment count occurrences within the target paragraph; find_text counts
+# document-wide.
+doc.replace("thirty", "sixty", paragraph="P4#a1d2", occurrence=1)  # 2nd "thirty"
 
 # Delete text (creates tracked deletion)
 doc.delete("unnecessary clause", paragraph="P5#d4e5")
@@ -273,8 +289,17 @@ import os
 author = os.environ.get("USER") or "Reviewer"
 doc = Document.open("document.docx", author=author)
 
-# Add a comment anchored to text (returns comment ID)
-doc.add_comment("ambiguous term", "Please clarify this term")
+# Add a comment anchored to text (returns the new comment's ID).
+# Full signature: add_comment(anchor_text, comment, *, paragraph=None, occurrence=0)
+# paragraph=None searches the whole document; occurrence is 0-based within the
+# paragraph. The anchor is located with the same visible-text search the edit
+# methods use, so anchors spanning run boundaries are found.
+cid = doc.add_comment("ambiguous term", "Please clarify this term")
+cid2 = doc.add_comment("term", "Anchored to the 2nd 'term' in P3",
+                       paragraph="P3#b2c4", occurrence=1)
+
+# Comment IDs are allocated sequentially starting at 0 (in a document with no
+# existing comments) — always use the ID returned by add_comment, don't guess.
 
 # List all comments (returns list[Comment] objects)
 comments = doc.list_comments()
@@ -286,12 +311,12 @@ for c in comments:
 # Filter by author
 my_comments = doc.list_comments(author="Reviewer")
 
-# Reply to a comment (returns new comment ID)
-doc.reply_to_comment(comment_id=1, reply="I agree, needs clarification")
+# Reply to a comment (returns the reply's new comment ID)
+doc.reply_to_comment(cid, "I agree, needs clarification")
 
 # Resolve or delete comments (return True if found, False if not)
-doc.resolve_comment(comment_id=1)
-doc.delete_comment(comment_id=2)
+doc.resolve_comment(cid)
+doc.delete_comment(cid2)
 
 doc.save()
 doc.close()
@@ -329,6 +354,44 @@ doc.reject_all(author="OtherUser")
 doc.save()
 doc.close()
 ```
+
+### Reviewing Someone Else's Redlines
+
+When a document arrives with pending tracked changes from other authors:
+
+**Anchors match visible text.** `find_text`, the edit methods, and
+`add_comment` all search the view with pending insertions included and pending
+deletions excluded — target the text as it reads with all changes showing
+(exactly what `get_visible_text()` returns).
+
+**Nested revisions** (one author edited inside another author's pending
+insertion):
+
+- *Accepting* the insertion unwraps it in place — a deletion another author
+  nested inside it survives as an independent pending deletion.
+- *Rejecting* the insertion removes everything inside it — nested deletions
+  disappear with it.
+- `accept_all()` / `reject_all()` resolve nesting fully (they re-scan until no
+  revisions remain), and `author=` filters process each author's changes
+  independently.
+
+**Predict, then verify.** `get_visible_text()` is the document as it will read
+after `accept_all()`; `get_original_text()` is the document as it will read
+after `reject_all()` (for revisions inside paragraphs). Snapshot before acting,
+compare after:
+
+```python
+doc = Document.open("redlined.docx", author=author)
+expected = doc.get_visible_text()   # the accept-all outcome
+doc.accept_all(author="OtherUser")  # resolve their changes only
+assert doc.get_visible_text() == expected
+doc.save("resolved.docx")
+doc.close()
+```
+
+To act on a subset, target revisions by ID: `list_revisions()` (optionally
+`author=`-filtered), pick by `.text`/`.type`, then `accept_revision(id)` /
+`reject_revision(id)`. There is no paragraph-scoped revision filter today.
 
 ## Redlining Workflow (Document Review)
 
@@ -458,6 +521,32 @@ with Document.open("file.docx", author=author) as doc:
 Build operations with the typed constructors (`EditOperation.replace/.delete/.insert_after/.insert_before` — same signatures as the `Document` methods). They validate arguments immediately and raise `ValueError` with a field-specific message, instead of failing later at apply time.
 
 If any hash is stale, the entire batch is rejected before any edits are applied.
+
+**Pre-flight with `dry_run=True`** — validates every operation without applying
+anything and returns `list[EditValidationResult]` (fields: `index`, `paragraph`,
+`valid`, `error`), one per operation in input order. The document is left
+unchanged:
+
+```python
+results = doc.batch_edit(ops, dry_run=True)
+if all(r.valid for r in results):
+    new_refs = doc.batch_edit(ops)
+else:
+    for r in results:
+        if not r.valid:
+            print(f"op {r.index} on {r.paragraph}: {r.error}")
+```
+
+Each operation is validated independently against the current document —
+`dry_run` does **not** simulate the sequential effects of multiple operations
+on the same paragraph.
+
+**Multiple operations on the same paragraph** apply sequentially in input
+order: each op's find/anchor text and `occurrence` resolve against the
+paragraph's visible text *as left by the previous ops in the batch* (a tracked
+delete removes text from that view; an insert adds to it). Across different
+paragraphs, ops are applied in reverse document order — a behavior that keeps
+one `list_paragraphs()` snapshot valid for the whole batch.
 
 ### Error Handling & Recovery
 
@@ -613,6 +702,10 @@ docx-session exec "paras = doc.list_paragraphs(); print('\n'.join(str(p) for p i
 docx-session exec "ref = doc.replace('30 days', '45 days', paragraph='P2#f3c1'); ref"
 docx-session exec "doc.add_comment('45 days', 'Extended per negotiation.', paragraph=ref)"
 docx-session exec "doc.save(); doc.close()"
+
+# Check whether a session is running: prints "running"/"not running";
+# exit code 0 if running, 3 if not
+docx-session status
 
 docx-session stop
 ```

--- a/skills/docx/SKILL.md
+++ b/skills/docx/SKILL.md
@@ -341,9 +341,10 @@ for r in revisions:
 # Filter by author
 their_changes = doc.list_revisions(author="OtherUser")
 
-# Accept or reject individual revisions (return True if found, False if not)
-doc.accept_revision(revision_id=1)
-doc.reject_revision(revision_id=2)
+# Accept or reject individual revisions (return True if found, False if not).
+# Use IDs from list_revisions() — don't guess numbering.
+doc.accept_revision(revisions[0].id)
+doc.reject_revision(their_changes[0].id)
 
 # Accept or reject all revisions (returns count of revisions processed)
 doc.accept_all()

--- a/skills/docx/SKILL.md
+++ b/skills/docx/SKILL.md
@@ -29,7 +29,7 @@ What do you need to do?
     - Tracked changes (redlining)
     - Comments (add, reply, resolve)
     - Accept/reject revisions
-    - Review received redlines (see "Reviewing someone else's redlines")
+    - Review received redlines (see "Reviewing Someone Else's Redlines")
 ```
 
 ## Reading and analyzing content
@@ -254,9 +254,10 @@ locations = doc.list_paragraph_locations()
 new_ref = doc.replace("30 days", "60 days", paragraph="P2#f3c1")
 doc.replace("net", "gross", paragraph=new_ref)  # chain without list_paragraphs()
 
-# occurrence is 0-based everywhere (0 = first, the default). Edit methods and
-# add_comment count occurrences within the target paragraph; find_text counts
-# document-wide.
+# occurrence is 0-based everywhere (0 = first, the default). Edit methods
+# count occurrences within the target paragraph; find_text counts document-wide.
+# add_comment counts within the paragraph when paragraph= is given, and
+# document-wide (like find_text) when paragraph=None.
 doc.replace("thirty", "sixty", paragraph="P4#a1d2", occurrence=1)  # 2nd "thirty"
 
 # Delete text (creates tracked deletion)
@@ -291,8 +292,9 @@ doc = Document.open("document.docx", author=author)
 
 # Add a comment anchored to text (returns the new comment's ID).
 # Full signature: add_comment(anchor_text, comment, *, paragraph=None, occurrence=0)
-# paragraph=None searches the whole document; occurrence is 0-based within the
-# paragraph. The anchor is located with the same visible-text search the edit
+# paragraph=None searches the whole document and counts occurrence document-wide;
+# pass paragraph= to scope both the search and the occurrence count to it.
+# The anchor is located with the same visible-text search the edit
 # methods use, so anchors spanning run boundaries are found.
 cid = doc.add_comment("ambiguous term", "Please clarify this term")
 cid2 = doc.add_comment("term", "Anchored to the 2nd 'term' in P3",
@@ -381,6 +383,9 @@ after `reject_all()` (for revisions inside paragraphs). Snapshot before acting,
 compare after:
 
 ```python
+import os
+author = os.environ.get("USER") or "Reviewer"
+
 doc = Document.open("redlined.docx", author=author)
 expected = doc.get_visible_text()   # the accept-all outcome
 doc.accept_all(author="OtherUser")  # resolve their changes only
@@ -509,11 +514,12 @@ from docx_editor import Document, EditOperation
 
 with Document.open("file.docx", author=author) as doc:
     refs = doc.list_paragraphs()
-    new_refs = doc.batch_edit([
+    ops = [
         EditOperation.replace("old term", "new term", paragraph="P2#f3c1"),
         EditOperation.delete("remove this", paragraph="P5#d4e5"),
         EditOperation.insert_after("Section 5", " (amended)", paragraph="P3#b2c4"),
-    ])
+    ]
+    new_refs = doc.batch_edit(ops)
     # new_refs[0] = "P2#c3d4" — fresh ref for paragraph 2
     doc.save()
 ```
@@ -525,7 +531,7 @@ If any hash is stale, the entire batch is rejected before any edits are applied.
 **Pre-flight with `dry_run=True`** — validates every operation without applying
 anything and returns `list[EditValidationResult]` (fields: `index`, `paragraph`,
 `valid`, `error`), one per operation in input order. The document is left
-unchanged:
+unchanged (`ops` is the `EditOperation` list built above):
 
 ```python
 results = doc.batch_edit(ops, dry_run=True)
@@ -542,11 +548,11 @@ Each operation is validated independently against the current document —
 on the same paragraph.
 
 **Multiple operations on the same paragraph** apply sequentially in input
-order: each op's find/anchor text and `occurrence` resolve against the
-paragraph's visible text *as left by the previous ops in the batch* (a tracked
-delete removes text from that view; an insert adds to it). Across different
-paragraphs, ops are applied in reverse document order — a behavior that keeps
-one `list_paragraphs()` snapshot valid for the whole batch.
+order: each operation's find/anchor text and `occurrence` resolve against the
+paragraph's visible text *as left by the previous operations in the batch* (a
+tracked delete removes text from that view; an insert adds to it). Across
+different paragraphs, operations are applied in reverse document order — a
+behavior that keeps one `list_paragraphs()` snapshot valid for the whole batch.
 
 ### Error Handling & Recovery
 


### PR DESCRIPTION
## Summary

Syncs `skills/docx/SKILL.md` and `docs/api.md` with the actual `docx_editor` API, fixing drift found by reading the live package (ISSUES.md #32 — repo-local tracker, not a GitHub issue). Docs-only: 2 files, +194/−29.

### What was out of sync

- `add_comment` was documented with the old two-arg signature; now documents the full `(anchor_text, comment, *, paragraph=None, occurrence=0)` form and the text-map anchor search
- Comment IDs allocate sequentially from 0; examples used hardcoded `comment_id=1/2` literals
- `batch_edit(dry_run=True)` and its `EditValidationResult` return type were undocumented, as were the same-paragraph sequential semantics and reverse-document-order application
- `save(force=...)` and `DocumentOpenError` (owner-file guard) were undocumented
- `close()` silently discarding unsaved edits was not called out
- `get_original_text()`, `list_paragraph_locations()`, and `docx-session status` were missing entirely
- `occurrence` is 0-based everywhere but was documented inconsistently
- New "Reviewing Someone Else's Redlines" section covering nested revision accept/reject semantics and the predict-then-verify idiom

### Verification

- Empirical smoke test (14 assertions) proved the behavioral claims end-to-end against live fixture documents: comment ID from 0, `occurrence=1` targeting, same-paragraph sequential resolution, `dry_run` isolation, nested foreign-deletion accept/reject semantics
- Every documented claim traced back to source during self-review (signatures, exception attributes, exit codes, batch ordering)
- `pytest` 940 passed / 2 skipped, `ruff` clean, `ty check` exit 0, `mkdocs build --strict` clean