### PR TITLE
feat: resolve style-inherited numbering in ParagraphLocation (ISSUES.md #36)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -135,7 +135,7 @@ Report whether a paragraph lives in the document body or inside a table cell, wh
 
 - `ref` (str): Paragraph reference from `list_paragraphs()`, such as `P2#f3c1`
 
-**Returns:** `ParagraphLocation`. `location.in_table` is `False` for body paragraphs; `True` when the paragraph is inside a `<w:tc>` cell, in which case `location.table` carries the 1-based table index, row, `w:gridSpan`-aware logical column, and nesting depth. `location.list` is a `ListItem(num_id, ilvl)` for paragraphs carrying a direct `w:pPr/w:numPr`, `None` otherwise — raw values only: numbering inherited via a paragraph style is not resolved, and rendered display numbers (e.g. "7.2(a)") are not computed.
+**Returns:** `ParagraphLocation`. `location.in_table` is `False` for body paragraphs; `True` when the paragraph is inside a `<w:tc>` cell, in which case `location.table` carries the 1-based table index, row, `w:gridSpan`-aware logical column, and nesting depth. `location.list` is a `ListItem(num_id, ilvl)` for list paragraphs, `None` otherwise: a direct `w:pPr/w:numPr` wins when present — including Word's `numId=0` "numbering disabled" marker, which reports `None` with no style fallback — otherwise the numbering defined by the paragraph's style applies, with `w:basedOn` inheritance chains resolved. Rendered display numbers (e.g. "7.2(a)") are not computed.
 
 `location.style` is the raw `w:pStyle` style id (e.g. `"Heading1"`), `None` when the paragraph carries no explicit style — no name resolution against `word/styles.xml`. `location.outline_level` is the 0-based outline level (`0` == Heading 1, so a document heading level is `outline_level + 1`): a direct `w:outlineLvl` on the paragraph wins, and the spec's `w:val="9"` marker means body text (`None`); otherwise the level defined by the paragraph's style applies, with `w:basedOn` inheritance chains resolved. `location.heading_path` is the chain of nearest preceding headings that contains the paragraph, outermost first (e.g. `("Chapter one", "Termination")`), built from each heading's current visible text; a heading's own path lists only its ancestors, never itself. Headings inside table cells participate in document order. `location.section` is the paragraph's 1-based section index: a paragraph carrying a direct `w:pPr/w:sectPr` closes a section and belongs to the section it closes, the next paragraph starts the following one, and the body-level `w:sectPr` defines the final section — single-section documents report `1` everywhere.
 
@@ -156,7 +156,7 @@ print(f"section {loc.section}")
 
 #### `list_paragraph_locations()`
 
-Batch counterpart to `get_paragraph_location()`: pair every paragraph with its structural location in one pass, precomputing table indexes, style outline levels, heading paths, and section indexes once instead of rescanning the document per ref.
+Batch counterpart to `get_paragraph_location()`: pair every paragraph with its structural location in one pass, precomputing table indexes, style outline levels, style numbering, heading paths, and section indexes once instead of rescanning the document per ref.
 
 **Returns:** List of `(ref, ParagraphLocation)` tuples in document order, where `ref` is the same `P{index}#{hash}` token emitted by `list_paragraphs()`. Each location carries the same table, list, style, outline-level, heading-path, and section info as `get_paragraph_location()`.
 

--- a/docx_editor/document.py
+++ b/docx_editor/document.py
@@ -17,10 +17,12 @@ from .track_changes import EditOperation, EditValidationResult, Revision, Revisi
 from .workspace import Workspace
 from .xml_editor import (
     DocxXMLEditor,
+    ListItem,
     ParagraphInfo,
     ParagraphLocation,
     ParagraphRef,
     XMLEditor,
+    _build_style_numbering_map,
     _build_style_outline_map,
     _build_table_index,
     _compute_heading_paths,
@@ -396,16 +398,18 @@ class Document:
         h = compute_paragraph_hash(p)
         return ParagraphInfo(index=index, ref=f"P{index}#{h}", text=build_text_map(p).text)
 
-    def _style_outline_map(self) -> dict[str, int]:
-        """Outline levels defined by paragraph styles in ``word/styles.xml``.
+    def _style_maps(self) -> tuple[dict[str, int], dict[str, ListItem]]:
+        """Outline-level and numbering maps defined by paragraph styles.
 
-        Parsed per call (no caching, matching the per-call table rescan
-        philosophy); a document without a styles part degrades to ``{}``.
+        One ``word/styles.xml`` parse serves both maps. Parsed per call
+        (no caching, matching the per-call table rescan philosophy); a
+        document without a styles part degrades to ``({}, {})``.
         """
         styles_path = self._workspace.word_path / "styles.xml"
         if not styles_path.exists():
-            return {}
-        return _build_style_outline_map(XMLEditor(styles_path).dom)
+            return {}, {}
+        styles_dom = XMLEditor(styles_path).dom
+        return _build_style_outline_map(styles_dom), _build_style_numbering_map(styles_dom)
 
     def get_paragraph_location(self, ref: str) -> ParagraphLocation:
         """Return the structural location of the paragraph identified by ``ref``.
@@ -414,16 +418,19 @@ class Document:
         inside a table cell, and — when in a table — gives its 1-based
         coordinates (table index, row, logical column, depth). Also reports
         list membership: ``location.list`` is a ``ListItem(num_id, ilvl)``
-        when the paragraph carries a direct ``w:pPr/w:numPr``, else ``None``.
+        for list paragraphs, else ``None``.
 
         ``location.table.col`` is the *logical-grid* column, accounting for
         ``w:gridSpan`` of preceding cells in the same row. A cell that
         visually sits in column 4 reports ``col=4`` even when an earlier
         cell in the row spans 2 grid columns.
 
-        ``location.list`` holds raw values only: numbering inherited via a
-        paragraph style (``w:pStyle``) is not resolved, and rendered display
-        numbers (e.g. "7.2(a)") are not computed.
+        For ``location.list``, a direct ``w:pPr/w:numPr`` wins when present
+        — including Word's ``numId=0`` "numbering disabled" marker, which
+        reports ``None`` with no style fallback; otherwise the numbering
+        defined by the paragraph's style in ``word/styles.xml`` applies,
+        with ``w:basedOn`` chains resolved. Rendered display numbers
+        (e.g. "7.2(a)") are not computed.
 
         ``location.style`` is the raw ``w:pStyle`` style id (e.g.
         ``"Heading1"``), ``None`` when absent. ``location.outline_level``
@@ -493,17 +500,24 @@ class Document:
             if len(tm.text) > 80:
                 preview += "..."
             raise HashMismatchError(parsed.index, parsed.hash, actual_hash, preview)
-        style_outlines = self._style_outline_map()
+        style_outlines, style_numbering = self._style_maps()
         heading_path = _compute_heading_paths(paragraphs[: parsed.index], style_outlines)[-1]
         section = _compute_section_indexes(paragraphs[: parsed.index])[-1]
-        return _compute_paragraph_location(p, style_outlines=style_outlines, heading_path=heading_path, section=section)
+        return _compute_paragraph_location(
+            p,
+            style_outlines=style_outlines,
+            style_numbering=style_numbering,
+            heading_path=heading_path,
+            section=section,
+        )
 
     def list_paragraph_locations(self) -> list[tuple[str, ParagraphLocation]]:
         """List every paragraph paired with its structural location.
 
         Batch counterpart to :meth:`get_paragraph_location`: precomputes
-        table indexes, style outline levels, heading paths, and section
-        indexes once instead of re-scanning the document per ref. Each
+        table indexes, style outline levels, style numbering, heading
+        paths, and section indexes once instead of re-scanning the
+        document per ref. Each
         entry is ``(ref, location)`` where ``ref`` is the same
         ``"P{i}#{hash}"`` token emitted by :meth:`list_paragraphs` (the
         part before ``|``) and accepted by :meth:`get_paragraph_location`
@@ -513,9 +527,10 @@ class Document:
             List of ``(ref, ParagraphLocation)`` tuples in document order.
             ``location.in_table`` is ``False`` for body paragraphs; ``True``
             when the paragraph is inside a ``<w:tc>`` cell.
-            ``location.list`` is a :class:`ListItem` for paragraphs with a
-            direct ``w:pPr/w:numPr``, ``None`` otherwise (raw values; no
-            style-inherited numbering, no rendered display numbers).
+            ``location.list`` is a :class:`ListItem` for list paragraphs,
+            ``None`` otherwise (a direct ``w:numPr`` wins, else the
+            paragraph style's numbering applies with ``w:basedOn`` chains
+            resolved; rendered display numbers are not computed).
             ``location.style``, ``location.outline_level``,
             ``location.heading_path`` and ``location.section`` carry the
             paragraph's heading and section context with the same
@@ -534,7 +549,7 @@ class Document:
         self._ensure_open()
         dom = self._document_editor.dom
         table_index = _build_table_index(dom)
-        style_outlines = self._style_outline_map()
+        style_outlines, style_numbering = self._style_maps()
         paragraphs = dom.getElementsByTagName("w:p")
         heading_paths = _compute_heading_paths(paragraphs, style_outlines)
         section_indexes = _compute_section_indexes(paragraphs)
@@ -544,7 +559,12 @@ class Document:
             result.append((
                 ref,
                 _compute_paragraph_location(
-                    p, table_index, style_outlines=style_outlines, heading_path=path, section=section
+                    p,
+                    table_index,
+                    style_outlines=style_outlines,
+                    style_numbering=style_numbering,
+                    heading_path=path,
+                    section=section,
                 ),
             ))
         return result

--- a/docx_editor/document.py
+++ b/docx_editor/document.py
@@ -517,11 +517,10 @@ class Document:
         Batch counterpart to :meth:`get_paragraph_location`: precomputes
         table indexes, style outline levels, style numbering, heading
         paths, and section indexes once instead of re-scanning the
-        document per ref. Each
-        entry is ``(ref, location)`` where ``ref`` is the same
-        ``"P{i}#{hash}"`` token emitted by :meth:`list_paragraphs` (the
-        part before ``|``) and accepted by :meth:`get_paragraph_location`
-        and the editing methods.
+        document per ref. Each entry is ``(ref, location)`` where ``ref``
+        is the same ``"P{i}#{hash}"`` token emitted by
+        :meth:`list_paragraphs` (the part before ``|``) and accepted by
+        :meth:`get_paragraph_location` and the editing methods.
 
         Returns:
             List of ``(ref, ParagraphLocation)`` tuples in document order.

--- a/docx_editor/xml_editor.py
+++ b/docx_editor/xml_editor.py
@@ -159,16 +159,22 @@ class TableCell:
 
 @dataclass(frozen=True)
 class ListItem:
-    """Raw numbering reference of a list paragraph.
+    """Numbering reference of a list paragraph.
 
-    Values come straight from the paragraph's direct ``<w:pPr>/<w:numPr>``:
-    ``num_id`` keys into ``word/numbering.xml``; ``ilvl`` is the 0-based
-    indentation level (0 when ``<w:ilvl>`` is absent, per spec default).
+    A direct ``<w:pPr>/<w:numPr>`` wins when present — including the
+    ``numId=0`` "numbering disabled" marker Word writes to remove
+    style-inherited numbering from a single paragraph (→ no ``ListItem``,
+    no style fallback). Otherwise the numbering defined by the
+    paragraph's style in ``word/styles.xml`` applies, with ``w:basedOn``
+    chains resolved. ``num_id`` keys into ``word/numbering.xml``;
+    ``ilvl`` is the 0-based indentation level (0 when ``<w:ilvl>`` is
+    absent, per spec default).
 
-    Limitations of this raw extraction: numbering inherited via a paragraph
-    style (``w:pStyle``) is NOT resolved — a paragraph numbered only through
-    its style reports ``list=None``. Rendered display numbers ("7.2(a)")
-    are not computed (that requires resolving ``word/numbering.xml``).
+    Limitations: rendered display numbers ("7.2(a)") are not computed
+    (that requires resolving ``word/numbering.xml``), and a
+    style-numbered paragraph reports the style's raw ``ilvl`` — levels
+    assigned via ``w:lvl/w:pStyle`` associations inside
+    ``word/numbering.xml`` are not resolved.
     """
 
     num_id: int  # w:numPr/w:numId/@w:val — key into word/numbering.xml
@@ -184,8 +190,10 @@ class ParagraphLocation:
     may add other container kinds (header, footer, footnote), etc., as
     plain optional field additions.
 
-    ``list`` is the paragraph's raw numbering reference (see
-    :class:`ListItem`), or ``None`` for non-list paragraphs.
+    ``list`` is the paragraph's numbering reference (see
+    :class:`ListItem` — a direct ``w:numPr`` wins; absent that, the
+    numbering defined by the paragraph's style applies), or ``None`` for
+    non-list paragraphs.
 
     ``style`` is the raw ``w:pPr/w:pStyle/@w:val`` style id (a key into
     ``word/styles.xml``, e.g. ``"Heading1"``), or ``None`` when the
@@ -352,21 +360,14 @@ def _direct_child(elem, tag_name: str) -> Element | None:
     return None
 
 
-def _extract_list_item(paragraph) -> ListItem | None:
-    """Raw ``<w:pPr>/<w:numPr>`` of ``paragraph``, as a :class:`ListItem`.
+def _parse_num_pr(numpr) -> ListItem | None:
+    """Parse a ``<w:numPr>`` element as a :class:`ListItem`.
 
-    Walks direct children only, so a stale ``w:numPr`` inside a
-    ``<w:pPrChange>`` revision record is never picked up. Returns ``None``
-    when there is no ``w:numPr``, when ``w:numId`` is absent or malformed,
-    or when ``w:numId`` is 0 (the spec's "numbering disabled" marker).
-    ``w:ilvl`` absent/malformed → level 0 (spec default).
+    Returns ``None`` when ``w:numId`` is absent or malformed, or when it
+    is < 1 (``numId=0`` is the spec's "numbering disabled" marker).
+    ``w:ilvl`` absent/malformed → level 0 (spec default). Direct-child
+    walks only.
     """
-    ppr = _direct_child(paragraph, "w:pPr")
-    if ppr is None:
-        return None
-    numpr = _direct_child(ppr, "w:numPr")
-    if numpr is None:
-        return None
     numid_elem = _direct_child(numpr, "w:numId")
     if numid_elem is None:
         return None
@@ -384,6 +385,29 @@ def _extract_list_item(paragraph) -> ListItem | None:
         except ValueError:
             ilvl = 0
     return ListItem(num_id=num_id, ilvl=ilvl)
+
+
+def _extract_list_item(paragraph, style: str | None, style_numbering: dict[str, ListItem]) -> ListItem | None:
+    """Effective numbering of ``paragraph``, as a :class:`ListItem`.
+
+    A direct ``<w:pPr>/<w:numPr>`` always wins: when the element is
+    present, its value decides (``numId=0`` — Word's "remove numbering
+    from this styled paragraph" marker — malformed, or ``numId``-less
+    blocks → ``None``, no style fallback, matching OOXML
+    direct-formatting override semantics; a direct block carrying only
+    ``w:ilvl`` is not merged with the style's ``numId``). When absent,
+    the numbering defined by ``style`` in ``style_numbering`` (see
+    :func:`_build_style_numbering_map`) applies. Direct-child walk only,
+    so a stale ``w:numPr`` inside a ``<w:pPrChange>`` revision record is
+    never picked up.
+    """
+    ppr = _direct_child(paragraph, "w:pPr")
+    numpr = _direct_child(ppr, "w:numPr") if ppr is not None else None
+    if numpr is not None:
+        return _parse_num_pr(numpr)
+    if style is not None:
+        return style_numbering.get(style)
+    return None
 
 
 def _extract_style(paragraph) -> str | None:
@@ -476,6 +500,48 @@ def _build_style_outline_map(styles_dom) -> dict[str, int]:
     return resolved
 
 
+def _build_style_numbering_map(styles_dom) -> dict[str, ListItem]:
+    """Map paragraph-style ids to their effective numbering reference.
+
+    Structural mirror of :func:`_build_style_outline_map`: one pass over
+    ``<w:style w:type="paragraph">`` elements collects each style's own
+    ``<w:pPr>/<w:numPr>`` and its ``w:basedOn`` parent; a second pass
+    resolves ``basedOn`` chains (visited-set cycle guard) so a custom
+    style based on e.g. ``ListNumber`` without restating the numbering
+    inherits it. A *present* ``w:numPr`` terminates the chain even when
+    it yields no numbering (``numId=0`` explicitly disables inherited
+    numbering). Styles that end up with no numbering are omitted from
+    the map.
+    """
+    raw: dict[str, tuple[ListItem | None, bool, str | None]] = {}
+    for style in styles_dom.getElementsByTagName("w:style"):
+        if style.getAttribute("w:type") != "paragraph":
+            continue
+        style_id = style.getAttribute("w:styleId")
+        if not style_id:
+            continue
+        ppr = _direct_child(style, "w:pPr")
+        numpr = _direct_child(ppr, "w:numPr") if ppr is not None else None
+        item = _parse_num_pr(numpr) if numpr is not None else None
+        based_on_elem = _direct_child(style, "w:basedOn")
+        based_on = based_on_elem.getAttribute("w:val") if based_on_elem is not None else None
+        raw[style_id] = (item, numpr is not None, based_on or None)
+
+    resolved: dict[str, ListItem] = {}
+    for style_id in raw:
+        current: str | None = style_id
+        visited: set[str] = set()
+        while current is not None and current in raw and current not in visited:
+            visited.add(current)
+            item, has_own_numpr, based_on = raw[current]
+            if has_own_numpr:
+                if item is not None:
+                    resolved[style_id] = item
+                break
+            current = based_on
+    return resolved
+
+
 def _compute_heading_paths(paragraphs, style_outlines: dict[str, int]) -> list[tuple[str, ...]]:
     """Heading-ancestor path for each of ``paragraphs`` (document order).
 
@@ -522,13 +588,14 @@ def _compute_paragraph_location(
     paragraph,
     table_index: dict | None = None,
     style_outlines: dict[str, int] | None = None,
+    style_numbering: dict[str, ListItem] | None = None,
     heading_path: tuple[str, ...] = (),
     section: int = 1,
 ) -> ParagraphLocation:
     """Compute the structural location of a ``<w:p>`` element.
 
     Reports the innermost enclosing ``<w:tc>`` (and its table) plus the
-    paragraph's raw list membership (see :func:`_extract_list_item`),
+    paragraph's list membership (see :func:`_extract_list_item`),
     style id, and outline level; a plain body paragraph gets ``table=None``.
 
     ``table_index`` is an optional ``{tbl_node: 1-based-index}`` map (see
@@ -540,12 +607,15 @@ def _compute_paragraph_location(
     ``style_outlines`` is an optional precomputed ``{style_id:
     outline_level}`` map (see :func:`_build_style_outline_map`) used to
     resolve style-defined outline levels; ``None`` behaves like ``{}``.
+    ``style_numbering`` is the analogous ``{style_id: ListItem}`` map
+    (see :func:`_build_style_numbering_map`) used to resolve
+    style-defined numbering; ``None`` behaves like ``{}``.
     ``heading_path`` and ``section`` are threaded through verbatim —
     computing them needs whole-document context (see
     :func:`_compute_heading_paths` and :func:`_compute_section_indexes`).
     """
-    list_item = _extract_list_item(paragraph)
     style = _extract_style(paragraph)
+    list_item = _extract_list_item(paragraph, style, style_numbering or {})
     outline_level = _extract_outline_level(paragraph, style, style_outlines or {})
     tc = _innermost_ancestor(paragraph, "w:tc")
     if tc is None:

--- a/docx_editor/xml_editor.py
+++ b/docx_editor/xml_editor.py
@@ -510,8 +510,9 @@ def _build_style_numbering_map(styles_dom) -> dict[str, ListItem]:
     style based on e.g. ``ListNumber`` without restating the numbering
     inherits it. A *present* ``w:numPr`` terminates the chain even when
     it yields no numbering (``numId=0`` explicitly disables inherited
-    numbering). Styles that end up with no numbering are omitted from
-    the map.
+    numbering; a block carrying only ``w:ilvl`` likewise contributes
+    nothing — the parent's ``numId`` is not merged in). Styles that end
+    up with no numbering are omitted from the map.
     """
     raw: dict[str, tuple[ListItem | None, bool, str | None]] = {}
     for style in styles_dom.getElementsByTagName("w:style"):

--- a/skills/docx/SKILL.md
+++ b/skills/docx/SKILL.md
@@ -226,8 +226,8 @@ match = doc.find_text("30 days")
 # Get all visible text (inserted text included, deleted text excluded)
 visible = doc.get_visible_text()
 
-# Structural location: table cell, list item (raw numId/ilvl), heading context,
-# and section index
+# Structural location: table cell, list item (numId/ilvl; style-inherited
+# numbering resolved), heading context, and section index
 loc = doc.get_paragraph_location("P3#b2c4")
 if loc.table:
     print(f"table {loc.table.index} r{loc.table.row} c{loc.table.col}")

--- a/tests/test_paragraph_location.py
+++ b/tests/test_paragraph_location.py
@@ -7,8 +7,10 @@ Covers:
     ``<w:tc>`` count
   * nested tables increment ``depth`` and produce a depth-first doc-wide
     table ``index``
-  * list paragraphs report ``ListItem(num_id, ilvl)`` from their direct
-    ``w:pPr/w:numPr``; non-list paragraphs report ``list=None``
+  * list paragraphs report ``ListItem(num_id, ilvl)``: a direct
+    ``w:pPr/w:numPr`` wins when present (``numId=0`` disables), otherwise
+    the numbering defined by the paragraph style applies (``w:basedOn``
+    chains resolved); non-list paragraphs report ``list=None``
   * ``style`` reports the raw ``w:pStyle`` id; ``outline_level`` comes from
     a direct ``w:outlineLvl`` or the style definition in ``word/styles.xml``
     (``w:basedOn`` chains resolved, ``w:val="9"`` = body text)
@@ -1092,6 +1094,148 @@ class TestStyleOutlineBasedOnChain:
             assert loc.outline_level is None
 
 
+class TestStyleNumberingChain:
+    """Style-defined ``w:numPr`` resolution in the style numbering map."""
+
+    _STYLES_XML = (
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+        f"<w:styles {_W_NS}>"
+        # Style carrying its own numbering (the dogfooding shape: no ilvl).
+        '<w:style w:type="paragraph" w:styleId="ListNumber">'
+        '<w:name w:val="List Number"/>'
+        '<w:pPr><w:numPr><w:numId w:val="5"/></w:numPr></w:pPr>'
+        "</w:style>"
+        # Custom style inheriting the numbering from ListNumber.
+        '<w:style w:type="paragraph" w:styleId="MyList">'
+        '<w:name w:val="My List"/>'
+        '<w:basedOn w:val="ListNumber"/>'
+        "</w:style>"
+        # Style whose own numPr carries an explicit level.
+        '<w:style w:type="paragraph" w:styleId="LeveledList">'
+        '<w:pPr><w:numPr><w:ilvl w:val="1"/><w:numId w:val="5"/></w:numPr></w:pPr>'
+        "</w:style>"
+        # numId=0 disables the numbering inherited from ListNumber.
+        '<w:style w:type="paragraph" w:styleId="DisabledNum">'
+        '<w:basedOn w:val="ListNumber"/>'
+        '<w:pPr><w:numPr><w:numId w:val="0"/></w:numPr></w:pPr>'
+        "</w:style>"
+        # basedOn cycle — must terminate, not hang.
+        '<w:style w:type="paragraph" w:styleId="CycleA"><w:basedOn w:val="CycleB"/></w:style>'
+        '<w:style w:type="paragraph" w:styleId="CycleB"><w:basedOn w:val="CycleA"/></w:style>'
+        # Non-paragraph style carrying a numPr — must be ignored.
+        '<w:style w:type="character" w:styleId="CharNum">'
+        '<w:pPr><w:numPr><w:numId w:val="5"/></w:numPr></w:pPr>'
+        "</w:style>"
+        "</w:styles>"
+    )
+
+    _DOCUMENT_XML = (
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+        f"<w:document {_W_NS}>"
+        "<w:body>"
+        f"<w:p>{_p_style('ListNumber')}<w:r><w:t>Styled number</w:t></w:r></w:p>"
+        f"<w:p>{_p_style('MyList')}<w:r><w:t>Inherited number</w:t></w:r></w:p>"
+        f"<w:p>{_p_style('LeveledList')}<w:r><w:t>Leveled number</w:t></w:r></w:p>"
+        '<w:p><w:pPr><w:pStyle w:val="ListNumber"/>'
+        '<w:numPr><w:ilvl w:val="2"/><w:numId w:val="9"/></w:numPr></w:pPr>'
+        "<w:r><w:t>Direct wins</w:t></w:r></w:p>"
+        '<w:p><w:pPr><w:pStyle w:val="ListNumber"/>'
+        '<w:numPr><w:numId w:val="0"/></w:numPr></w:pPr>'
+        "<w:r><w:t>Direct disable</w:t></w:r></w:p>"
+        '<w:p><w:pPr><w:pStyle w:val="ListNumber"/>'
+        '<w:numPr><w:ilvl w:val="1"/></w:numPr></w:pPr>'
+        "<w:r><w:t>Ilvl only</w:t></w:r></w:p>"
+        f"<w:p>{_p_style('DisabledNum')}<w:r><w:t>Disabled style</w:t></w:r></w:p>"
+        f"<w:p>{_p_style('CycleA')}<w:r><w:t>Cycle styled</w:t></w:r></w:p>"
+        f"<w:p>{_p_style('CharNum')}<w:r><w:t>Char styled</w:t></w:r></w:p>"
+        "<w:p><w:r><w:t>Plain paragraph</w:t></w:r></w:p>"
+        "</w:body>"
+        "</w:document>"
+    )
+
+    @pytest.fixture
+    def style_numbered_docx(self, simple_docx, tmp_path) -> Path:
+        dest = tmp_path / "style-numbered.docx"
+        replace_docx_parts(
+            simple_docx,
+            dest,
+            {"word/document.xml": self._DOCUMENT_XML, "word/styles.xml": self._STYLES_XML},
+        )
+        return dest
+
+    def test_style_defined_numbering_is_resolved(self, style_numbered_docx):
+        """The dogfooding shape: pStyle=ListNumber, numPr only in styles.xml."""
+        with Document.open(style_numbered_docx) as doc:
+            loc = doc.get_paragraph_location(_ref_for_text(doc, "Styled number"))
+            assert loc.style == "ListNumber"
+            assert loc.list == ListItem(num_id=5, ilvl=0)
+
+    def test_based_on_chain_inherits_numbering(self, style_numbered_docx):
+        with Document.open(style_numbered_docx) as doc:
+            loc = doc.get_paragraph_location(_ref_for_text(doc, "Inherited number"))
+            assert loc.list == ListItem(num_id=5, ilvl=0)
+
+    def test_style_ilvl_comes_through(self, style_numbered_docx):
+        with Document.open(style_numbered_docx) as doc:
+            loc = doc.get_paragraph_location(_ref_for_text(doc, "Leveled number"))
+            assert loc.list == ListItem(num_id=5, ilvl=1)
+
+    def test_direct_num_pr_overrides_style(self, style_numbered_docx):
+        with Document.open(style_numbered_docx) as doc:
+            loc = doc.get_paragraph_location(_ref_for_text(doc, "Direct wins"))
+            assert loc.list == ListItem(num_id=9, ilvl=2)
+
+    def test_direct_num_id_zero_disables_style_numbering(self, style_numbered_docx):
+        """Word's "remove numbering from this styled paragraph" marker: a
+        present direct ``numId=0`` decides — the style's numbering must
+        NOT leak back in as a fallback.
+        """
+        with Document.open(style_numbered_docx) as doc:
+            loc = doc.get_paragraph_location(_ref_for_text(doc, "Direct disable"))
+            assert loc.list is None
+
+    def test_direct_ilvl_only_block_is_not_merged_with_style(self, style_numbered_docx):
+        """A direct ``w:numPr`` carrying only ``w:ilvl`` (no ``w:numId``)
+        decides by presence: no ``ListItem``, and the style's ``numId`` is
+        not merged in — the documented non-merge limitation.
+        """
+        with Document.open(style_numbered_docx) as doc:
+            loc = doc.get_paragraph_location(_ref_for_text(doc, "Ilvl only"))
+            assert loc.list is None
+
+    def test_style_num_id_zero_terminates_chain(self, style_numbered_docx):
+        """A style whose own ``numId=0`` disables the numbering it would
+        otherwise inherit via ``basedOn``.
+        """
+        with Document.open(style_numbered_docx) as doc:
+            loc = doc.get_paragraph_location(_ref_for_text(doc, "Disabled style"))
+            assert loc.list is None
+
+    def test_based_on_cycle_degrades_to_none(self, style_numbered_docx):
+        """A ``basedOn`` cycle must terminate (visited guard), yielding no
+        numbering."""
+        with Document.open(style_numbered_docx) as doc:
+            loc = doc.get_paragraph_location(_ref_for_text(doc, "Cycle styled"))
+            assert loc.list is None
+
+    def test_non_paragraph_styles_are_ignored(self, style_numbered_docx):
+        with Document.open(style_numbered_docx) as doc:
+            loc = doc.get_paragraph_location(_ref_for_text(doc, "Char styled"))
+            assert loc.list is None
+
+    def test_plain_paragraph_reports_none(self, style_numbered_docx):
+        with Document.open(style_numbered_docx) as doc:
+            loc = doc.get_paragraph_location(_ref_for_text(doc, "Plain paragraph"))
+            assert loc.list is None
+
+    def test_batch_equivalence_with_per_call_accessor(self, style_numbered_docx):
+        with Document.open(style_numbered_docx) as doc:
+            entries = doc.list_paragraph_locations()
+            for ref, loc in entries:
+                assert loc == doc.get_paragraph_location(ref)
+            assert any(loc.list is not None for _, loc in entries)
+
+
 class TestMissingStylesPart:
     """A document without ``word/styles.xml`` degrades gracefully."""
 
@@ -1121,6 +1265,25 @@ class TestMissingStylesPart:
             assert entries
             for ref, loc in entries:
                 assert loc == doc.get_paragraph_location(ref)
+
+    def test_style_numbering_degrades_to_none(self, simple_docx, tmp_path):
+        """A pStyle-numbered paragraph reports ``list=None`` when there is
+        no ``word/styles.xml`` to resolve the style's numbering from.
+        """
+        body = (
+            '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+            f"<w:document {_W_NS}>"
+            "<w:body>"
+            f"<w:p>{_p_style('ListNumber')}<w:r><w:t>Styled number</w:t></w:r></w:p>"
+            "</w:body>"
+            "</w:document>"
+        )
+        dest = tmp_path / "no-styles-numbered.docx"
+        replace_docx_parts(simple_docx, dest, {"word/document.xml": body, "word/styles.xml": None})
+        with Document.open(dest) as doc:
+            loc = doc.get_paragraph_location(_ref_for_text(doc, "Styled number"))
+            assert loc.style == "ListNumber"
+            assert loc.list is None
 
 
 class TestListParagraphLocationsStyleInfo:


### PR DESCRIPTION
## Summary

Resolves ISSUES.md item #36 (completes #26): `ParagraphLocation.list` now reports numbering that a paragraph inherits from its style, instead of `None`.

- A paragraph numbered only via `w:pStyle` (numbering defined in `word/styles.xml`) now reports a `ListItem(num_id, ilvl)`; `w:basedOn` chains are resolved with a visited-set cycle guard.
- A **direct** `w:pPr/w:numPr` always wins by presence — including Word's `numId=0` "numbering disabled" marker, which reports `None` with no style fallback (matches OOXML direct-formatting override semantics).
- Structural mirror of the outline-level style-chain resolution merged in #42: `_build_style_numbering_map` follows `_build_style_outline_map` exactly; `Document._style_maps()` now builds both maps from a single `styles.xml` parse.
- Documented intentional limitations: rendered display numbers ("7.2(a)") are not computed, `numbering.xml` `w:lvl/w:pStyle` level associations are not resolved, and a direct ilvl-only `w:numPr` block is not merged with the style's `numId` (pinned by a test).

## Changes

- `docx_editor/xml_editor.py`: factor `_parse_num_pr`, add `_build_style_numbering_map`, extend `_extract_list_item` with style fallback
- `docx_editor/document.py`: fold `_style_outline_map()` into `_style_maps()` (one parse, two maps), thread `style_numbering` through both location accessors
- `tests/test_paragraph_location.py`: new `TestStyleNumberingChain` (11 tests) + missing-styles degradation test
- `docs/api.md`, `skills/docx/SKILL.md`, docstrings: updated semantics in all documented locations

## Test plan

- `uv run pytest` — 951 passed, 2 skipped
- `uv run ruff check .` / `format --check` — clean
- `uv run ty check` — exit 0 (6 warnings pre-existing in untouched test files)