### PR TITLE
feat: corpus round-trip harness at benchmarks/corpus (ISSUES.md #38)

### DIFF
--- a/.github/workflows/corpus.yml
+++ b/.github/workflows/corpus.yml
@@ -26,7 +26,7 @@ jobs:
         run: uv run python benchmarks/corpus/build_corpus.py
 
       - name: Run round-trip harness
-        run: uv run python benchmarks/corpus/corpus_harness.py --no-pdf
+        run: uv run python benchmarks/corpus/corpus_harness.py
 
       - name: Upload results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/corpus.yml
+++ b/.github/workflows/corpus.yml
@@ -1,0 +1,36 @@
+name: Corpus round-trip
+
+on:
+  schedule:
+    - cron: "17 4 * * 1" # Mondays 04:17 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  corpus:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+
+      - name: Set up the environment
+        uses: ./.github/actions/setup-python-env
+
+      - name: Install LibreOffice and pandoc
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libreoffice-writer pandoc
+
+      - name: Assemble corpus
+        run: uv run python benchmarks/corpus/build_corpus.py
+
+      - name: Run round-trip harness
+        run: uv run python benchmarks/corpus/corpus_harness.py --no-pdf
+
+      - name: Upload results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: corpus-results
+          path: benchmarks/corpus/results.json

--- a/.gitignore
+++ b/.gitignore
@@ -225,5 +225,5 @@ benchmarks/corpus/files/
 benchmarks/corpus/out/
 benchmarks/corpus/work/
 benchmarks/corpus/loprofile/
-benchmarks/corpus/results.json
+benchmarks/corpus/results.json*
 benchmarks/corpus/srcgen/plain.odt

--- a/.gitignore
+++ b/.gitignore
@@ -219,3 +219,11 @@ __marimo__/
 .claude/commands/agtx/
 .claude/commands/openspec/
 .mcp.json
+
+# Corpus benchmark artifacts (benchmarks/corpus/README.md)
+benchmarks/corpus/files/
+benchmarks/corpus/out/
+benchmarks/corpus/work/
+benchmarks/corpus/loprofile/
+benchmarks/corpus/results.json
+benchmarks/corpus/srcgen/plain.odt

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,11 @@ publish: ## Publish a release to PyPI.
 .PHONY: build-and-publish
 build-and-publish: build publish ## Build and publish.
 
+.PHONY: corpus-check
+corpus-check: ## Assemble the docx corpus and run the round-trip harness (full run, incl. PDF stage)
+	@uv run python benchmarks/corpus/build_corpus.py
+	@uv run python benchmarks/corpus/corpus_harness.py
+
 .PHONY: docs-test
 docs-test: ## Test if documentation can be built without warnings or errors
 	@uv run mkdocs build -s

--- a/benchmarks/corpus/README.md
+++ b/benchmarks/corpus/README.md
@@ -1,0 +1,72 @@
+# Corpus round-trip harness
+
+A robustness harness that runs docx-editor over a 56-file corpus of real-world
+`.docx` files from 14 producer flavors (Word, LibreOffice, pandoc, ONLYOFFICE,
+and the test suites of python-docx, mammoth, Apache POI, pandoc, and
+LibreOffice core).
+
+Each file goes through the stages:
+
+```
+input_validate → open → read → edit → save1 → reopen → save2 → pdf
+```
+
+`edit` performs a tracked replace of the first word and asserts it added
+revisions (at least a del/ins pair; text spanning several runs legally yields
+one `w:del` per run — see ISSUES.md #37); `reopen` asserts the edit marker
+survived, that the revision count is unchanged by the save/reopen round-trip,
+and that `accept_all()` accepts and keeps the edit. `pdf` converts the final
+output with LibreOffice as an external can-other-tools-read-it check.
+
+## Running
+
+```bash
+make corpus-check                                    # assemble + full run (incl. PDF stage)
+uv run python benchmarks/corpus/build_corpus.py      # assemble corpus into files/
+uv run python benchmarks/corpus/corpus_harness.py --no-pdf   # skip the PDF stage
+uv run python benchmarks/corpus/corpus_harness.py --only mammoth  # filter by substring
+```
+
+Each file runs in an isolated subprocess with a hard timeout; one hang or crash
+cannot kill the run. Results are written to `results.json` and a summary table
+is printed. Row marks: `.` pass, `F` fail, `s` skip, `r` rejected, `-` not run.
+
+A weekly GitHub Actions workflow (`.github/workflows/corpus.yml`) runs the full
+corpus with LibreOffice and pandoc installed; trigger it manually with
+`workflow_dispatch` after changes.
+
+## Failure semantics
+
+- An invalid input that fails `input_validate` and is then refused by
+  `Document.open` is **rejected** (`r`), not a failure — refusing a broken
+  document is correct library behavior (e.g. `poi_ExternalEntityInText.docx`,
+  which contains external XML entities).
+- The harness exits nonzero if any file has a real failure (failed stage or
+  harness error). Baseline: 55 clean + 1 rejected → exit 0.
+
+## Provenance policy
+
+- **No `.docx` file is ever committed to this repo** (upstream licensing + repo
+  size). `files/`, `out/`, `work/`, and `results.json` are gitignored.
+- Corpus files are fetched to the developer's machine or CI runner at build
+  time and never redistributed.
+- `manifest.json` is the single source of truth and provenance record. Every
+  entry records its `kind`, producer, source, size, and truncated sha256:
+  - `local` — copied from this repo's `tests/test_data/` fixtures.
+  - `download` — fetched from a URL pinned to a full upstream commit SHA and
+    verified against the recorded sha256 at fetch time (mismatch = failure).
+  - `generated` — produced locally by LibreOffice (`soffice`) or pandoc from
+    the text sources in `srcgen/` or from local fixtures (recipes live in
+    `build_corpus.py`; `srcgen/plain.odt` is an uncommitted intermediate
+    generated from `plain.txt`). Sizes/hashes are informational — output bytes
+    vary by tool version. If a tool is missing the entries are skipped with a
+    notice; the corpus still works, just smaller.
+
+## Adding a file
+
+1. Add a manifest entry: `kind`, `producer`, source (for downloads: a
+   raw.githubusercontent.com URL pinned to a full commit SHA), `size`, and the
+   truncated sha256 of the content — or add a generation recipe in
+   `build_corpus.py` plus a source file in `srcgen/`.
+2. Keep files ≤ 2MB.
+3. Re-run `uv run python benchmarks/corpus/build_corpus.py`.

--- a/benchmarks/corpus/README.md
+++ b/benchmarks/corpus/README.md
@@ -32,8 +32,8 @@ cannot kill the run. Results are written to `results.json` and a summary table
 is printed. Row marks: `.` pass, `F` fail, `s` skip, `r` rejected, `-` not run.
 
 A weekly GitHub Actions workflow (`.github/workflows/corpus.yml`) runs the full
-corpus with LibreOffice and pandoc installed; trigger it manually with
-`workflow_dispatch` after changes.
+corpus — including the PDF stage — with LibreOffice and pandoc installed;
+trigger it manually with `workflow_dispatch` after changes.
 
 ## Failure semantics
 
@@ -41,8 +41,15 @@ corpus with LibreOffice and pandoc installed; trigger it manually with
   `Document.open` is **rejected** (`r`), not a failure — refusing a broken
   document is correct library behavior (e.g. `poi_ExternalEntityInText.docx`,
   which contains external XML entities).
+- A manifest entry can set `"must_reject": true`: the library **must** refuse
+  that file, and a run where it is accepted fails with `MustRejectViolation`.
+  This pins the rejection of `poi_ExternalEntityInText.docx`, so a parser
+  regression that starts expanding entities cannot slip through as "one more
+  passing file".
 - The harness exits nonzero if any file has a real failure (failed stage or
-  harness error). Baseline: 55 clean + 1 rejected → exit 0.
+  harness error), and if the corpus directory is empty or a `--only` filter
+  matches nothing (a run that tested nothing must not look green).
+  Baseline: 55 clean + 1 rejected → exit 0.
 
 ## Provenance policy
 
@@ -67,6 +74,7 @@ corpus with LibreOffice and pandoc installed; trigger it manually with
 1. Add a manifest entry: `kind`, `producer`, source (for downloads: a
    raw.githubusercontent.com URL pinned to a full commit SHA), `size`, and the
    truncated sha256 of the content — or add a generation recipe in
-   `build_corpus.py` plus a source file in `srcgen/`.
+   `build_corpus.py` plus a source file in `srcgen/`. Add `"must_reject": true`
+   for an intentionally invalid file the library must refuse.
 2. Keep files ≤ 2MB.
 3. Re-run `uv run python benchmarks/corpus/build_corpus.py`.

--- a/benchmarks/corpus/build_corpus.py
+++ b/benchmarks/corpus/build_corpus.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Assemble the docx corpus described by manifest.json into files/.
+
+manifest.json is the single source of truth. Each entry has a "kind":
+  local      copied from a repo-relative path (tests/test_data fixtures)
+  download   fetched from a commit-pinned raw.githubusercontent.com URL and
+             verified against the recorded sha256 (mismatch = hard failure)
+  generated  produced locally with LibreOffice (soffice) or pandoc from the
+             sources in srcgen/; skipped with a notice if the tool is absent
+
+Exits 1 if any local/download entry is missing at the end; tool-absence
+skips of generated entries are not failures.
+"""
+
+import hashlib
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+import urllib.request
+from pathlib import Path
+
+CORPUS = Path(__file__).resolve().parent
+REPO_ROOT = CORPUS.parents[1]
+FILES = CORPUS / "files"
+SRCGEN = CORPUS / "srcgen"
+LO_PROFILE = CORPUS / "loprofile"
+MANIFEST_PATH = CORPUS / "manifest.json"
+
+MAX_SIZE = 2 * 1024 * 1024  # 2MB per corpus file
+DOWNLOAD_TIMEOUT = 30  # seconds
+CONVERT_TIMEOUT = 120  # seconds, per soffice/pandoc invocation
+
+# Recipes for kind=generated entries: output name -> (tool, input path).
+# Inputs under srcgen/ are corpus-relative; tests/... are repo-relative.
+RECIPES: dict[str, tuple[str, str]] = {
+    "lo_from_txt.docx": ("soffice", "srcgen/plain.txt"),
+    "lo_from_html.docx": ("soffice", "srcgen/rich.html"),
+    "lo_from_html_unicode.docx": ("soffice", "srcgen/unicode.html"),
+    "lo_from_rtf.docx": ("soffice", "srcgen/doc.rtf"),
+    "lo_from_odt.docx": ("soffice", "srcgen/plain.odt"),
+    "lo_resave_tricky_track_changes.docx": ("soffice", "tests/test_data/tricky-track-changes.docx"),
+    "lo_resave_with_tables.docx": ("soffice", "tests/test_data/with_tables.docx"),
+    "lo_resave_oxml_trackchanges.docx": ("soffice", "tests/test_data/OXML_TrackChanges_Test.docx"),
+    "pandoc_notes.docx": ("pandoc", "srcgen/notes.md"),
+    "pandoc_unicode.docx": ("pandoc", "srcgen/unicode.html"),
+}
+
+
+def sha16(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()[:16]
+
+
+def resolve_input(source: str) -> Path:
+    if source.startswith("srcgen/"):
+        return CORPUS / source
+    return REPO_ROOT / source
+
+
+def download(url: str, dest: Path, expected_sha: str) -> str | None:
+    """Fetch url to dest and verify its truncated sha256. Returns an error string or None."""
+    try:
+        with urllib.request.urlopen(url, timeout=DOWNLOAD_TIMEOUT) as r:
+            data = r.read(MAX_SIZE + 1)
+    except Exception as e:  # noqa: BLE001
+        return f"download failed: {e}"
+    if len(data) > MAX_SIZE:
+        return "too large (>2MB)"
+    actual = hashlib.sha256(data).hexdigest()[:16]
+    if actual != expected_sha:
+        return f"sha256 mismatch: expected {expected_sha}, got {actual}"
+    dest.write_bytes(data)
+    return None
+
+
+def soffice_convert(soffice: str, src: Path, to_format: str, dest: Path) -> str | None:
+    """Convert src with LibreOffice into dest. Returns an error string or None.
+
+    soffice names its output by the input stem, so convert into a temp dir
+    and move the result (also avoids stem collisions, e.g. plain.txt/plain.odt).
+    docx output names its export filter explicitly — HTML inputs open as
+    Writer/Web documents, which have no default docx filter.
+    """
+    convert_to = f"{to_format}:MS Word 2007 XML" if to_format == "docx" else to_format
+    with tempfile.TemporaryDirectory(dir=CORPUS) as tmp:
+        cmd = [
+            soffice,
+            "--headless",
+            f"-env:UserInstallation=file://{LO_PROFILE}",
+            "--convert-to",
+            convert_to,
+            "--outdir",
+            tmp,
+            str(src),
+        ]
+        try:
+            proc = subprocess.run(cmd, capture_output=True, text=True, timeout=CONVERT_TIMEOUT)
+        except subprocess.TimeoutExpired:
+            return "soffice timeout"
+        produced = Path(tmp) / f"{src.stem}.{to_format}"
+        if proc.returncode != 0 or not produced.exists():
+            return f"soffice failed: {(proc.stderr or proc.stdout or 'no output produced')[:200]}"
+        shutil.move(str(produced), dest)
+    return None
+
+
+def pandoc_convert(pandoc: str, src: Path, dest: Path) -> str | None:
+    try:
+        proc = subprocess.run(
+            [pandoc, str(src), "-o", str(dest)],
+            capture_output=True,
+            text=True,
+            timeout=CONVERT_TIMEOUT,
+        )
+    except subprocess.TimeoutExpired:
+        return "pandoc timeout"
+    if proc.returncode != 0 or not dest.exists():
+        return f"pandoc failed: {(proc.stderr or 'no output produced')[:200]}"
+    return None
+
+
+def generate(name: str, tools: dict[str, str | None]) -> str | None:
+    """Generate one kind=generated corpus file. Returns an error string or None."""
+    tool_name, source = RECIPES[name]
+    tool = tools[tool_name]
+    if tool is None:
+        return f"skip: {tool_name} not found"
+    src = resolve_input(source)
+    if source == "srcgen/plain.odt" and not src.exists():
+        # Intermediate: plain.odt is itself generated from plain.txt (not committed).
+        err = soffice_convert(tool, SRCGEN / "plain.txt", "odt", src)
+        if err:
+            return f"intermediate plain.odt: {err}"
+    if not src.exists():
+        return f"input missing: {source}"
+    if tool_name == "soffice":
+        return soffice_convert(tool, src, "docx", FILES / name)
+    return pandoc_convert(tool, src, FILES / name)
+
+
+def main() -> int:
+    manifest: dict[str, dict] = json.loads(MANIFEST_PATH.read_text())
+    FILES.mkdir(exist_ok=True)
+    tools = {"soffice": shutil.which("soffice"), "pandoc": shutil.which("pandoc")}
+
+    failed: list[tuple[str, str]] = []  # local/download problems -> exit 1
+    skipped: list[tuple[str, str]] = []  # generated entries skipped (tool absent)
+
+    for name, entry in manifest.items():
+        kind = entry["kind"]
+        dest = FILES / name
+        if kind == "local":
+            src = REPO_ROOT / entry["source"]
+            if not src.exists():
+                failed.append((name, f"local source missing: {entry['source']}"))
+                continue
+            shutil.copy(src, dest)
+        elif kind == "download":
+            if dest.exists() and sha16(dest) == entry["sha256"]:
+                continue
+            err = download(entry["source"], dest, entry["sha256"])
+            if err:
+                failed.append((name, err))
+        elif kind == "generated":
+            if dest.exists():
+                continue
+            err = generate(name, tools)
+            if err and err.startswith("skip: "):
+                skipped.append((name, err[len("skip: ") :]))
+            elif err:
+                failed.append((name, err))
+        else:
+            failed.append((name, f"unknown kind: {kind}"))
+
+    assembled = sum(1 for name in manifest if (FILES / name).exists())
+    print(f"assembled {assembled}/{len(manifest)}", end="")
+    if skipped:
+        reasons = ", ".join(sorted({r for _, r in skipped}))
+        print(f" (skipped {len(skipped)}: {reasons})", end="")
+    print()
+    for name, err in failed:
+        print(f"FAILED: {name}: {err}", file=sys.stderr)
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/corpus/build_corpus.py
+++ b/benchmarks/corpus/build_corpus.py
@@ -63,7 +63,7 @@ def download(url: str, dest: Path, expected_sha: str) -> str | None:
     try:
         with urllib.request.urlopen(url, timeout=DOWNLOAD_TIMEOUT) as r:
             data = r.read(MAX_SIZE + 1)
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         return f"download failed: {e}"
     if len(data) > MAX_SIZE:
         return "too large (>2MB)"
@@ -122,6 +122,8 @@ def pandoc_convert(pandoc: str, src: Path, dest: Path) -> str | None:
 
 def generate(name: str, tools: dict[str, str | None]) -> str | None:
     """Generate one kind=generated corpus file. Returns an error string or None."""
+    if name not in RECIPES:
+        return f"no generation recipe for {name}"
     tool_name, source = RECIPES[name]
     tool = tools[tool_name]
     if tool is None:

--- a/benchmarks/corpus/corpus_harness.py
+++ b/benchmarks/corpus/corpus_harness.py
@@ -1,0 +1,473 @@
+#!/usr/bin/env python3
+"""Round-trip robustness harness for docx-editor over a real-world .docx corpus.
+
+Modes:
+  corpus_harness.py                 run all corpus files (parent mode)
+  corpus_harness.py --only NAME     run a single file by name (parent mode, filtered)
+  corpus_harness.py --no-pdf        skip the LibreOffice PDF-conversion stage
+  corpus_harness.py --single PATH   internal: run stages for one file, JSON to stdout
+
+Parent mode isolates each file in a subprocess with a hard timeout, so one
+hang/crash cannot kill the run. Results land in results.json next to this
+script, a summary table is printed, and the exit code is 1 if any file has
+a real failure (CI signal).
+
+Stages per file:
+  input_validate  informational: does the *input* zip/XML parse cleanly?
+  open            Document.open with a dedicated workspace_dir
+  read            list_paragraphs + get_visible_text + list_revisions
+  edit            tracked-replace of the first word of the first non-empty paragraph
+  save1           save-as to out/<name>_edited.docx + zip/XML validation
+  reopen          reopen saved file, assert the edit survived and the revision
+                  count is coherent, then accept_all
+  save2           save to out/<name>_final.docx + zip/XML validation
+  pdf             soffice --headless --convert-to pdf on the final output
+
+An input that fails input_validate and is then refused by Document.open is
+recorded as "rejected" (mark: r), not as a failure — refusing an invalid
+document is correct library behavior.
+"""
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import time
+import traceback
+import zipfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+FILES_DIR = HERE / "files"
+OUT_DIR = HERE / "out"
+WORK_DIR = HERE / "work"
+PDF_DIR = OUT_DIR / "pdf"
+RESULTS_PATH = HERE / "results.json"
+PER_FILE_TIMEOUT = 60  # seconds, library stages
+PDF_TIMEOUT = 60  # seconds, soffice conversion
+
+STAGES = ["input_validate", "open", "read", "edit", "save1", "reopen", "save2", "pdf"]
+
+
+# --------------------------------------------------------------------------
+# Validation helpers
+# --------------------------------------------------------------------------
+
+
+def validate_docx(path: Path) -> dict:
+    """Validate that a .docx is a sound zip and every XML part parses.
+
+    Uses defusedxml so entity/DTD tricks are surfaced rather than expanded.
+    Returns {"ok": True} or {"ok": False, "error_type": ..., "error": ...}.
+    """
+    from defusedxml import minidom as safe_minidom
+
+    try:
+        with zipfile.ZipFile(path) as z:
+            bad = z.testzip()
+            if bad is not None:
+                return {"ok": False, "error_type": "BadZipCRC", "error": f"CRC error in {bad}"}
+            names = z.namelist()
+            if "word/document.xml" not in names:
+                return {
+                    "ok": False,
+                    "error_type": "MissingDocumentXml",
+                    "error": "word/document.xml not in package",
+                }
+            for n in names:
+                if n.endswith((".xml", ".rels")):
+                    try:
+                        safe_minidom.parseString(z.read(n))
+                    except Exception as e:  # noqa: BLE001
+                        return {
+                            "ok": False,
+                            "error_type": type(e).__name__,
+                            "error": f"part {n}: {e}",
+                        }
+    except Exception as e:  # noqa: BLE001
+        return {"ok": False, "error_type": type(e).__name__, "error": str(e)[:300]}
+    return {"ok": True}
+
+
+def err_record(e: Exception) -> dict:
+    tb = traceback.extract_tb(e.__traceback__)
+    frame = ""
+    for fr in reversed(tb):
+        if "docx_editor" in fr.filename:
+            frame = f"{Path(fr.filename).name}:{fr.lineno} in {fr.name}"
+            break
+    return {
+        "status": "fail",
+        "error_type": type(e).__name__,
+        "error": str(e)[:400],
+        "lib_frame": frame,
+    }
+
+
+def assert_fail(error_type: str, error: str) -> dict:
+    return {"status": "fail", "error_type": error_type, "error": error}
+
+
+# --------------------------------------------------------------------------
+# Single-file mode (runs inside the timeout subprocess)
+# --------------------------------------------------------------------------
+
+
+def run_single(path: Path, do_pdf: bool) -> dict:
+    name = path.name
+    stages: dict[str, dict] = {}
+    result = {"file": name, "stages": stages}
+
+    def fail_rest(from_stage: str):
+        idx = STAGES.index(from_stage)
+        for s in STAGES[idx + 1 :]:
+            stages[s] = {"status": "not_run"}
+
+    # Stage 0: input validation (informational, never blocks)
+    stages["input_validate"] = validate_docx(path)
+    stages["input_validate"]["status"] = "pass" if stages["input_validate"]["ok"] else "fail"
+    input_ok = stages["input_validate"]["ok"]
+
+    work = WORK_DIR / path.stem
+    out1 = OUT_DIR / f"{path.stem}_edited.docx"
+    out2 = OUT_DIR / f"{path.stem}_final.docx"
+
+    from docx_editor import Document
+
+    # Stage 1: open. An invalid input that the library refuses is "rejected",
+    # not a failure — that is the correct behavior for such a document.
+    doc = None
+    try:
+        doc = Document.open(path, author="CorpusHarness", workspace_dir=work, force_recreate=True)
+        stages["open"] = {"status": "pass"}
+    except Exception as e:  # noqa: BLE001
+        rec = err_record(e)
+        if not input_ok:
+            rec["status"] = "rejected"
+        stages["open"] = rec
+        fail_rest("open")
+        return result
+
+    try:
+        # Stage 2: read
+        try:
+            paras = doc.list_paragraphs_structured()
+            visible = doc.get_visible_text()
+            revs = doc.list_revisions()
+            stages["read"] = {
+                "status": "pass",
+                "paragraphs": len(paras),
+                "visible_chars": len(visible),
+                "revisions": len(revs),
+            }
+        except Exception as e:  # noqa: BLE001
+            stages["read"] = err_record(e)
+            fail_rest("read")
+            return result
+
+        # Stage 3: edit (tracked replace of first word of first non-empty paragraph)
+        target = next((p for p in paras if p.text.strip()), None)
+        if target is None:
+            stages["edit"] = {"status": "skip", "reason": "no non-empty paragraph"}
+        else:
+            word = target.text.split()[0]
+            try:
+                doc.replace(word, word + "-EDITED", paragraph=target.ref, occurrence=0)
+                # One logical replace yields >= 2 element-level revisions: one
+                # w:del per source run the text spans, plus the w:ins
+                # (grouping them is ISSUES.md #37). The exact count is recorded
+                # so reopen can assert it survives the save/reopen round-trip.
+                revisions_after_edit = len(doc.list_revisions())
+                if revisions_after_edit < stages["read"]["revisions"] + 2:
+                    stages["edit"] = assert_fail(
+                        "AssertEditRevisionsMissing",
+                        f"expected at least {stages['read']['revisions']} original + 2 "
+                        f"revisions after tracked replace, got {revisions_after_edit}",
+                    )
+                    fail_rest("edit")
+                    return result
+                stages["edit"] = {
+                    "status": "pass",
+                    "word": word[:40],
+                    "ref": target.ref,
+                    "revisions_after_edit": revisions_after_edit,
+                }
+            except Exception as e:  # noqa: BLE001
+                stages["edit"] = err_record(e)
+                fail_rest("edit")
+                return result
+
+        # Stage 4: save-as + validate
+        try:
+            doc.save(out1)
+            v = validate_docx(out1)
+            if v["ok"]:
+                stages["save1"] = {"status": "pass"}
+            else:
+                stages["save1"] = {
+                    "status": "fail",
+                    "error_type": "OutputValidation:" + v["error_type"],
+                    "error": v["error"][:400],
+                }
+                fail_rest("save1")
+                return result
+        except Exception as e:  # noqa: BLE001
+            stages["save1"] = err_record(e)
+            fail_rest("save1")
+            return result
+    finally:
+        try:
+            doc.close(cleanup=True)
+        except Exception:  # noqa: BLE001
+            pass
+
+    # Stage 5: reopen + deep assertions + accept_all
+    edited = stages["edit"]["status"] == "pass"
+    doc2 = None
+    try:
+        try:
+            doc2 = Document.open(out1, author="CorpusHarness", workspace_dir=work, force_recreate=True)
+            if edited:
+                if "-EDITED" not in doc2.get_visible_text():
+                    stages["reopen"] = assert_fail(
+                        "AssertEditMarkerLost",
+                        "edit marker missing from visible text after reopen",
+                    )
+                    fail_rest("reopen")
+                    return result
+                reopen_revisions = len(doc2.list_revisions())
+                if reopen_revisions != stages["edit"]["revisions_after_edit"]:
+                    stages["reopen"] = assert_fail(
+                        "AssertRevisionCountMismatch",
+                        f"{stages['edit']['revisions_after_edit']} revisions before save, "
+                        f"{reopen_revisions} after reopen",
+                    )
+                    fail_rest("reopen")
+                    return result
+            accepted = doc2.accept_all()
+            if edited and accepted <= 0:
+                stages["reopen"] = assert_fail(
+                    "AssertNoAcceptedRevisions", "accept_all() accepted 0 revisions after an edit"
+                )
+                fail_rest("reopen")
+                return result
+            if edited and "-EDITED" not in doc2.get_visible_text():
+                stages["reopen"] = assert_fail(
+                    "AssertEditMarkerLostAfterAccept",
+                    "edit marker missing from visible text after accept_all",
+                )
+                fail_rest("reopen")
+                return result
+            stages["reopen"] = {"status": "pass", "accepted": accepted}
+        except Exception as e:  # noqa: BLE001
+            stages["reopen"] = err_record(e)
+            fail_rest("reopen")
+            return result
+
+        # Stage 6: save2 + validate
+        try:
+            doc2.save(out2)
+            v = validate_docx(out2)
+            if v["ok"]:
+                stages["save2"] = {"status": "pass"}
+            else:
+                stages["save2"] = {
+                    "status": "fail",
+                    "error_type": "OutputValidation:" + v["error_type"],
+                    "error": v["error"][:400],
+                }
+                fail_rest("save2")
+                return result
+        except Exception as e:  # noqa: BLE001
+            stages["save2"] = err_record(e)
+            fail_rest("save2")
+            return result
+    finally:
+        if doc2 is not None:
+            try:
+                doc2.close(cleanup=True)
+            except Exception:  # noqa: BLE001
+                pass
+
+    # Stage 7: PDF conversion of the final output
+    if not do_pdf:
+        stages["pdf"] = {"status": "skip", "reason": "--no-pdf"}
+        return result
+    soffice = shutil.which("soffice")
+    if soffice is None:
+        stages["pdf"] = {"status": "skip", "reason": "soffice not found"}
+        return result
+    profile = HERE / "loprofile"
+    pdf_path = PDF_DIR / f"{out2.stem}.pdf"
+    pdf_path.unlink(missing_ok=True)
+    try:
+        proc = subprocess.run(
+            [
+                soffice,
+                "--headless",
+                f"-env:UserInstallation=file://{profile}",
+                "--convert-to",
+                "pdf",
+                "--outdir",
+                str(PDF_DIR),
+                str(out2),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=PDF_TIMEOUT,
+        )
+        if proc.returncode == 0 and pdf_path.exists() and pdf_path.stat().st_size > 0:
+            stages["pdf"] = {"status": "pass"}
+        else:
+            stages["pdf"] = {
+                "status": "fail",
+                "error_type": "PdfConversionFailed",
+                "error": (proc.stderr or proc.stdout or "no pdf produced")[:400],
+            }
+    except subprocess.TimeoutExpired:
+        stages["pdf"] = {"status": "fail", "error_type": "PdfConversionTimeout", "error": ""}
+    return result
+
+
+# --------------------------------------------------------------------------
+# Parent mode
+# --------------------------------------------------------------------------
+
+
+def file_failed(rec: dict) -> bool:
+    """A real failure: any harness error or failed stage other than input_validate.
+
+    "rejected" (invalid input refused by the library) is not a failure.
+    """
+    return (
+        any(st.get("status") == "fail" for s, st in rec["stages"].items() if s != "input_validate")
+        or "harness" in rec["stages"]
+    )
+
+
+def run_all(only: str | None, do_pdf: bool) -> int:
+    OUT_DIR.mkdir(exist_ok=True)
+    PDF_DIR.mkdir(exist_ok=True)
+    WORK_DIR.mkdir(exist_ok=True)
+
+    manifest = {}
+    manifest_path = HERE / "manifest.json"
+    if manifest_path.exists():
+        manifest = json.loads(manifest_path.read_text())
+
+    files = sorted(FILES_DIR.glob("*.docx"))
+    if only:
+        files = [f for f in files if only in f.name]
+
+    results = []
+    for i, f in enumerate(files, 1):
+        t0 = time.time()
+        cmd = [sys.executable, str(Path(__file__).resolve()), "--single", str(f)]
+        if not do_pdf:
+            cmd.append("--no-pdf")
+        try:
+            proc = subprocess.run(cmd, capture_output=True, text=True, timeout=PER_FILE_TIMEOUT + PDF_TIMEOUT)
+            if proc.returncode == 0 and proc.stdout.strip():
+                rec = json.loads(proc.stdout)
+            else:
+                rec = {
+                    "file": f.name,
+                    "stages": {
+                        "harness": {
+                            "status": "fail",
+                            "error_type": "SubprocessCrash",
+                            "error": (proc.stderr or "")[-400:],
+                        }
+                    },
+                }
+        except subprocess.TimeoutExpired:
+            rec = {
+                "file": f.name,
+                "stages": {
+                    "harness": {
+                        "status": "fail",
+                        "error_type": "Timeout",
+                        "error": f">{PER_FILE_TIMEOUT + PDF_TIMEOUT}s",
+                    }
+                },
+            }
+        except Exception as e:  # noqa: BLE001
+            rec = {
+                "file": f.name,
+                "stages": {"harness": {"status": "fail", "error_type": type(e).__name__, "error": str(e)}},
+            }
+        rec["duration_s"] = round(time.time() - t0, 1)
+        rec["provenance"] = manifest.get(f.name, {})
+        results.append(rec)
+        statuses = summarize_row(rec)
+        print(f"[{i:2d}/{len(files)}] {f.name:50s} {statuses}", flush=True)
+
+    RESULTS_PATH.write_text(json.dumps(results, indent=2))
+    print(f"\nresults written to {RESULTS_PATH}\n")
+    print_summary(results)
+    return sum(1 for r in results if file_failed(r))
+
+
+def summarize_row(rec: dict) -> str:
+    marks = {"pass": ".", "fail": "F", "skip": "s", "not_run": "-", "rejected": "r"}
+    if "harness" in rec["stages"]:
+        return "HARNESS-FAIL " + rec["stages"]["harness"].get("error_type", "")
+    return " ".join(f"{s}:{marks.get(rec['stages'].get(s, {}).get('status', '?'), '?')}" for s in STAGES)
+
+
+def print_summary(results: list[dict]) -> None:
+    print(f"{'stage':<16}{'pass':>6}{'fail':>6}{'skip':>6}{'rejected':>10}{'not_run':>9}")
+    for s in STAGES:
+        counts = {"pass": 0, "fail": 0, "skip": 0, "rejected": 0, "not_run": 0}
+        for r in results:
+            st = r["stages"].get(s, {}).get("status")
+            if st in counts:
+                counts[st] += 1
+        print(
+            f"{s:<16}{counts['pass']:>6}{counts['fail']:>6}{counts['skip']:>6}"
+            f"{counts['rejected']:>10}{counts['not_run']:>9}"
+        )
+    fails = {}
+    for r in results:
+        for s, rec in r["stages"].items():
+            if rec.get("status") == "fail" and s != "input_validate":
+                sig = f"{s}/{rec.get('error_type', '?')}"
+                fails.setdefault(sig, []).append(r["file"])
+    if fails:
+        print("\nFailure signatures:")
+        for sig, names in sorted(fails.items()):
+            print(f"  {sig}: {len(names)} file(s)")
+            for n in names[:6]:
+                print(f"    - {n}")
+    clean = sum(
+        1
+        for r in results
+        if all(r["stages"].get(s, {}).get("status") in ("pass", "skip") for s in STAGES if s != "input_validate")
+        and "harness" not in r["stages"]
+    )
+    rejected = sum(1 for r in results if r["stages"].get("open", {}).get("status") == "rejected")
+    print(f"\n{clean}/{len(results)} files fully clean (all stages pass/skip)")
+    if rejected:
+        print(f"{rejected} rejected (invalid input refused by the library — not a failure)")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--single", type=Path, help="internal: run one file, JSON to stdout")
+    ap.add_argument("--only", help="filter corpus files by substring")
+    ap.add_argument("--no-pdf", action="store_true", help="skip soffice PDF stage")
+    args = ap.parse_args()
+
+    if args.single:
+        OUT_DIR.mkdir(exist_ok=True)
+        PDF_DIR.mkdir(exist_ok=True)
+        WORK_DIR.mkdir(exist_ok=True)
+        print(json.dumps(run_single(args.single, do_pdf=not args.no_pdf)))
+        return
+    failures = run_all(args.only, do_pdf=not args.no_pdf)
+    sys.exit(1 if failures else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/corpus/corpus_harness.py
+++ b/benchmarks/corpus/corpus_harness.py
@@ -10,7 +10,7 @@ Modes:
 Parent mode isolates each file in a subprocess with a hard timeout, so one
 hang/crash cannot kill the run. Results land in results.json next to this
 script, a summary table is printed, and the exit code is 1 if any file has
-a real failure (CI signal).
+a real failure — or if no corpus files were found at all (CI signal).
 
 Stages per file:
   input_validate  informational: does the *input* zip/XML parse cleanly?
@@ -351,10 +351,9 @@ def run_all(only: str | None, do_pdf: bool) -> int:
     PDF_DIR.mkdir(exist_ok=True)
     WORK_DIR.mkdir(exist_ok=True)
 
-    manifest = {}
-    manifest_path = HERE / "manifest.json"
-    if manifest_path.exists():
-        manifest = json.loads(manifest_path.read_text())
+    # Loaded unconditionally: must_reject enforcement lives in the manifest,
+    # and a missing manifest must not silently disable it.
+    manifest: dict[str, dict] = json.loads((HERE / "manifest.json").read_text())
 
     files = sorted(FILES_DIR.glob("*.docx"))
     if only:
@@ -366,6 +365,7 @@ def run_all(only: str | None, do_pdf: bool) -> int:
             print(f"no corpus files in {FILES_DIR} — run build_corpus.py first", file=sys.stderr)
         return 1
 
+    timeout = PER_FILE_TIMEOUT + (PDF_TIMEOUT if do_pdf else 0)
     results = []
     for i, f in enumerate(files, 1):
         t0 = time.time()
@@ -373,7 +373,7 @@ def run_all(only: str | None, do_pdf: bool) -> int:
         if not do_pdf:
             cmd.append("--no-pdf")
         try:
-            proc = subprocess.run(cmd, capture_output=True, text=True, timeout=PER_FILE_TIMEOUT + PDF_TIMEOUT)
+            proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
             if proc.returncode == 0 and proc.stdout.strip():
                 rec = json.loads(proc.stdout)
             else:
@@ -394,7 +394,7 @@ def run_all(only: str | None, do_pdf: bool) -> int:
                     "harness": {
                         "status": "fail",
                         "error_type": "Timeout",
-                        "error": f">{PER_FILE_TIMEOUT + PDF_TIMEOUT}s",
+                        "error": f">{timeout}s",
                     }
                 },
             }
@@ -407,18 +407,20 @@ def run_all(only: str | None, do_pdf: bool) -> int:
         prov = manifest.get(f.name, {})
         rec["provenance"] = prov
         # A file the manifest marks must_reject (e.g. external XML entities)
-        # must be refused by the library; accepting it is a failure.
-        if prov.get("must_reject") and "harness" not in rec["stages"]:
-            open_status = rec["stages"].get("open", {}).get("status")
-            if open_status != "rejected":
-                rec["stages"]["open"] = {
-                    "status": "fail",
-                    "error_type": "MustRejectViolation",
-                    "error": f"manifest marks this file must_reject, but open status was {open_status!r}",
-                }
+        # must be refused by the library; accepting it is a failure. A genuine
+        # open failure already counts as failed and keeps its own diagnostics.
+        if prov.get("must_reject") and rec["stages"].get("open", {}).get("status") == "pass":
+            rec["stages"]["open"] = {
+                "status": "fail",
+                "error_type": "MustRejectViolation",
+                "error": "manifest marks this file must_reject, but Document.open accepted it",
+            }
         results.append(rec)
-        # Rewrite results after every file so a killed run keeps partial diagnostics.
-        RESULTS_PATH.write_text(json.dumps(results, indent=2))
+        # Rewrite results after every file so a killed run keeps partial
+        # diagnostics; write-then-replace so a kill mid-write can't truncate it.
+        tmp_results = RESULTS_PATH.with_suffix(".json.tmp")
+        tmp_results.write_text(json.dumps(results, indent=2))
+        tmp_results.replace(RESULTS_PATH)
         statuses = summarize_row(rec)
         print(f"[{i:2d}/{len(files)}] {f.name:50s} {statuses}", flush=True)
 

--- a/benchmarks/corpus/corpus_harness.py
+++ b/benchmarks/corpus/corpus_harness.py
@@ -79,13 +79,13 @@ def validate_docx(path: Path) -> dict:
                 if n.endswith((".xml", ".rels")):
                     try:
                         safe_minidom.parseString(z.read(n))
-                    except Exception as e:  # noqa: BLE001
+                    except Exception as e:
                         return {
                             "ok": False,
                             "error_type": type(e).__name__,
                             "error": f"part {n}: {e}",
                         }
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         return {"ok": False, "error_type": type(e).__name__, "error": str(e)[:300]}
     return {"ok": True}
 
@@ -141,7 +141,7 @@ def run_single(path: Path, do_pdf: bool) -> dict:
     try:
         doc = Document.open(path, author="CorpusHarness", workspace_dir=work, force_recreate=True)
         stages["open"] = {"status": "pass"}
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         rec = err_record(e)
         if not input_ok:
             rec["status"] = "rejected"
@@ -161,7 +161,7 @@ def run_single(path: Path, do_pdf: bool) -> dict:
                 "visible_chars": len(visible),
                 "revisions": len(revs),
             }
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             stages["read"] = err_record(e)
             fail_rest("read")
             return result
@@ -193,7 +193,7 @@ def run_single(path: Path, do_pdf: bool) -> dict:
                     "ref": target.ref,
                     "revisions_after_edit": revisions_after_edit,
                 }
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:
                 stages["edit"] = err_record(e)
                 fail_rest("edit")
                 return result
@@ -212,14 +212,14 @@ def run_single(path: Path, do_pdf: bool) -> dict:
                 }
                 fail_rest("save1")
                 return result
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             stages["save1"] = err_record(e)
             fail_rest("save1")
             return result
     finally:
         try:
             doc.close(cleanup=True)
-        except Exception:  # noqa: BLE001
+        except Exception:
             pass
 
     # Stage 5: reopen + deep assertions + accept_all
@@ -260,7 +260,7 @@ def run_single(path: Path, do_pdf: bool) -> dict:
                 fail_rest("reopen")
                 return result
             stages["reopen"] = {"status": "pass", "accepted": accepted}
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             stages["reopen"] = err_record(e)
             fail_rest("reopen")
             return result
@@ -279,7 +279,7 @@ def run_single(path: Path, do_pdf: bool) -> dict:
                 }
                 fail_rest("save2")
                 return result
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             stages["save2"] = err_record(e)
             fail_rest("save2")
             return result
@@ -287,7 +287,7 @@ def run_single(path: Path, do_pdf: bool) -> dict:
         if doc2 is not None:
             try:
                 doc2.close(cleanup=True)
-            except Exception:  # noqa: BLE001
+            except Exception:
                 pass
 
     # Stage 7: PDF conversion of the final output
@@ -359,6 +359,12 @@ def run_all(only: str | None, do_pdf: bool) -> int:
     files = sorted(FILES_DIR.glob("*.docx"))
     if only:
         files = [f for f in files if only in f.name]
+    if not files:
+        if only:
+            print(f"no corpus files match --only {only!r}", file=sys.stderr)
+        else:
+            print(f"no corpus files in {FILES_DIR} — run build_corpus.py first", file=sys.stderr)
+        return 1
 
     results = []
     for i, f in enumerate(files, 1):
@@ -392,18 +398,30 @@ def run_all(only: str | None, do_pdf: bool) -> int:
                     }
                 },
             }
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             rec = {
                 "file": f.name,
                 "stages": {"harness": {"status": "fail", "error_type": type(e).__name__, "error": str(e)}},
             }
         rec["duration_s"] = round(time.time() - t0, 1)
-        rec["provenance"] = manifest.get(f.name, {})
+        prov = manifest.get(f.name, {})
+        rec["provenance"] = prov
+        # A file the manifest marks must_reject (e.g. external XML entities)
+        # must be refused by the library; accepting it is a failure.
+        if prov.get("must_reject") and "harness" not in rec["stages"]:
+            open_status = rec["stages"].get("open", {}).get("status")
+            if open_status != "rejected":
+                rec["stages"]["open"] = {
+                    "status": "fail",
+                    "error_type": "MustRejectViolation",
+                    "error": f"manifest marks this file must_reject, but open status was {open_status!r}",
+                }
         results.append(rec)
+        # Rewrite results after every file so a killed run keeps partial diagnostics.
+        RESULTS_PATH.write_text(json.dumps(results, indent=2))
         statuses = summarize_row(rec)
         print(f"[{i:2d}/{len(files)}] {f.name:50s} {statuses}", flush=True)
 
-    RESULTS_PATH.write_text(json.dumps(results, indent=2))
     print(f"\nresults written to {RESULTS_PATH}\n")
     print_summary(results)
     return sum(1 for r in results if file_failed(r))

--- a/benchmarks/corpus/manifest.json
+++ b/benchmarks/corpus/manifest.json
@@ -249,7 +249,8 @@
     "producer": "Apache POI test fixture (Word, bug reports)",
     "source": "https://raw.githubusercontent.com/apache/poi/63eda92cc63b39d4e8956e7775ccddb1f0d925cf/test-data/document/ExternalEntityInText.docx",
     "size": 12756,
-    "sha256": "5cf7340ffd6516c2"
+    "sha256": "5cf7340ffd6516c2",
+    "must_reject": true
   },
   "poi_HeaderFooterUnicode.docx": {
     "kind": "download",

--- a/benchmarks/corpus/manifest.json
+++ b/benchmarks/corpus/manifest.json
@@ -1,0 +1,394 @@
+{
+  "local_OXML_TrackChanges_Test.docx": {
+    "kind": "local",
+    "producer": "docx-editor test fixture",
+    "source": "tests/test_data/OXML_TrackChanges_Test.docx",
+    "size": 10160,
+    "sha256": "a98aaeefb4bc04aa"
+  },
+  "local_empty.docx": {
+    "kind": "local",
+    "producer": "docx-editor test fixture",
+    "source": "tests/test_data/empty.docx",
+    "size": 36563,
+    "sha256": "587c1862b9fd37e1"
+  },
+  "local_long_content.docx": {
+    "kind": "local",
+    "producer": "docx-editor test fixture",
+    "source": "tests/test_data/long_content.docx",
+    "size": 37232,
+    "sha256": "3eff759d7a7449c1"
+  },
+  "local_search_fixture.docx": {
+    "kind": "local",
+    "producer": "docx-editor test fixture",
+    "source": "tests/test_data/search_fixture.docx",
+    "size": 37243,
+    "sha256": "affc23df904816a7"
+  },
+  "local_simple.docx": {
+    "kind": "local",
+    "producer": "docx-editor test fixture",
+    "source": "tests/test_data/simple.docx",
+    "size": 36717,
+    "sha256": "215879d451c0f2bc"
+  },
+  "local_special_chars.docx": {
+    "kind": "local",
+    "producer": "docx-editor test fixture",
+    "source": "tests/test_data/special_chars.docx",
+    "size": 36777,
+    "sha256": "1653528736d4144e"
+  },
+  "local_test_document_with_errors.docx": {
+    "kind": "local",
+    "producer": "docx-editor test fixture",
+    "source": "tests/test_data/test_document_with_errors.docx",
+    "size": 16978,
+    "sha256": "7bcd1b7837cc6309"
+  },
+  "local_tricky-track-changes.docx": {
+    "kind": "local",
+    "producer": "docx-editor test fixture",
+    "source": "tests/test_data/tricky-track-changes.docx",
+    "size": 14390,
+    "sha256": "d2a9a06e7c819b2a"
+  },
+  "local_with_tables.docx": {
+    "kind": "local",
+    "producer": "docx-editor test fixture",
+    "source": "tests/test_data/with_tables.docx",
+    "size": 36832,
+    "sha256": "c6cc8da39b6a0e4d"
+  },
+  "lo_from_txt.docx": {
+    "kind": "generated",
+    "producer": "LibreOffice (txt->docx)",
+    "source": "srcgen/plain.txt",
+    "size": 5203,
+    "sha256": "e0c1a7d57d20248c"
+  },
+  "lo_from_html.docx": {
+    "kind": "generated",
+    "producer": "LibreOffice (html->docx)",
+    "source": "srcgen/rich.html",
+    "size": 7508,
+    "sha256": "b93446988180decc"
+  },
+  "lo_from_html_unicode.docx": {
+    "kind": "generated",
+    "producer": "LibreOffice (html->docx)",
+    "source": "srcgen/unicode.html",
+    "size": 6071,
+    "sha256": "3c9769ba3b65f9a6"
+  },
+  "lo_from_rtf.docx": {
+    "kind": "generated",
+    "producer": "LibreOffice (rtf->docx)",
+    "source": "srcgen/doc.rtf",
+    "size": 5124,
+    "sha256": "de2b9c040937dff9"
+  },
+  "lo_from_odt.docx": {
+    "kind": "generated",
+    "producer": "LibreOffice (odt->docx)",
+    "source": "srcgen/plain.odt",
+    "size": 5328,
+    "sha256": "215043ff7023b9bd"
+  },
+  "lo_resave_tricky_track_changes.docx": {
+    "kind": "generated",
+    "producer": "LibreOffice (docx re-save)",
+    "source": "tests/test_data/tricky-track-changes.docx",
+    "size": 9744,
+    "sha256": "24fe2a20a1f29ba0"
+  },
+  "lo_resave_with_tables.docx": {
+    "kind": "generated",
+    "producer": "LibreOffice (docx re-save)",
+    "source": "tests/test_data/with_tables.docx",
+    "size": 20144,
+    "sha256": "5cd1d2c410bdeef0"
+  },
+  "lo_resave_oxml_trackchanges.docx": {
+    "kind": "generated",
+    "producer": "LibreOffice (docx re-save)",
+    "source": "tests/test_data/OXML_TrackChanges_Test.docx",
+    "size": 8678,
+    "sha256": "d2266e65564a75a1"
+  },
+  "pandoc_notes.docx": {
+    "kind": "generated",
+    "producer": "pandoc (md->docx)",
+    "source": "srcgen/notes.md",
+    "size": 10633,
+    "sha256": "11e5ee625f465667"
+  },
+  "pandoc_unicode.docx": {
+    "kind": "generated",
+    "producer": "pandoc (html->docx)",
+    "source": "srcgen/unicode.html",
+    "size": 10246,
+    "sha256": "a16fb876f0c6b8bf"
+  },
+  "pydocx_test.docx": {
+    "kind": "download",
+    "producer": "python-docx test fixture (Word)",
+    "source": "https://raw.githubusercontent.com/python-openxml/python-docx/e45454602b53e8e572b179ccf1c91093ec9f4ed7/tests/test_files/test.docx",
+    "size": 31773,
+    "sha256": "fba1c76b66ff3098"
+  },
+  "pydocx_blk-inner-content.docx": {
+    "kind": "download",
+    "producer": "python-docx test fixture (Word)",
+    "source": "https://raw.githubusercontent.com/python-openxml/python-docx/e45454602b53e8e572b179ccf1c91093ec9f4ed7/tests/test_files/blk-inner-content.docx",
+    "size": 11949,
+    "sha256": "16243dd05f686d6d"
+  },
+  "pydocx_sct-inner-content.docx": {
+    "kind": "download",
+    "producer": "python-docx test fixture (Word)",
+    "source": "https://raw.githubusercontent.com/python-openxml/python-docx/e45454602b53e8e572b179ccf1c91093ec9f4ed7/tests/test_files/sct-inner-content.docx",
+    "size": 12051,
+    "sha256": "d92e9ca7b09fab7b"
+  },
+  "pydocx_having-images.docx": {
+    "kind": "download",
+    "producer": "python-docx test fixture (Word)",
+    "source": "https://raw.githubusercontent.com/python-openxml/python-docx/e45454602b53e8e572b179ccf1c91093ec9f4ed7/tests/test_files/having-images.docx",
+    "size": 132875,
+    "sha256": "72f40baa1b89e484"
+  },
+  "mammoth_comments.docx": {
+    "kind": "download",
+    "producer": "mammoth test fixture (Word)",
+    "source": "https://raw.githubusercontent.com/mwilliamson/python-mammoth/1cac2458ea3c0a68754f1cc86df3aee50b02782b/tests/test-data/comments.docx",
+    "size": 15526,
+    "sha256": "adc9f524d176f562"
+  },
+  "mammoth_endnotes.docx": {
+    "kind": "download",
+    "producer": "mammoth test fixture (Word)",
+    "source": "https://raw.githubusercontent.com/mwilliamson/python-mammoth/1cac2458ea3c0a68754f1cc86df3aee50b02782b/tests/test-data/endnotes.docx",
+    "size": 4431,
+    "sha256": "8b0275a08427605e"
+  },
+  "mammoth_footnotes.docx": {
+    "kind": "download",
+    "producer": "mammoth test fixture (Word)",
+    "source": "https://raw.githubusercontent.com/mwilliamson/python-mammoth/1cac2458ea3c0a68754f1cc86df3aee50b02782b/tests/test-data/footnotes.docx",
+    "size": 15936,
+    "sha256": "a3d786ba3ad53833"
+  },
+  "mammoth_simple-list.docx": {
+    "kind": "download",
+    "producer": "mammoth test fixture (Word)",
+    "source": "https://raw.githubusercontent.com/mwilliamson/python-mammoth/1cac2458ea3c0a68754f1cc86df3aee50b02782b/tests/test-data/simple-list.docx",
+    "size": 13887,
+    "sha256": "ed3c015cf411d07b"
+  },
+  "mammoth_strict-format.docx": {
+    "kind": "download",
+    "producer": "mammoth test fixture (Word)",
+    "source": "https://raw.githubusercontent.com/mwilliamson/python-mammoth/1cac2458ea3c0a68754f1cc86df3aee50b02782b/tests/test-data/strict-format.docx",
+    "size": 11692,
+    "sha256": "86d90f50d8fd3310"
+  },
+  "mammoth_tables.docx": {
+    "kind": "download",
+    "producer": "mammoth test fixture (Word)",
+    "source": "https://raw.githubusercontent.com/mwilliamson/python-mammoth/1cac2458ea3c0a68754f1cc86df3aee50b02782b/tests/test-data/tables.docx",
+    "size": 13087,
+    "sha256": "9f75a82d36530d91"
+  },
+  "mammoth_text-box.docx": {
+    "kind": "download",
+    "producer": "mammoth test fixture (Word)",
+    "source": "https://raw.githubusercontent.com/mwilliamson/python-mammoth/1cac2458ea3c0a68754f1cc86df3aee50b02782b/tests/test-data/text-box.docx",
+    "size": 15850,
+    "sha256": "a94f4c516bec29b7"
+  },
+  "mammoth_utf8-bom.docx": {
+    "kind": "download",
+    "producer": "mammoth test fixture (Word)",
+    "source": "https://raw.githubusercontent.com/mwilliamson/python-mammoth/1cac2458ea3c0a68754f1cc86df3aee50b02782b/tests/test-data/utf8-bom.docx",
+    "size": 2836,
+    "sha256": "8b59e5faa2879369"
+  },
+  "poi_51921-Word-Crash067.docx": {
+    "kind": "download",
+    "producer": "Apache POI test fixture (Word, bug reports)",
+    "source": "https://raw.githubusercontent.com/apache/poi/63eda92cc63b39d4e8956e7775ccddb1f0d925cf/test-data/document/51921-Word-Crash067.docx",
+    "size": 20006,
+    "sha256": "422e62dfe18243e8"
+  },
+  "poi_Bug51170.docx": {
+    "kind": "download",
+    "producer": "Apache POI test fixture (Word, bug reports)",
+    "source": "https://raw.githubusercontent.com/apache/poi/63eda92cc63b39d4e8956e7775ccddb1f0d925cf/test-data/document/Bug51170.docx",
+    "size": 239621,
+    "sha256": "3a5f19e5bfdc7f25"
+  },
+  "poi_ComplexNumberedLists.docx": {
+    "kind": "download",
+    "producer": "Apache POI test fixture (Word, bug reports)",
+    "source": "https://raw.githubusercontent.com/apache/poi/63eda92cc63b39d4e8956e7775ccddb1f0d925cf/test-data/document/ComplexNumberedLists.docx",
+    "size": 14458,
+    "sha256": "297a085a7d433af2"
+  },
+  "poi_FieldCodes.docx": {
+    "kind": "download",
+    "producer": "Apache POI test fixture (Word, bug reports)",
+    "source": "https://raw.githubusercontent.com/apache/poi/63eda92cc63b39d4e8956e7775ccddb1f0d925cf/test-data/document/FieldCodes.docx",
+    "size": 17034,
+    "sha256": "9247f85ab90b15f1"
+  },
+  "poi_ExternalEntityInText.docx": {
+    "kind": "download",
+    "producer": "Apache POI test fixture (Word, bug reports)",
+    "source": "https://raw.githubusercontent.com/apache/poi/63eda92cc63b39d4e8956e7775ccddb1f0d925cf/test-data/document/ExternalEntityInText.docx",
+    "size": 12756,
+    "sha256": "5cf7340ffd6516c2"
+  },
+  "poi_HeaderFooterUnicode.docx": {
+    "kind": "download",
+    "producer": "Apache POI test fixture (Word, bug reports)",
+    "source": "https://raw.githubusercontent.com/apache/poi/63eda92cc63b39d4e8956e7775ccddb1f0d925cf/test-data/document/HeaderFooterUnicode.docx",
+    "size": 15079,
+    "sha256": "ec439ac0643294e1"
+  },
+  "poi_IllustrativeCases.docx": {
+    "kind": "download",
+    "producer": "Apache POI test fixture (Word, bug reports)",
+    "source": "https://raw.githubusercontent.com/apache/poi/63eda92cc63b39d4e8956e7775ccddb1f0d925cf/test-data/document/IllustrativeCases.docx",
+    "size": 22858,
+    "sha256": "4c2407d338f02a6a"
+  },
+  "poi_MultipleBodyBug.docx": {
+    "kind": "download",
+    "producer": "Apache POI test fixture (Word, bug reports)",
+    "source": "https://raw.githubusercontent.com/apache/poi/63eda92cc63b39d4e8956e7775ccddb1f0d925cf/test-data/document/MultipleBodyBug.docx",
+    "size": 102103,
+    "sha256": "7b34a3e9458daa3c"
+  },
+  "poi_SampleDoc.docx": {
+    "kind": "download",
+    "producer": "Apache POI test fixture (Word, bug reports)",
+    "source": "https://raw.githubusercontent.com/apache/poi/63eda92cc63b39d4e8956e7775ccddb1f0d925cf/test-data/document/SampleDoc.docx",
+    "size": 11611,
+    "sha256": "ea2c517bd7be4628"
+  },
+  "pandocfx_comments.docx": {
+    "kind": "download",
+    "producer": "pandoc test fixture (pandoc/Word mixed)",
+    "source": "https://raw.githubusercontent.com/jgm/pandoc/db8d64fe6f55f446bc36796d3dc20f823f55bc4e/test/docx/comments.docx",
+    "size": 17109,
+    "sha256": "b6df01371955a599"
+  },
+  "pandocfx_block_quotes.docx": {
+    "kind": "download",
+    "producer": "pandoc test fixture (pandoc/Word mixed)",
+    "source": "https://raw.githubusercontent.com/jgm/pandoc/db8d64fe6f55f446bc36796d3dc20f823f55bc4e/test/docx/block_quotes.docx",
+    "size": 12153,
+    "sha256": "f6901b01b1b7e289"
+  },
+  "pandocfx_char_styles.docx": {
+    "kind": "download",
+    "producer": "pandoc test fixture (pandoc/Word mixed)",
+    "source": "https://raw.githubusercontent.com/jgm/pandoc/db8d64fe6f55f446bc36796d3dc20f823f55bc4e/test/docx/char_styles.docx",
+    "size": 18059,
+    "sha256": "4befadc2fcc30221"
+  },
+  "pandocfx_lists.docx": {
+    "kind": "download",
+    "producer": "pandoc test fixture (pandoc/Word mixed)",
+    "source": "https://raw.githubusercontent.com/jgm/pandoc/db8d64fe6f55f446bc36796d3dc20f823f55bc4e/test/docx/lists.docx",
+    "size": 9473,
+    "sha256": "e5b1a7204be70bb0"
+  },
+  "pandocfx_nested_sdt.docx": {
+    "kind": "download",
+    "producer": "pandoc test fixture (pandoc/Word mixed)",
+    "source": "https://raw.githubusercontent.com/jgm/pandoc/db8d64fe6f55f446bc36796d3dc20f823f55bc4e/test/docx/nested_sdt.docx",
+    "size": 11694,
+    "sha256": "b52b096bda700e04"
+  },
+  "pandocfx_image_vml.docx": {
+    "kind": "download",
+    "producer": "pandoc test fixture (pandoc/Word mixed)",
+    "source": "https://raw.githubusercontent.com/jgm/pandoc/db8d64fe6f55f446bc36796d3dc20f823f55bc4e/test/docx/image_vml.docx",
+    "size": 23559,
+    "sha256": "8065acde23fe24fd"
+  },
+  "pandocfx_metadata.docx": {
+    "kind": "download",
+    "producer": "pandoc test fixture (pandoc/Word mixed)",
+    "source": "https://raw.githubusercontent.com/jgm/pandoc/db8d64fe6f55f446bc36796d3dc20f823f55bc4e/test/docx/metadata.docx",
+    "size": 26077,
+    "sha256": "6b2fcb3cb98842e8"
+  },
+  "locore_CommentDone.docx": {
+    "kind": "download",
+    "producer": "LibreOffice core ooxmlexport fixture (Word/LO mixed)",
+    "source": "https://raw.githubusercontent.com/LibreOffice/core/1c29ec6c2b2ec1f343545915ba66b7e9718b3792/sw/qa/extras/ooxmlexport/data/CommentDone.docx",
+    "size": 20946,
+    "sha256": "f0c35b661ee60f28"
+  },
+  "locore_CommentReply.docx": {
+    "kind": "download",
+    "producer": "LibreOffice core ooxmlexport fixture (Word/LO mixed)",
+    "source": "https://raw.githubusercontent.com/LibreOffice/core/1c29ec6c2b2ec1f343545915ba66b7e9718b3792/sw/qa/extras/ooxmlexport/data/CommentReply.docx",
+    "size": 10353,
+    "sha256": "cfc3a47bb7a51a20"
+  },
+  "locore_UnknownStyleInRedline.docx": {
+    "kind": "download",
+    "producer": "LibreOffice core ooxmlexport fixture (Word/LO mixed)",
+    "source": "https://raw.githubusercontent.com/LibreOffice/core/1c29ec6c2b2ec1f343545915ba66b7e9718b3792/sw/qa/extras/ooxmlexport/data/UnknownStyleInRedline.docx",
+    "size": 14030,
+    "sha256": "09bca1e884e68313"
+  },
+  "locore_cell-sdt-redline.docx": {
+    "kind": "download",
+    "producer": "LibreOffice core ooxmlexport fixture (Word/LO mixed)",
+    "source": "https://raw.githubusercontent.com/LibreOffice/core/1c29ec6c2b2ec1f343545915ba66b7e9718b3792/sw/qa/extras/ooxmlexport/data/cell-sdt-redline.docx",
+    "size": 11268,
+    "sha256": "04bdf9ad34de06c3"
+  },
+  "locore_TC-table-DnD-move.docx": {
+    "kind": "download",
+    "producer": "LibreOffice core ooxmlexport fixture (Word/LO mixed)",
+    "source": "https://raw.githubusercontent.com/LibreOffice/core/1c29ec6c2b2ec1f343545915ba66b7e9718b3792/sw/qa/extras/ooxmlexport/data/TC-table-DnD-move.docx",
+    "size": 12977,
+    "sha256": "32419eb1c66dc5ca"
+  },
+  "locore_99_Fields.docx": {
+    "kind": "download",
+    "producer": "LibreOffice core ooxmlexport fixture (Word/LO mixed)",
+    "source": "https://raw.githubusercontent.com/LibreOffice/core/1c29ec6c2b2ec1f343545915ba66b7e9718b3792/sw/qa/extras/ooxmlexport/data/99_Fields.docx",
+    "size": 15788,
+    "sha256": "957a5a8cc989cd31"
+  },
+  "locore_NumberedList.docx": {
+    "kind": "download",
+    "producer": "LibreOffice core ooxmlexport fixture (Word/LO mixed)",
+    "source": "https://raw.githubusercontent.com/LibreOffice/core/1c29ec6c2b2ec1f343545915ba66b7e9718b3792/sw/qa/extras/ooxmlexport/data/NumberedList.docx",
+    "size": 55519,
+    "sha256": "ebb078d791b6deb4"
+  },
+  "locore_floating-tables-anchor.docx": {
+    "kind": "download",
+    "producer": "LibreOffice core ooxmlexport fixture (Word/LO mixed)",
+    "source": "https://raw.githubusercontent.com/LibreOffice/core/1c29ec6c2b2ec1f343545915ba66b7e9718b3792/sw/qa/extras/ooxmlexport/data/floating-tables-anchor.docx",
+    "size": 16348,
+    "sha256": "428f189fb7afbd60"
+  },
+  "onlyoffice_sample.docx": {
+    "kind": "download",
+    "producer": "ONLYOFFICE sample template",
+    "source": "https://raw.githubusercontent.com/ONLYOFFICE/document-templates/71430c9f183489e8912f54f9dc859e369cf0dfb4/sample/sample.docx",
+    "size": 410390,
+    "sha256": "d678383aee1f2deb"
+  }
+}

--- a/benchmarks/corpus/srcgen/doc.rtf
+++ b/benchmarks/corpus/srcgen/doc.rtf
@@ -1,0 +1,6 @@
+{\rtf1\ansi\deff0 {\fonttbl{\f0 Times New Roman;}}
+{\b Bold heading}\par
+Plain paragraph with {\i italics} and {\ul underline}.\par
+\pard\li720 Indented paragraph one.\par
+Second paragraph with special chars: \'e9\'e8 caf\'e9.\par
+}

--- a/benchmarks/corpus/srcgen/notes.md
+++ b/benchmarks/corpus/srcgen/notes.md
@@ -1,0 +1,22 @@
+# Meeting Notes
+
+Attendees: **Sam**, *Priya*, `ops-bot`
+
+## Decisions
+
+1. Migrate CI to the new runner pool[^1]
+2. Freeze schema changes until Q3
+
+| Item | Owner | Due |
+|------|-------|-----|
+| Runbook | Sam | Fri |
+| Audit | Priya | Mon |
+
+```python
+def hello():
+    return "world"
+```
+
+> Quote: measure twice, cut once.
+
+[^1]: Pending budget approval.

--- a/benchmarks/corpus/srcgen/plain.txt
+++ b/benchmarks/corpus/srcgen/plain.txt
@@ -1,0 +1,11 @@
+Quarterly Report Summary
+
+Revenue increased by 14 percent over the previous quarter. The engineering
+team shipped three major releases. Customer churn dropped to 2.1 percent.
+
+Key priorities for next quarter:
+- Expand the enterprise sales pipeline
+- Reduce infrastructure spend by 10 percent
+- Launch the partner integration program
+
+Prepared by the operations team, March 2026.

--- a/benchmarks/corpus/srcgen/rich.html
+++ b/benchmarks/corpus/srcgen/rich.html
@@ -1,0 +1,13 @@
+<html><head><meta charset="utf-8"><title>Project Charter</title></head><body>
+<h1>Project Charter: Meridian</h1>
+<p>This document defines the <b>scope</b>, <i>schedule</i>, and <u>budget</u> for the Meridian initiative.</p>
+<h2>Stakeholders</h2>
+<table border="1"><tr><th>Name</th><th>Role</th><th>Region</th></tr>
+<tr><td>A. Okafor</td><td>Sponsor</td><td>EMEA</td></tr>
+<tr><td>J. Lindqvist</td><td>Lead</td><td>Nordics</td></tr>
+<tr><td colspan="2">Combined cell</td><td>APAC</td></tr></table>
+<h2>Milestones</h2>
+<ol><li>Discovery <ul><li>interviews</li><li>audit</li></ul></li><li>Build</li><li>Launch</li></ol>
+<blockquote>Risk: vendor lock-in must be assessed before phase 2.</blockquote>
+<p><a href="https://example.com/charter">Full charter online</a></p>
+</body></html>

--- a/benchmarks/corpus/srcgen/unicode.html
+++ b/benchmarks/corpus/srcgen/unicode.html
@@ -1,0 +1,7 @@
+<html><head><meta charset="utf-8"><title>i18n</title></head><body>
+<h1>Internationalization test — español, français</h1>
+<p>Chinese: 这是一个测试文档。 Japanese: これはテストです。 Korean: 테스트 문서입니다.</p>
+<p dir="rtl">العربية: هذه وثيقة اختبار. עברית: זהו מסמך בדיקה.</p>
+<p>Emoji: 🚀 📄 ✅ — Math: ∑ᵢ xᵢ² ≤ ∞, α+β=γ</p>
+<p>Combining: éèêë ñ ç ø å ß — Zalgo: e̸̛x̷̽ạ̸m̶̎p̵̚l̸̎e̶̊</p>
+</body></html>

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -5,7 +5,8 @@ import re
 import zipfile
 
 import pytest
-from conftest import find_ref
+from conftest import NS, find_ref, replace_document_xml
+from defusedxml.common import EntitiesForbidden
 
 import docx_editor
 from docx_editor import Document, SearchResult
@@ -75,6 +76,19 @@ class TestDocumentOpen:
         doc2 = Document.open(clean_workspace, force_recreate=True, workspace_dir=tmp_path)
         assert doc2._workspace.workspace_path.parent == tmp_path
         doc2.close()
+
+    def test_open_rejects_external_entities(self, simple_docx, tmp_path):
+        """A document declaring XML entities must be refused, never expanded (XXE)."""
+        evil = tmp_path / "entities.docx"
+        replace_document_xml(
+            simple_docx,
+            evil,
+            '<?xml version="1.0"?>\n'
+            '<!DOCTYPE w:document [<!ENTITY x SYSTEM "http://example.com/x">]>\n'
+            f"<w:document {NS}><w:body><w:p><w:r><w:t>&x;</w:t></w:r></w:p></w:body></w:document>",
+        )
+        with pytest.raises(EntitiesForbidden):
+            Document.open(evil, workspace_dir=tmp_path / "ws")
 
 
 class TestDocumentSave:


### PR DESCRIPTION
## Summary

Adopts a corpus round-trip harness at `benchmarks/corpus/` (ISSUES.md item 38): a 56-file real-world `.docx` corpus from 14 producer flavors, plus an 8-stage robustness pipeline that exercises the library end-to-end over every file.

## What's included

- **`manifest.json`** — single source of truth for the corpus: 9 `local` (copied from `tests/test_data/`), 37 `download` (https raw.githubusercontent.com URLs pinned to full upstream commit SHAs, sha256-verified at fetch time, from python-docx, mammoth, Apache POI, pandoc, LibreOffice core, ONLYOFFICE test suites), 10 `generated` (LibreOffice/pandoc conversions of small text sources in `srcgen/`).
- **`build_corpus.py`** — manifest-driven assembly into `files/` with 2MB size cap, hard failure on hash mismatch, and graceful skip of generated entries when soffice/pandoc are absent.
- **`corpus_harness.py`** — per-file stages: `input_validate → open → read → edit → save1 → reopen → save2 → pdf`, each file isolated in a subprocess with a hard timeout. Deep assertions: tracked edit adds at least a del/ins revision pair, edit marker survives save/reopen, revision count is stable across the round-trip, `accept_all()` accepts and keeps the edit, and outputs re-validate as sound zip+XML (defusedxml). An invalid input the library refuses is recorded as **rejected**, not a failure.
- **CI**: `.github/workflows/corpus.yml` — weekly scheduled + manual run (`--no-pdf`), results.json uploaded as artifact, token restricted to `contents: read`. Plus a `make corpus-check` target for full local runs including the PDF stage.

## Provenance policy

No `.docx` file is committed (upstream licensing + repo size); `files/`, `out/`, `work/`, and `results.json` are gitignored, and corpus files are fetched or generated at build time. `manifest.json` records kind, producer, source, size, and truncated sha256 for every entry.

## Verification

- Full harness run: 56/56 assembled, **55 clean + 1 correctly rejected** (`poi_ExternalEntityInText.docx`, external XML entities), exit 0 — including the PDF stage locally
- `uv run pytest`: 940 passed, 2 skipped
- `uv run ruff check` + `ruff format --check`: clean; `uv run ty check`: exit 0
- Wheel packaging unaffected (`packages = ["docx_editor"]` — benchmarks excluded by construction)