### PR TITLE
fix: wrap parse errors in InvalidDocumentError, clean up partial workspace (ISSUES.md #35)

### DIFF
--- a/docx_editor/ooxml/unpack.py
+++ b/docx_editor/ooxml/unpack.py
@@ -75,7 +75,10 @@ def unpack_document(input_file: str | Path, output_dir: str | Path) -> str:
             if entry.is_symlink():
                 raise InvalidDocumentError(f"Symlink inside output directory: {entry}")
 
-    created_output_dir = not output_path.exists()
+    # Ownership of the output dir is claimed by the mkdir itself, not by a
+    # separate exists() check, so a directory created concurrently by someone
+    # else can never be adopted and then deleted by the failure cleanup.
+    created_output_dir = False
 
     try:
         # Validate ZIP entries before extractall (and before mkdir) so a
@@ -87,7 +90,11 @@ def unpack_document(input_file: str | Path, output_dir: str | Path) -> str:
                         raise InvalidDocumentError(f"Unsafe ZIP entry path: {info.filename!r} in {input_file}")
                     if _is_symlink_entry(info):
                         raise InvalidDocumentError(f"Symlink ZIP entry: {info.filename!r} in {input_file}")
-                output_path.mkdir(parents=True, exist_ok=True)
+                try:
+                    output_path.mkdir(parents=True)
+                    created_output_dir = True
+                except FileExistsError:
+                    pass
                 zf.extractall(output_path)
         except zipfile.BadZipFile as e:
             raise InvalidDocumentError(f"Not a valid .docx file: {input_file}") from e

--- a/docx_editor/ooxml/unpack.py
+++ b/docx_editor/ooxml/unpack.py
@@ -1,11 +1,14 @@
 """Unpack and format XML contents of Office files (.docx, .pptx, .xlsx)."""
 
 import random
+import shutil
 import stat
 import zipfile
 from pathlib import Path
+from xml.parsers.expat import ExpatError
 
 import defusedxml.minidom
+from defusedxml.common import DefusedXmlException
 
 from docx_editor.exceptions import DocumentNotFoundError, InvalidDocumentError
 
@@ -48,8 +51,13 @@ def unpack_document(input_file: str | Path, output_dir: str | Path) -> str:
     Raises:
         DocumentNotFoundError: If the input file doesn't exist
         InvalidDocumentError: If the file is not a valid zip/docx, contains an
-            unsafe entry path or a symlink entry, or the output directory is
-            (or contains) a symlink or is an existing non-directory.
+            unsafe entry path or a symlink entry, a part contains malformed XML
+            or XML constructs refused for security (DTD entity/external
+            declarations), or the output directory is (or contains) a symlink
+            or is an existing non-directory.
+
+    On failure after extraction has started, the output directory is removed
+    if this call created it; a pre-existing directory is left in place.
     """
     input_path = Path(input_file)
     output_path = Path(output_dir)
@@ -67,26 +75,44 @@ def unpack_document(input_file: str | Path, output_dir: str | Path) -> str:
             if entry.is_symlink():
                 raise InvalidDocumentError(f"Symlink inside output directory: {entry}")
 
-    # Validate ZIP entries before extractall (and before mkdir) so a rejection
-    # leaves the filesystem untouched.
-    try:
-        with zipfile.ZipFile(input_path) as zf:
-            for info in zf.infolist():
-                if _is_unsafe_zip_path(info.filename):
-                    raise InvalidDocumentError(f"Unsafe ZIP entry path: {info.filename!r} in {input_file}")
-                if _is_symlink_entry(info):
-                    raise InvalidDocumentError(f"Symlink ZIP entry: {info.filename!r} in {input_file}")
-            output_path.mkdir(parents=True, exist_ok=True)
-            zf.extractall(output_path)
-    except zipfile.BadZipFile as e:
-        raise InvalidDocumentError(f"Not a valid .docx file: {input_file}") from e
+    created_output_dir = not output_path.exists()
 
-    # Pretty print all XML files
-    xml_files = list(output_path.rglob("*.xml")) + list(output_path.rglob("*.rels"))
-    for xml_file in xml_files:
-        content = xml_file.read_text(encoding="utf-8")
-        dom = defusedxml.minidom.parseString(content)
-        xml_file.write_bytes(dom.toprettyxml(indent="  ", encoding="utf-8"))
+    try:
+        # Validate ZIP entries before extractall (and before mkdir) so a
+        # rejection leaves the filesystem untouched.
+        try:
+            with zipfile.ZipFile(input_path) as zf:
+                for info in zf.infolist():
+                    if _is_unsafe_zip_path(info.filename):
+                        raise InvalidDocumentError(f"Unsafe ZIP entry path: {info.filename!r} in {input_file}")
+                    if _is_symlink_entry(info):
+                        raise InvalidDocumentError(f"Symlink ZIP entry: {info.filename!r} in {input_file}")
+                output_path.mkdir(parents=True, exist_ok=True)
+                zf.extractall(output_path)
+        except zipfile.BadZipFile as e:
+            raise InvalidDocumentError(f"Not a valid .docx file: {input_file}") from e
+
+        # Pretty print all XML files
+        xml_files = list(output_path.rglob("*.xml")) + list(output_path.rglob("*.rels"))
+        for xml_file in xml_files:
+            content = xml_file.read_text(encoding="utf-8")
+            try:
+                dom = defusedxml.minidom.parseString(content)
+            except (ExpatError, DefusedXmlException) as e:
+                # DefusedXmlException covers EntitiesForbidden and siblings; it
+                # subclasses ValueError, so catch the defused type specifically
+                # to keep unrelated ValueErrors loud. `from e` preserves the
+                # security exception for audit.
+                raise InvalidDocumentError(
+                    f"Invalid XML in {xml_file.relative_to(output_path)} of {input_file}: {e}"
+                ) from e
+            xml_file.write_bytes(dom.toprettyxml(indent="  ", encoding="utf-8"))
+    except BaseException:
+        # A partially-extracted dir would wedge later opens; only remove it if
+        # this call created it — a pre-existing dir may hold caller data.
+        if created_output_dir:
+            shutil.rmtree(output_path, ignore_errors=True)
+        raise
 
     # Generate and return RSID for tracked changes
     suggested_rsid = "".join(random.choices("0123456789ABCDEF", k=8))

--- a/docx_editor/ooxml/unpack.py
+++ b/docx_editor/ooxml/unpack.py
@@ -41,6 +41,9 @@ def _is_symlink_entry(info: zipfile.ZipInfo) -> bool:
 def unpack_document(input_file: str | Path, output_dir: str | Path) -> str:
     """Unpack a .docx file to a directory with pretty-printed XML.
 
+    On failure after extraction has started, the output directory is removed
+    if this call created it; a pre-existing directory is left in place.
+
     Args:
         input_file: Path to the .docx file to unpack
         output_dir: Directory to extract contents to
@@ -55,9 +58,6 @@ def unpack_document(input_file: str | Path, output_dir: str | Path) -> str:
             or XML constructs refused for security (DTD entity/external
             declarations), or the output directory is (or contains) a symlink
             or is an existing non-directory.
-
-    On failure after extraction has started, the output directory is removed
-    if this call created it; a pre-existing directory is left in place.
     """
     input_path = Path(input_file)
     output_path = Path(output_dir)
@@ -95,7 +95,11 @@ def unpack_document(input_file: str | Path, output_dir: str | Path) -> str:
         # Pretty print all XML files
         xml_files = list(output_path.rglob("*.xml")) + list(output_path.rglob("*.rels"))
         for xml_file in xml_files:
-            content = xml_file.read_text(encoding="utf-8")
+            # Parse bytes, not decoded text: expat then honors the part's XML
+            # encoding declaration (a UTF-16 part is valid OOXML), and byte-level
+            # garbage surfaces as ExpatError below instead of a raw
+            # UnicodeDecodeError escaping the InvalidDocumentError contract.
+            content = xml_file.read_bytes()
             try:
                 dom = defusedxml.minidom.parseString(content)
             except (ExpatError, DefusedXmlException) as e:
@@ -104,7 +108,7 @@ def unpack_document(input_file: str | Path, output_dir: str | Path) -> str:
                 # to keep unrelated ValueErrors loud. `from e` preserves the
                 # security exception for audit.
                 raise InvalidDocumentError(
-                    f"Invalid XML in {xml_file.relative_to(output_path)} of {input_file}: {e}"
+                    f"Invalid XML in {xml_file.relative_to(output_path).as_posix()} of {input_file}: {e}"
                 ) from e
             xml_file.write_bytes(dom.toprettyxml(indent="  ", encoding="utf-8"))
     except BaseException:

--- a/docx_editor/workspace.py
+++ b/docx_editor/workspace.py
@@ -580,28 +580,37 @@ class Workspace:
                 f"or pass workspace_dir=."
             ) from exc
 
-        # Unpack document
-        rsid = unpack_document(self.source_path, self.workspace_path)
+        try:
+            # Unpack document
+            rsid = unpack_document(self.source_path, self.workspace_path)
 
-        # Get source file info
-        source_stat = self.source_path.stat()
+            # Get source file info
+            source_stat = self.source_path.stat()
 
-        # Create metadata
-        self.meta = {
-            "source_path": str(self.source_path),
-            "source_mtime": source_stat.st_mtime,
-            "source_size": source_stat.st_size,
-            "source_sha256": _file_sha256(self.source_path),
-            "created_at": datetime.now(timezone.utc).isoformat(),
-            "author": self._author,
-            "initials": self._author[0].upper() if self._author else "",
-            "rsid": rsid,
-            "next_comment_id": 0,
-            "next_change_id": 0,
-            "dirty": False,
-        }
+            # Create metadata
+            self.meta = {
+                "source_path": str(self.source_path),
+                "source_mtime": source_stat.st_mtime,
+                "source_size": source_stat.st_size,
+                "source_sha256": _file_sha256(self.source_path),
+                "created_at": datetime.now(timezone.utc).isoformat(),
+                "author": self._author,
+                "initials": self._author[0].upper() if self._author else "",
+                "rsid": rsid,
+                "next_comment_id": 0,
+                "next_change_id": 0,
+                "dirty": False,
+            }
 
-        self._save_meta()
+            self._save_meta()
+        except BaseException:
+            # A partial workspace (no meta.json) would make the next open fail
+            # with a misleading WorkspaceExistsError. This method is only
+            # reached when the dir did not pre-exist, so nothing but our own
+            # partial output is removed; the advisory lock is a sibling file
+            # released by __init__'s handler, so rmtree composes cleanly.
+            shutil.rmtree(self.workspace_path, ignore_errors=True)
+            raise
 
     def _load_meta(self) -> dict[str, Any] | None:
         """Load metadata from meta.json."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,6 +44,10 @@ def replace_document_xml(src: Path, dest: Path, new_doc_xml: str) -> None:
 
 NS = 'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"'
 
+# XML with an entity declaration: defusedxml refuses it (EntitiesForbidden),
+# reproducing the ISSUES.md #35 parse-failure path (apache/poi XXE sample).
+ENTITY_DTD_XML = '<!DOCTYPE r [<!ENTITY xxe SYSTEM "file:///etc/passwd">]><r>&xxe;</r>'
+
 
 def parse_paragraph(xml: str):
     """Parse XML string and return the first w:p element."""

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -5,12 +5,17 @@ import re
 import zipfile
 
 import pytest
-from conftest import NS, find_ref, replace_document_xml
+from conftest import ENTITY_DTD_XML, NS, find_ref, replace_document_xml
 from defusedxml.common import EntitiesForbidden
 
 import docx_editor
 from docx_editor import Document, SearchResult
-from docx_editor.exceptions import DocumentOpenError, WorkspaceSyncError
+from docx_editor.exceptions import (
+    DocumentOpenError,
+    DocxEditError,
+    InvalidDocumentError,
+    WorkspaceSyncError,
+)
 from docx_editor.workspace import Workspace
 
 
@@ -87,8 +92,22 @@ class TestDocumentOpen:
             '<!DOCTYPE w:document [<!ENTITY x SYSTEM "http://example.com/x">]>\n'
             f"<w:document {NS}><w:body><w:p><w:r><w:t>&x;</w:t></w:r></w:p></w:body></w:document>",
         )
-        with pytest.raises(EntitiesForbidden):
+        # The refusal now surfaces as the documented InvalidDocumentError;
+        # the EntitiesForbidden cause proves the entity was never expanded.
+        with pytest.raises(InvalidDocumentError) as excinfo:
             Document.open(evil, workspace_dir=tmp_path / "ws")
+        assert isinstance(excinfo.value.__cause__, EntitiesForbidden)
+
+    def test_document_open_invalid_xml_raises_invalid_document_error(self, simple_docx, temp_dir):
+        """ISSUES.md #35: malformed XML in a part surfaces as InvalidDocumentError."""
+        bad_docx = temp_dir / "bad.docx"
+        replace_document_xml(simple_docx, bad_docx, ENTITY_DTD_XML)
+
+        with pytest.raises(DocxEditError) as excinfo:
+            Document.open(bad_docx)
+
+        assert isinstance(excinfo.value, InvalidDocumentError)
+
 
 
 class TestDocumentSave:

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -99,7 +99,7 @@ class TestDocumentOpen:
         assert isinstance(excinfo.value.__cause__, EntitiesForbidden)
 
     def test_document_open_invalid_xml_raises_invalid_document_error(self, simple_docx, temp_dir):
-        """ISSUES.md #35: malformed XML in a part surfaces as InvalidDocumentError."""
+        """Malformed XML in a part surfaces as InvalidDocumentError (ISSUES.md #35)."""
         bad_docx = temp_dir / "bad.docx"
         replace_document_xml(simple_docx, bad_docx, ENTITY_DTD_XML)
 

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -109,7 +109,6 @@ class TestDocumentOpen:
         assert isinstance(excinfo.value, InvalidDocumentError)
 
 
-
 class TestDocumentSave:
     """Tests for saving documents."""
 

--- a/tests/test_ooxml.py
+++ b/tests/test_ooxml.py
@@ -3,9 +3,11 @@
 import stat
 import sys
 import zipfile
+from xml.parsers.expat import ExpatError
 
 import pytest
-from conftest import NS, replace_document_xml
+from conftest import ENTITY_DTD_XML, NS, replace_document_xml
+from defusedxml.common import EntitiesForbidden
 
 from docx_editor.exceptions import DocumentNotFoundError, InvalidDocumentError
 from docx_editor.ooxml.pack import pack_document
@@ -168,6 +170,55 @@ class TestUnpack:
 
         with pytest.raises(InvalidDocumentError, match="Symlink inside output directory"):
             unpack_document(simple_docx, output)
+
+
+class TestUnpackParseErrors:
+    """ISSUES.md #35: parse-stage failures must raise InvalidDocumentError, not leak raw.
+
+    Each fixture contains exactly one bad XML part — rglob order is
+    nondeterministic, so a second bad part would make the "names the
+    offending part" assertion flaky.
+    """
+
+    def test_unpack_wraps_entity_dtd_in_invalid_document_error(self, temp_dir):
+        """Entity-bearing DTD (defusedxml refusal) surfaces as InvalidDocumentError."""
+        bad_zip = temp_dir / "bad.docx"
+        _build_zip(bad_zip, [("word/document.xml", ENTITY_DTD_XML.encode("utf-8"))])
+        output = temp_dir / "output"
+
+        with pytest.raises(InvalidDocumentError, match=r"Invalid XML in word/document\.xml") as excinfo:
+            unpack_document(bad_zip, output)
+
+        assert isinstance(excinfo.value.__cause__, EntitiesForbidden)
+        # The partially-extracted dir this call created must be removed.
+        assert not output.exists()
+
+    def test_unpack_wraps_truncated_xml_in_invalid_document_error(self, temp_dir):
+        """Malformed/truncated XML (ExpatError) surfaces as InvalidDocumentError."""
+        bad_zip = temp_dir / "bad.docx"
+        _build_zip(bad_zip, [("word/document.xml", b"<w:document")])
+        output = temp_dir / "output"
+
+        with pytest.raises(InvalidDocumentError, match=r"Invalid XML in word/document\.xml") as excinfo:
+            unpack_document(bad_zip, output)
+
+        assert isinstance(excinfo.value.__cause__, ExpatError)
+        assert not output.exists()
+
+    def test_unpack_parse_failure_preserves_preexisting_output_dir(self, temp_dir):
+        """Cleanup must never delete a caller's pre-existing output directory."""
+        bad_zip = temp_dir / "bad.docx"
+        _build_zip(bad_zip, [("word/document.xml", ENTITY_DTD_XML.encode("utf-8"))])
+        output = temp_dir / "output"
+        output.mkdir()
+        sentinel = output / "keep.txt"
+        sentinel.write_text("user data")
+
+        with pytest.raises(InvalidDocumentError, match=r"Invalid XML in word/document\.xml"):
+            unpack_document(bad_zip, output)
+
+        assert output.exists()
+        assert sentinel.read_text() == "user data"
 
 
 SMART_TEXT = "“He said ‘hello’ — it’s fine”"

--- a/tests/test_ooxml.py
+++ b/tests/test_ooxml.py
@@ -173,7 +173,7 @@ class TestUnpack:
 
 
 class TestUnpackParseErrors:
-    """Parse-stage failures must raise InvalidDocumentError, not leak raw (ISSUES.md #35).
+    """Parse-stage failures must raise InvalidDocumentError, not the raw parser exception (ISSUES.md #35).
 
     Each fixture contains exactly one bad XML part — rglob order is
     nondeterministic, so a second bad part would make the "names the

--- a/tests/test_ooxml.py
+++ b/tests/test_ooxml.py
@@ -173,7 +173,7 @@ class TestUnpack:
 
 
 class TestUnpackParseErrors:
-    """ISSUES.md #35: parse-stage failures must raise InvalidDocumentError, not leak raw.
+    """Parse-stage failures must raise InvalidDocumentError, not leak raw (ISSUES.md #35).
 
     Each fixture contains exactly one bad XML part — rglob order is
     nondeterministic, so a second bad part would make the "names the
@@ -204,6 +204,31 @@ class TestUnpackParseErrors:
 
         assert isinstance(excinfo.value.__cause__, ExpatError)
         assert not output.exists()
+
+    def test_unpack_wraps_non_utf8_garbage_in_invalid_document_error(self, temp_dir):
+        """Byte-level garbage must not escape as a raw UnicodeDecodeError."""
+        bad_zip = temp_dir / "bad.docx"
+        _build_zip(bad_zip, [("word/document.xml", b"<r>\xff\xfe</r>")])
+        output = temp_dir / "output"
+
+        with pytest.raises(InvalidDocumentError, match=r"Invalid XML in word/document\.xml") as excinfo:
+            unpack_document(bad_zip, output)
+
+        assert isinstance(excinfo.value.__cause__, ExpatError)
+        assert not output.exists()
+
+    def test_unpack_honors_part_encoding_declaration(self, temp_dir):
+        """A part declaring a non-UTF-8 encoding is valid XML and must unpack."""
+        u16_zip = temp_dir / "u16.docx"
+        part = '<?xml version="1.0" encoding="utf-16"?><r>héllo</r>'.encode("utf-16")
+        _build_zip(u16_zip, [("word/document.xml", part)])
+        output = temp_dir / "output"
+
+        unpack_document(u16_zip, output)
+
+        # toprettyxml(encoding="utf-8") re-serializes every part as UTF-8.
+        pretty = (output / "word" / "document.xml").read_text(encoding="utf-8")
+        assert "héllo" in pretty
 
     def test_unpack_parse_failure_preserves_preexisting_output_dir(self, temp_dir):
         """Cleanup must never delete a caller's pre-existing output directory."""

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -4,13 +4,14 @@ import hashlib
 import json
 import os
 import re
+import shutil
 import stat
 import subprocess
 import sys
 from pathlib import Path
 
 import pytest
-from conftest import find_ref
+from conftest import ENTITY_DTD_XML, find_ref, replace_document_xml
 
 from docx_editor.document import Document
 from docx_editor.exceptions import (
@@ -83,6 +84,37 @@ class TestWorkspaceCreation:
 
         with pytest.raises(InvalidDocumentError):
             Workspace(txt_file)
+
+
+class TestWorkspaceParseFailureCleanup:
+    """ISSUES.md #35: a parse failure during creation must not leave a partial workspace."""
+
+    def test_create_workspace_parse_failure_leaves_no_workspace(self, simple_docx, temp_dir, isolated_workspace_base):
+        """A failed unpack leaves neither a workspace dir nor a .lock sibling."""
+        bad_docx = temp_dir / "bad.docx"
+        replace_document_xml(simple_docx, bad_docx, ENTITY_DTD_XML)
+
+        with pytest.raises(InvalidDocumentError):
+            Workspace(bad_docx)
+
+        assert list(isolated_workspace_base.iterdir()) == []
+
+    def test_open_retry_after_parse_failure_not_wedged(self, simple_docx, temp_dir):
+        """After a failed open, fixing the file and reopening must succeed.
+
+        Without cleanup the partial dir (no meta.json) makes the retry raise a
+        misleading WorkspaceExistsError — the user-facing regression this guards.
+        """
+        doc_path = temp_dir / "retry.docx"
+        replace_document_xml(simple_docx, doc_path, ENTITY_DTD_XML)
+
+        with pytest.raises(InvalidDocumentError):
+            Workspace(doc_path)
+
+        shutil.copy(simple_docx, doc_path)
+        workspace = Workspace(doc_path)
+        assert workspace.document_xml_path.exists()
+        workspace.close()
 
 
 class TestWorkspacePersistence:

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -87,7 +87,7 @@ class TestWorkspaceCreation:
 
 
 class TestWorkspaceParseFailureCleanup:
-    """ISSUES.md #35: a parse failure during creation must not leave a partial workspace."""
+    """A parse failure during creation must not leave a partial workspace (ISSUES.md #35)."""
 
     def test_create_workspace_parse_failure_leaves_no_workspace(self, simple_docx, temp_dir, isolated_workspace_base):
         """A failed unpack leaves neither a workspace dir nor a .lock sibling."""


### PR DESCRIPTION
## Problem

Tracked as ISSUES.md item #35 (repo-local issue list, not a GitHub issue).

Malformed XML in a docx part escaped `Document.open` as raw exceptions, violating `unpack_document`'s documented `InvalidDocumentError` contract:

- An XXE/DTD-bearing docx (e.g. apache/poi `ExternalEntityInText.docx`) raised raw `defusedxml.common.EntitiesForbidden`.
- A valid zip with truncated `document.xml` leaked raw `xml.parsers.expat.ExpatError`.

The parse failure also happens **after** `extractall`, so it left a partially-initialized workspace (no `meta.json`). The next `Document.open` then failed with a misleading `WorkspaceExistsError`, wedging the user until they manually deleted the workspace or used `force_recreate=True`.

## Fix

**`docx_editor/ooxml/unpack.py`**
- Wrap `ExpatError` and `DefusedXmlException` (base of `EntitiesForbidden`, `DTDForbidden`, `ExternalReferenceForbidden`) per part in `InvalidDocumentError`, naming the offending part; `from e` preserves the security exception for audit. `DefusedXmlException` subclasses `ValueError`, so the defused type is caught specifically to keep unrelated `ValueError`s loud. Entity/DTD refusal behavior is unchanged — this stays a hard reject, just typed.
- On any failure after extraction starts, remove the output directory **only if this call created it**; a pre-existing directory (which may hold caller data) is left in place.

**`docx_editor/workspace.py`**
- `_create_workspace` removes the partial workspace dir on any failure, so fixing the document and reopening succeeds instead of raising `WorkspaceExistsError`. The method is only reachable when the dir did not pre-exist, so nothing but its own partial output is removed; the advisory `.lock` sibling stays owned by `__init__`'s existing release handler.

## Tests

- `test_unpack_wraps_entity_dtd_in_invalid_document_error` — `EntitiesForbidden` cause, part named, created dir removed
- `test_unpack_wraps_truncated_xml_in_invalid_document_error` — `ExpatError` cause, part named, created dir removed
- `test_unpack_parse_failure_preserves_preexisting_output_dir` — safety pin: never delete a caller's dir
- `test_create_workspace_parse_failure_leaves_no_workspace` — workspace base left completely empty (no dir, no `.lock`)
- `test_open_retry_after_parse_failure_not_wedged` — the user-facing regression: fix file, reopen, succeeds
- `test_document_open_invalid_xml_raises_invalid_document_error` — end-to-end `Document.open` contract

## Verification

- `uv run pytest` — 946 passed, 2 skipped (pre-existing)
- `uv run ruff check .` / `ruff format --check .` — clean
- `uv run ty check` — exit 0 (6 pre-existing warnings in untouched test files)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `.docx` validation and handling of malformed or security-sensitive XML.
  * Blocked unsafe archive paths and symlink-based entries during document extraction.
  * Preserved existing output data when extraction fails.
  * Cleaned up incomplete workspaces after failed creation, allowing retries to succeed.
  * Improved support for documents using non-UTF-8 XML encodings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->