### PR TITLE
feat: revision location, nesting state, and markup view in list_revisions (ISSUES.md #33)

### DIFF
--- a/docx_editor/document.py
+++ b/docx_editor/document.py
@@ -619,7 +619,9 @@ class Document:
 
         A verification view for humans and agents (e.g. checking redlines
         without accepting them), not a parseable format: author names are
-        not escaped, and tabs/breaks are not rendered.
+        not escaped, tabs/breaks are not rendered, and text inside a
+        drawing's text box appears both inline in the host paragraph's line
+        and again as its own line (same as get_text()).
 
         Returns:
             The marked-up text content
@@ -932,7 +934,7 @@ class Document:
 
         Example:
             # Reviewer workflow: inspect one paragraph's revisions, then act.
-            for ref, location in doc.list_paragraph_locations():
+            for ref in doc.list_paragraphs(max_chars=0):
                 for r in doc.list_revisions(paragraph=ref):
                     print(f"{r.id}: {r.type} '{r.text}' by {r.author}")
             doc.accept_revision(3)

--- a/docx_editor/document.py
+++ b/docx_editor/document.py
@@ -589,6 +589,30 @@ class Document:
             parts.append(tm.text)
         return "\n".join(parts)
 
+    def get_markup_text(self) -> str:
+        """Get document text with tracked changes rendered inline.
+
+        Paragraphs are separated by newlines; insertions render as
+        ``[ins#{id}:{author}]...[/ins]`` and deletions as
+        ``[del#{id}:{author}]...[/del]``, nesting included — a foreign
+        deletion inside a pending insertion renders as
+        ``[ins#1:A]kept [del#9:B]gone[/del][/ins]``.
+
+        A verification view for humans and agents (e.g. checking redlines
+        without accepting them), not a parseable format: author names are
+        not escaped, and tabs/breaks are not rendered.
+
+        Returns:
+            The marked-up text content
+
+        Example:
+            doc.replace("30 days", "60 days", paragraph="P2#f3c1")
+            print(doc.get_markup_text())
+            # ... [del#3:Reviewer]30 days[/del][ins#4:Reviewer]60 days[/ins] ...
+        """
+        self._ensure_open()
+        return self._revision_manager.get_markup_text()
+
     def replace(self, find: str, replace_with: str, *, paragraph: str, occurrence: int = 0) -> str:
         """Replace text with tracked changes.
 
@@ -861,22 +885,39 @@ class Document:
 
     # ==================== Revision Management API ====================
 
-    def list_revisions(self, author: str | None = None) -> list[Revision]:
+    def list_revisions(self, author: str | None = None, paragraph: str | None = None) -> list[Revision]:
         """List all tracked changes in the document.
 
         Args:
             author: If provided, filter by author name
+            paragraph: If provided, a paragraph reference from
+                list_paragraphs() (e.g. "P2#f3c1"); only revisions inside
+                that paragraph are returned.
 
         Returns:
-            List of Revision objects
+            List of Revision objects sorted by id. Each carries location
+            fields: ``paragraph_ref`` (hash-anchored ref of its containing
+            paragraph), ``occurrence`` (0-based index of the revision's text
+            within that paragraph — plugs into the ``occurrence=`` parameter
+            of replace()/delete()/add_comment(); None when the text is
+            not locatable, e.g. nested revisions), plus ``nested_under`` and
+            ``contains_ids`` describing revision nesting (e.g. a foreign
+            deletion inside another author's pending insertion).
+
+        Raises:
+            ValueError: If ``paragraph`` is malformed
+            ParagraphIndexError: If the paragraph index is out of range
+            HashMismatchError: If the paragraph hash doesn't match current content
 
         Example:
-            revisions = doc.list_revisions()
-            for r in revisions:
-                print(f"{r.type}: {r.text} by {r.author}")
+            # Reviewer workflow: inspect one paragraph's revisions, then act.
+            for ref, location in doc.list_paragraph_locations():
+                for r in doc.list_revisions(paragraph=ref):
+                    print(f"{r.id}: {r.type} '{r.text}' by {r.author}")
+            doc.accept_revision(3)
         """
         self._ensure_open()
-        return self._revision_manager.list_revisions(author=author)
+        return self._revision_manager.list_revisions(author=author, paragraph=paragraph)
 
     def accept_revision(self, revision_id: int) -> bool:
         """Accept a revision by ID.

--- a/docx_editor/document.py
+++ b/docx_editor/document.py
@@ -898,9 +898,11 @@ class Document:
             List of Revision objects sorted by id. Each carries location
             fields: ``paragraph_ref`` (hash-anchored ref of its containing
             paragraph), ``occurrence`` (0-based index of the revision's text
-            within that paragraph — plugs into the ``occurrence=`` parameter
-            of replace()/delete()/add_comment(); None when the text is
-            not locatable, e.g. nested revisions), plus ``nested_under`` and
+            within that paragraph — for insertions it plugs into the
+            ``occurrence=`` parameter of replace()/delete()/add_comment();
+            for deletions it counts in the original, pre-revision text and
+            must not be passed to those APIs; None when the text is not
+            locatable, e.g. nested revisions), plus ``nested_under`` and
             ``contains_ids`` describing revision nesting (e.g. a foreign
             deletion inside another author's pending insertion).
 

--- a/docx_editor/track_changes.py
+++ b/docx_editor/track_changes.py
@@ -1978,7 +1978,7 @@ class RevisionManager:
                     continue
                 if child.tagName in ("w:ins", "w:del"):
                     kind = "ins" if child.tagName == "w:ins" else "del"
-                    rev_id = child.getAttribute("w:id")
+                    rev_id = child.getAttribute("w:id") or "?"
                     rev_author = child.getAttribute("w:author") or "Unknown"
                     parts.append(f"[{kind}#{rev_id}:{rev_author}]{render(child)}[/{kind}]")
                 elif child.tagName in ("w:t", "w:delText"):

--- a/docx_editor/track_changes.py
+++ b/docx_editor/track_changes.py
@@ -203,17 +203,167 @@ class _LocatedMatch:
 
 @dataclass
 class Revision:
-    """Represents a tracked change (insertion or deletion)."""
+    """Represents a tracked change (insertion or deletion).
+
+    Location and nesting fields are populated by ``list_revisions``:
+
+    - ``paragraph_ref``: hash-anchored reference (``"P{i}#{hash}"``) of the
+      containing paragraph, or None when the revision sits outside any
+      ``<w:p>`` (e.g. ``<w:trPr>`` row markers).
+    - ``occurrence``: 0-based occurrence index of ``text`` within the
+      containing paragraph, counted in the view where the revision's text
+      lives — the accepted (visible) view for insertions, the original
+      (pre-revision) view for deletions. For insertions it plugs directly
+      into the ``occurrence=`` parameter of replace()/delete()/
+      add_comment(). None whenever targeting-by-text does not apply: empty
+      text, a host insertion whose original text no longer matches its
+      visible span (a nested deletion consumed part of it), or a nested
+      deletion (its text never existed in the original document).
+    - ``nested_under``: id of the nearest enclosing revision (e.g. a foreign
+      deletion inside another author's pending insertion), else None.
+    - ``contains_ids``: ids of revisions nested inside this one, in document
+      order.
+    """
 
     id: int
     type: Literal["insertion", "deletion"]
     author: str
     date: datetime | None
     text: str
+    paragraph_ref: str | None = None
+    occurrence: int | None = None
+    nested_under: int | None = None
+    contains_ids: tuple[int, ...] = ()
 
     def __repr__(self) -> str:
-        type_symbol = "+" if self.type == "insertion" else "-"
-        return f"Revision({type_symbol}{self.id}: '{self.text[:30]}...' by {self.author})"
+        kind = "ins" if self.type == "insertion" else "del"
+        location = f" @{self.paragraph_ref}" if self.paragraph_ref else ""
+        preview = self.text[:30] + ("..." if len(self.text) > 30 else "")
+        nested = f", nested_under={self.nested_under}" if self.nested_under is not None else ""
+        contains = f", contains={list(self.contains_ids)}" if self.contains_ids else ""
+        return f"Revision({kind} {self.id}{location}: '{preview}' by {self.author}{nested}{contains})"
+
+
+def _ancestor_paragraph(elem) -> Element | None:
+    """Nearest <w:p> ancestor of ``elem``, or None if outside any paragraph."""
+    node = elem.parentNode
+    while node is not None and node.nodeType == node.ELEMENT_NODE:
+        if node.tagName == "w:p":
+            return node
+        node = node.parentNode
+    return None
+
+
+def _nearest_revision_ancestor_id(elem) -> int | None:
+    """id of the closest <w:ins>/<w:del> ancestor carrying a w:id, else None."""
+    node = elem.parentNode
+    while node is not None and node.nodeType == node.ELEMENT_NODE:
+        if node.tagName in ("w:ins", "w:del"):
+            rev_id = node.getAttribute("w:id")
+            if rev_id:
+                return int(rev_id)
+        node = node.parentNode
+    return None
+
+
+def _descendant_revision_ids(elem) -> tuple[int, ...]:
+    """ids of all <w:ins>/<w:del> descendants of ``elem``, in document order."""
+    ids: list[int] = []
+
+    def walk(node) -> None:
+        for child in node.childNodes:
+            if child.nodeType != child.ELEMENT_NODE:
+                continue
+            if child.tagName in ("w:ins", "w:del"):
+                rev_id = child.getAttribute("w:id")
+                if rev_id:
+                    ids.append(int(rev_id))
+            walk(child)
+
+    walk(elem)
+    return tuple(ids)
+
+
+def _insertion_text_nodes(elem) -> list:
+    """All <w:t>/<w:delText> descendants of a <w:ins>, in document order.
+
+    Including <w:delText> means a host insertion whose content was later
+    deleted by a nested <w:del> still reports the full text it originally
+    inserted (plain <w:delText> never appears under <w:ins> otherwise).
+    """
+    nodes: list = []
+
+    def walk(node) -> None:
+        for child in node.childNodes:
+            if child.nodeType != child.ELEMENT_NODE:
+                continue
+            if child.tagName in ("w:t", "w:delText"):
+                nodes.append(child)
+            else:
+                walk(child)
+
+    walk(elem)
+    return nodes
+
+
+def _has_ancestor(node, ancestor) -> bool:
+    """True if ``ancestor`` is ``node`` itself or one of its ancestors."""
+    current = node
+    while current is not None:
+        if current is ancestor:
+            return True
+        current = current.parentNode
+    return False
+
+
+def _occurrence_in_text_map(tm: TextMap, elem, text: str) -> int | None:
+    """0-based occurrence index of ``text`` at ``elem``'s own span in ``tm``.
+
+    Mirrors ``find_in_text_map``'s stepping (``idx + 1`` between matches) so
+    the result plugs directly into the ``occurrence=`` parameter of the
+    anchor APIs. Returns None when the revision's span cannot be equated
+    with ``text``: no position in the map belongs to ``elem``, or the map
+    text at the span's start doesn't spell ``text``.
+    """
+    if not text:
+        return None
+    start = next((i for i, pos in enumerate(tm.positions) if _has_ancestor(pos.node, elem)), None)
+    if start is None:
+        return None
+    if not tm.text.startswith(text, start):
+        return None
+    count = 0
+    idx = tm.text.find(text)
+    while idx != -1 and idx < start:
+        count += 1
+        idx = tm.text.find(text, idx + 1)
+    return count
+
+
+class _RevisionLocationContext:
+    """Per-``list_revisions``-call cache of paragraph indexes, refs, and text maps."""
+
+    def __init__(self, dom):
+        self._p_index = {id(p): i for i, p in enumerate(dom.getElementsByTagName("w:p"), start=1)}
+        self._refs: dict[int, str] = {}
+        self._maps: dict[tuple[int, str], TextMap] = {}
+
+    def paragraph_ref(self, p) -> str | None:
+        """Hash-anchored ref ("P{i}#{hash}") of ``p``; None if not indexed."""
+        key = id(p)
+        index = self._p_index.get(key)
+        if index is None:
+            return None
+        if key not in self._refs:
+            self._refs[key] = f"P{index}#{compute_paragraph_hash(p)}"
+        return self._refs[key]
+
+    def text_map(self, p, view: Literal["accepted", "original"]) -> TextMap:
+        """Cached text map of ``p`` for ``view``."""
+        key = (id(p), view)
+        if key not in self._maps:
+            self._maps[key] = build_text_map(p, view=view)
+        return self._maps[key]
 
 
 class RevisionManager:
@@ -1729,35 +1879,101 @@ class RevisionManager:
                 return int(node.getAttribute("w:id"))
         return -1
 
-    def list_revisions(self, author: str | None = None) -> list[Revision]:
+    def list_revisions(self, author: str | None = None, paragraph: str | None = None) -> list[Revision]:
         """List all tracked changes in the document.
 
         Args:
             author: If provided, filter by author name
+            paragraph: If provided, a paragraph reference (e.g. "P3#a7b2")
+                from list_paragraphs(); only revisions inside that paragraph
+                are returned.
 
         Returns:
-            List of Revision objects
+            List of Revision objects sorted by id, with location and nesting
+            fields populated — see :class:`Revision`.
+
+        Raises:
+            ValueError: If ``paragraph`` is malformed
+            ParagraphIndexError: If the paragraph index is out of range
+            HashMismatchError: If the paragraph hash doesn't match current content
         """
+        paragraph_filter = None
+        if paragraph is not None:
+            ref = ParagraphRef.parse(paragraph)
+            self._resolve_paragraph(ref)  # validates index and hash
+            paragraph_filter = f"P{ref.index}#{ref.hash}"
+
+        ctx = _RevisionLocationContext(self.editor.dom)
+
+        def matches(rev: Revision | None) -> bool:
+            if rev is None:
+                return False
+            if author is not None and rev.author != author:
+                return False
+            return paragraph_filter is None or rev.paragraph_ref == paragraph_filter
+
         revisions = []
 
         # Find all insertions
         for ins_elem in self.editor.dom.getElementsByTagName("w:ins"):
-            rev = self._parse_revision(ins_elem, "insertion")
-            if rev and (author is None or rev.author == author):
+            rev = self._parse_revision(ins_elem, "insertion", ctx)
+            if matches(rev):
                 revisions.append(rev)
 
         # Find all deletions
         for del_elem in self.editor.dom.getElementsByTagName("w:del"):
-            rev = self._parse_revision(del_elem, "deletion")
-            if rev and (author is None or rev.author == author):
+            rev = self._parse_revision(del_elem, "deletion", ctx)
+            if matches(rev):
                 revisions.append(rev)
 
         # Sort by ID
         revisions.sort(key=lambda r: r.id)
         return revisions
 
-    def _parse_revision(self, elem, rev_type: Literal["insertion", "deletion"]) -> Revision | None:
-        """Parse a w:ins or w:del element into a Revision object."""
+    def get_markup_text(self) -> str:
+        """Render document text with inline revision markup.
+
+        Each paragraph is one line; tracked changes wrap their content as
+        ``[ins#{id}:{author}]...[/ins]`` / ``[del#{id}:{author}]...[/del]``,
+        nesting included (e.g. ``[ins#1:A]kept [del#9:B]gone[/del][/ins]``).
+
+        A human/agent verification view, not a parseable format: author
+        names are not escaped, and tabs/breaks/drawings are not rendered
+        (same limitation as the text map).
+        """
+
+        def render(node) -> str:
+            parts: list[str] = []
+            for child in node.childNodes:
+                if child.nodeType != child.ELEMENT_NODE:
+                    continue
+                if child.tagName in ("w:ins", "w:del"):
+                    kind = "ins" if child.tagName == "w:ins" else "del"
+                    rev_id = child.getAttribute("w:id")
+                    rev_author = child.getAttribute("w:author") or "Unknown"
+                    parts.append(f"[{kind}#{rev_id}:{rev_author}]{render(child)}[/{kind}]")
+                elif child.tagName in ("w:t", "w:delText"):
+                    parts.append(get_text_node_data(child))
+                else:
+                    parts.append(render(child))
+            return "".join(parts)
+
+        return "\n".join(render(p) for p in self.editor.dom.getElementsByTagName("w:p"))
+
+    def _parse_revision(
+        self,
+        elem,
+        rev_type: Literal["insertion", "deletion"],
+        ctx: _RevisionLocationContext | None = None,
+    ) -> Revision | None:
+        """Parse a w:ins or w:del element into a Revision object.
+
+        Args:
+            elem: The <w:ins>/<w:del> element
+            rev_type: Which kind of revision ``elem`` is
+            ctx: Per-call location cache from list_revisions. None (detached
+                elements, unit tests) leaves paragraph_ref/occurrence unset.
+        """
         rev_id = elem.getAttribute("w:id")
         if not rev_id:
             return None
@@ -1772,7 +1988,7 @@ class RevisionManager:
 
         # Extract text content
         if rev_type == "insertion":
-            text_elems = elem.getElementsByTagName("w:t")
+            text_elems = _insertion_text_nodes(elem)
         else:
             text_elems = elem.getElementsByTagName("w:delText")
             if not text_elems:
@@ -1781,14 +1997,30 @@ class RevisionManager:
                 # no w:delText at all; mixed content reads only w:delText.
                 text_elems = elem.getElementsByTagName("w:t")
 
-        text_parts = [self._get_node_text(t_elem) for t_elem in text_elems]
+        text = "".join(self._get_node_text(t_elem) for t_elem in text_elems)
+
+        paragraph_ref = None
+        occurrence = None
+        if ctx is not None:
+            paragraph = _ancestor_paragraph(elem)
+            if paragraph is not None:
+                paragraph_ref = ctx.paragraph_ref(paragraph)
+                if text:
+                    # Insertions live in the visible text; deletions in the
+                    # original (pre-revision) text.
+                    view: Literal["accepted", "original"] = "accepted" if rev_type == "insertion" else "original"
+                    occurrence = _occurrence_in_text_map(ctx.text_map(paragraph, view), elem, text)
 
         return Revision(
             id=int(rev_id),
             type=rev_type,
             author=author,
             date=date,
-            text="".join(text_parts),
+            text=text,
+            paragraph_ref=paragraph_ref,
+            occurrence=occurrence,
+            nested_under=_nearest_revision_ancestor_id(elem),
+            contains_ids=_descendant_revision_ids(elem),
         )
 
     def accept_revision(self, revision_id: int) -> bool:

--- a/docx_editor/track_changes.py
+++ b/docx_editor/track_changes.py
@@ -27,6 +27,7 @@ from .xml_editor import (
     _escape_xml,
     build_text_map,
     compute_paragraph_hash,
+    compute_text_hash,
     find_in_text_map,
     get_rPr_xml,
     get_text_node_data,
@@ -245,7 +246,12 @@ class Revision:
 
 
 def _ancestor_paragraph(elem) -> Element | None:
-    """Nearest <w:p> ancestor of ``elem``, or None if outside any paragraph."""
+    """Nearest <w:p> ancestor of ``elem``, or None if outside any paragraph.
+
+    Not replaceable by ``xml_editor._innermost_ancestor``: this loop also
+    stops at the first non-element ancestor, so it terminates even on node
+    chains whose ``parentNode`` never yields None (mock DOMs in tests).
+    """
     node = elem.parentNode
     while node is not None and node.nodeType == node.ELEMENT_NODE:
         if node.tagName == "w:p":
@@ -322,8 +328,11 @@ def _occurrence_in_text_map(tm: TextMap, elem, text: str) -> int | None:
     Mirrors ``find_in_text_map``'s stepping (``idx + 1`` between matches) so
     the result plugs directly into the ``occurrence=`` parameter of the
     anchor APIs. Returns None when the revision's span cannot be equated
-    with ``text``: no position in the map belongs to ``elem``, or the map
-    text at the span's start doesn't spell ``text``.
+    with ``text``: no position in the map belongs to ``elem``, the map
+    text at the span's start doesn't spell ``text``, or the spelled-out
+    span extends beyond ``elem`` (e.g. a partially consumed host insertion
+    whose missing suffix happens to be spelled by the following text —
+    anchoring there would silently cross the revision boundary).
     """
     if not text:
         return None
@@ -331,6 +340,8 @@ def _occurrence_in_text_map(tm: TextMap, elem, text: str) -> int | None:
     if start is None:
         return None
     if not tm.text.startswith(text, start):
+        return None
+    if not all(_has_ancestor(pos.node, elem) for pos in tm.positions[start : start + len(text)]):
         return None
     count = 0
     idx = tm.text.find(text)
@@ -355,7 +366,9 @@ class _RevisionLocationContext:
         if index is None:
             return None
         if key not in self._refs:
-            self._refs[key] = f"P{index}#{compute_paragraph_hash(p)}"
+            # Hash from the cached accepted map, shared with the occurrence
+            # path, instead of compute_paragraph_hash (which builds its own).
+            self._refs[key] = f"P{index}#{compute_text_hash(self.text_map(p, 'accepted').text)}"
         return self._refs[key]
 
     def text_map(self, p, view: Literal["accepted", "original"]) -> TextMap:
@@ -1879,7 +1892,13 @@ class RevisionManager:
                 return int(node.getAttribute("w:id"))
         return -1
 
-    def list_revisions(self, author: str | None = None, paragraph: str | None = None) -> list[Revision]:
+    def list_revisions(
+        self,
+        author: str | None = None,
+        paragraph: str | None = None,
+        *,
+        with_location: bool = True,
+    ) -> list[Revision]:
         """List all tracked changes in the document.
 
         Args:
@@ -1887,6 +1906,12 @@ class RevisionManager:
             paragraph: If provided, a paragraph reference (e.g. "P3#a7b2")
                 from list_paragraphs(); only revisions inside that paragraph
                 are returned.
+            with_location: If False, skip computing ``paragraph_ref`` and
+                ``occurrence`` (they stay None) — the location work builds a
+                text map and hash per revision-bearing paragraph, wasted on
+                callers that only need ids (accept_all/reject_all re-list on
+                every pass). Forced True when ``paragraph`` is given, since
+                the filter matches on ``paragraph_ref``.
 
         Returns:
             List of Revision objects sorted by id, with location and nesting
@@ -1903,7 +1928,9 @@ class RevisionManager:
             self._resolve_paragraph(ref)  # validates index and hash
             paragraph_filter = f"P{ref.index}#{ref.hash}"
 
-        ctx = _RevisionLocationContext(self.editor.dom)
+        ctx = None
+        if with_location or paragraph_filter is not None:
+            ctx = _RevisionLocationContext(self.editor.dom)
 
         def matches(rev: Revision | None) -> bool:
             if rev is None:
@@ -1938,8 +1965,9 @@ class RevisionManager:
         nesting included (e.g. ``[ins#1:A]kept [del#9:B]gone[/del][/ins]``).
 
         A human/agent verification view, not a parseable format: author
-        names are not escaped, and tabs/breaks/drawings are not rendered
-        (same limitation as the text map).
+        names are not escaped, tabs/breaks are not rendered, and text inside
+        a drawing's text box appears both inline in the host paragraph's
+        line and again as its own line (same as get_text()).
         """
 
         def render(node) -> str:
@@ -2101,7 +2129,8 @@ class RevisionManager:
         while True:
             progressed = False
             # Process in reverse order by ID to avoid index issues
-            for rev in sorted(self.list_revisions(author=author), key=lambda r: r.id, reverse=True):
+            revisions = self.list_revisions(author=author, with_location=False)
+            for rev in sorted(revisions, key=lambda r: r.id, reverse=True):
                 if self.accept_revision(rev.id):
                     count += 1
                     progressed = True
@@ -2128,7 +2157,8 @@ class RevisionManager:
         while True:
             progressed = False
             # Process in reverse order by ID to avoid index issues
-            for rev in sorted(self.list_revisions(author=author), key=lambda r: r.id, reverse=True):
+            revisions = self.list_revisions(author=author, with_location=False)
+            for rev in sorted(revisions, key=lambda r: r.id, reverse=True):
                 if self.reject_revision(rev.id):
                     count += 1
                     progressed = True

--- a/docx_editor/track_changes.py
+++ b/docx_editor/track_changes.py
@@ -1914,8 +1914,9 @@ class RevisionManager:
                 the filter matches on ``paragraph_ref``.
 
         Returns:
-            List of Revision objects sorted by id, with location and nesting
-            fields populated — see :class:`Revision`.
+            List of Revision objects sorted by id — see :class:`Revision`.
+            Nesting fields are always populated; the location fields
+            (``paragraph_ref``/``occurrence``) unless ``with_location=False``.
 
         Raises:
             ValueError: If ``paragraph`` is malformed

--- a/docx_editor/xml_editor.py
+++ b/docx_editor/xml_editor.py
@@ -132,13 +132,22 @@ class ParagraphInfo:
         return f"{self.ref}| {self.text}"
 
 
+def compute_text_hash(text: str) -> str:
+    """4-char hex CRC32 hash of a paragraph's visible text.
+
+    Single source of the hash formula behind ``"P{i}#{hash}"`` refs. Use
+    :func:`compute_paragraph_hash` unless the caller already holds the
+    paragraph's accepted-view text map.
+    """
+    return f"{zlib.crc32(text.encode('utf-8')) & 0xFFFF:04x}"
+
+
 def compute_paragraph_hash(paragraph) -> str:
     """Compute a 4-char hex content hash for a paragraph element.
 
     Uses CRC32 of the paragraph's visible text (from build_text_map).
     """
-    text = build_text_map(paragraph).text
-    return f"{zlib.crc32(text.encode('utf-8')) & 0xFFFF:04x}"
+    return compute_text_hash(build_text_map(paragraph).text)
 
 
 @dataclass(frozen=True)

--- a/skills/docx/SKILL.md
+++ b/skills/docx/SKILL.md
@@ -350,8 +350,10 @@ their_changes = doc.list_revisions(author="OtherUser")
 para_changes = doc.list_revisions(paragraph="P3#a7b2")
 
 # For INSERTIONS, r.paragraph_ref/r.occurrence plug straight into the anchor
-# APIs (occurrence is 0-based, same convention as replace/delete/add_comment):
-r = next(r for r in doc.list_revisions() if r.type == "insertion")
+# APIs (occurrence is 0-based, same convention as replace/delete/add_comment).
+# Filter on occurrence is not None — even an insertion can be unlocatable
+# (see the None cases below):
+r = next(r for r in doc.list_revisions() if r.type == "insertion" and r.occurrence is not None)
 doc.add_comment(r.text, "please confirm", paragraph=r.paragraph_ref, occurrence=r.occurrence)
 
 # Accept or reject individual revisions (return True if found, False if not).
@@ -410,7 +412,8 @@ print(doc.get_markup_text())
 ```
 
 A human/agent verification view, not a parseable format (author names are not
-escaped; tabs/breaks are not rendered).
+escaped; tabs/breaks are not rendered; text inside a drawing's text box
+appears both inline and again as its own line, same as `get_text()`).
 
 ### Reviewing Someone Else's Redlines
 

--- a/skills/docx/SKILL.md
+++ b/skills/docx/SKILL.md
@@ -321,9 +321,9 @@ their_changes = doc.list_revisions(author="OtherUser")
 # Filter to one paragraph (ref from list_paragraphs())
 para_changes = doc.list_revisions(paragraph="P3#a7b2")
 
-# r.paragraph_ref/r.occurrence plug straight into the anchor APIs
-# (occurrence is 0-based, same convention as replace/delete/add_comment):
-r = doc.list_revisions()[0]
+# For INSERTIONS, r.paragraph_ref/r.occurrence plug straight into the anchor
+# APIs (occurrence is 0-based, same convention as replace/delete/add_comment):
+r = next(r for r in doc.list_revisions() if r.type == "insertion")
 doc.add_comment(r.text, "please confirm", paragraph=r.paragraph_ref, occurrence=r.occurrence)
 
 # Accept or reject individual revisions (return True if found, False if not)
@@ -347,6 +347,12 @@ text (paragraph-mark markers), a host insertion whose text was partly consumed
 by a nested deletion, or a nested deletion itself (its text never existed in
 the original document). Never treat `None` as `0` — in every `None` case,
 `nested_under`/`contains_ids` describe the revision instead.
+
+**Deletion occurrences count in the original (pre-revision) text**, where the
+deleted span still exists — they locate the deletion for reporting, but must
+NOT be passed to replace/delete/add_comment, which search the visible text
+(an earlier inserted copy of the same text would shift the count and silently
+anchor the wrong span). Only insertion occurrences feed the anchor APIs.
 
 **Nested revisions**: when a reviewer deletes text inside another author's
 pending insertion (Word and this library both produce this), the deletion

--- a/skills/docx/SKILL.md
+++ b/skills/docx/SKILL.md
@@ -310,9 +310,21 @@ doc = Document.open("reviewed.docx", author=author)
 revisions = doc.list_revisions()
 for r in revisions:
     print(f"ID: {r.id}, Type: {r.type}, Author: {r.author}, Text: {r.text}")
+    # Location: which paragraph the revision lives in, and where in it
+    print(f"  at {r.paragraph_ref} occurrence={r.occurrence}")
+    # Nesting: e.g. a foreign deletion inside another author's insertion
+    print(f"  nested_under={r.nested_under} contains_ids={r.contains_ids}")
 
 # Filter by author
 their_changes = doc.list_revisions(author="OtherUser")
+
+# Filter to one paragraph (ref from list_paragraphs())
+para_changes = doc.list_revisions(paragraph="P3#a7b2")
+
+# r.paragraph_ref/r.occurrence plug straight into the anchor APIs
+# (occurrence is 0-based, same convention as replace/delete/add_comment):
+r = doc.list_revisions()[0]
+doc.add_comment(r.text, "please confirm", paragraph=r.paragraph_ref, occurrence=r.occurrence)
 
 # Accept or reject individual revisions (return True if found, False if not)
 doc.accept_revision(revision_id=1)
@@ -329,6 +341,34 @@ doc.reject_all(author="OtherUser")
 doc.save()
 doc.close()
 ```
+
+**`occurrence` is None when targeting-by-text does not apply**: empty revision
+text (paragraph-mark markers), a host insertion whose text was partly consumed
+by a nested deletion, or a nested deletion itself (its text never existed in
+the original document). Never treat `None` as `0` — in every `None` case,
+`nested_under`/`contains_ids` describe the revision instead.
+
+**Nested revisions**: when a reviewer deletes text inside another author's
+pending insertion (Word and this library both produce this), the deletion
+nests inside the insertion. The host insertion's `text` reports the full text
+it originally inserted; `contains_ids` lists the nested revision ids, and the
+nested deletion's `nested_under` points back at its host. Accepting the host
+insertion keeps its content **and** the nested deletion pending; rejecting the
+host removes the nested deletion along with it. Predict the outcome, then
+verify with `get_markup_text()`.
+
+### Inline markup view (verify redlines without pandoc)
+
+```python
+# Every paragraph on one line; revisions wrapped inline:
+#   Keep [ins#4:Reviewer]added[/ins][del#3:Reviewer]removed[/del]
+# Nesting renders naturally:
+#   [ins#1:A]kept [del#9:B]gone[/del][/ins]
+print(doc.get_markup_text())
+```
+
+A human/agent verification view, not a parseable format (author names are not
+escaped; tabs/breaks are not rendered).
 
 ## Redlining Workflow (Document Review)
 

--- a/tests/test_foreign_revisions.py
+++ b/tests/test_foreign_revisions.py
@@ -31,7 +31,13 @@ from conftest import find_ref, replace_document_xml
 
 from docx_editor import Document, Revision
 
-# Ground truth for OXML_TrackChanges_Test.docx.
+# Ground truth for OXML_TrackChanges_Test.docx. Paragraph indexes account for
+# the fixture's two empty <w:p/> elements (before the title and before the
+# em-dash paragraph); hashes are CRC32 of each paragraph's visible text
+# including its trailing bracketed note run. None of the fixture's revisions
+# nest, so nested_under/contains_ids keep their defaults. Ids 1007/1008 carry
+# identical text in the same paragraph — type + occurrence (in each type's own
+# view) is what tells them apart.
 EXPECTED_REVISIONS = [
     Revision(
         id=1001,
@@ -39,6 +45,8 @@ EXPECTED_REVISIONS = [
         author="Test Author",
         date=datetime(2026, 1, 29, 16, 55, tzinfo=timezone.utc),
         text="inserted",
+        paragraph_ref="P3#e6b4",
+        occurrence=0,
     ),
     Revision(
         id=1002,
@@ -46,6 +54,8 @@ EXPECTED_REVISIONS = [
         author="Test Author",
         date=datetime(2026, 1, 29, 16, 56, tzinfo=timezone.utc),
         text="old ",
+        paragraph_ref="P4#1750",
+        occurrence=0,
     ),
     Revision(
         id=1003,
@@ -53,6 +63,8 @@ EXPECTED_REVISIONS = [
         author="Editor A",
         date=datetime(2026, 1, 29, 16, 57, tzinfo=timezone.utc),
         text="colour",
+        paragraph_ref="P5#a192",
+        occurrence=0,
     ),
     Revision(
         id=1004,
@@ -60,6 +72,8 @@ EXPECTED_REVISIONS = [
         author="Editor A",
         date=datetime(2026, 1, 29, 16, 57, 1, tzinfo=timezone.utc),
         text="color",
+        paragraph_ref="P5#a192",
+        occurrence=0,
     ),
     Revision(
         id=1005,
@@ -67,6 +81,8 @@ EXPECTED_REVISIONS = [
         author="Reviewer",
         date=datetime(2026, 1, 29, 16, 58, tzinfo=timezone.utc),
         text="reenter",
+        paragraph_ref="P6#975f",
+        occurrence=0,
     ),
     Revision(
         id=1006,
@@ -74,6 +90,8 @@ EXPECTED_REVISIONS = [
         author="Reviewer B",
         date=datetime(2026, 1, 29, 16, 59, tzinfo=timezone.utc),
         text="— or is it?",
+        paragraph_ref="P8#1b23",
+        occurrence=0,
     ),
     Revision(
         id=1007,
@@ -81,6 +99,8 @@ EXPECTED_REVISIONS = [
         author="Author A",
         date=datetime(2026, 1, 29, 17, 0, tzinfo=timezone.utc),
         text="DRAFT ",
+        paragraph_ref="P9#5772",
+        occurrence=0,
     ),
     Revision(
         id=1008,
@@ -88,6 +108,8 @@ EXPECTED_REVISIONS = [
         author="Author B",
         date=datetime(2026, 1, 29, 17, 0, 10, tzinfo=timezone.utc),
         text="DRAFT ",
+        paragraph_ref="P9#5772",
+        occurrence=0,
     ),
 ]
 

--- a/tests/test_revision_location.py
+++ b/tests/test_revision_location.py
@@ -230,6 +230,20 @@ class TestNestedRevisions:
         assert host.occurrence is None
         assert _rev(manager, 2).nested_under == 1
 
+    def test_partial_consume_host_unlocatable_even_when_following_text_matches(self, temp_xml):
+        """Following visible text spelling the deleted suffix must not fake a match.
+
+        The host's visible span is only "Hello "; the "world" completing
+        "Hello world" belongs to the run AFTER the insertion. An occurrence
+        here would anchor across the revision boundary — must be None.
+        """
+        ins_content = "<w:r><w:t>Hello </w:t></w:r>" + _del("<w:r><w:delText>world</w:delText></w:r>", del_id=2)
+        body = f"<w:p>{_ins(ins_content, ins_id=1)}<w:r><w:t>world peace</w:t></w:r></w:p>"
+        manager = _make_manager(temp_xml(body))
+        host = _rev(manager, 1)
+        assert host.text == "Hello world"
+        assert host.occurrence is None
+
     def test_unnested_revisions_have_default_nesting_fields(self, temp_xml):
         body = (
             "<w:p><w:r><w:t>keep </w:t></w:r>"
@@ -257,6 +271,28 @@ class TestNestedRevisions:
         assert len(hosts) == 1
         assert nested_del.nested_under == hosts[0].id
         assert nested_del.id in hosts[0].contains_ids
+
+
+class TestWithLocationFlag:
+    """with_location=False skips location work for id-only callers."""
+
+    def test_with_location_false_leaves_location_unset(self, temp_xml):
+        body = f"<w:p><w:r><w:t>keep </w:t></w:r>{_ins('<w:r><w:t>new</w:t></w:r>', ins_id=1)}</w:p>"
+        manager = _make_manager(temp_xml(body))
+        (rev,) = manager.list_revisions(with_location=False)
+        assert rev.paragraph_ref is None
+        assert rev.occurrence is None
+        # Nesting state is cheap and still reported.
+        assert rev.nested_under is None
+        assert rev.contains_ids == ()
+
+    def test_paragraph_filter_overrides_with_location_false(self, temp_xml):
+        body = f"<w:p><w:r><w:t>keep </w:t></w:r>{_ins('<w:r><w:t>new</w:t></w:r>', ins_id=1)}</w:p>"
+        manager = _make_manager(temp_xml(body))
+        ref = _rev(manager, 1).paragraph_ref
+        assert ref is not None
+        (rev,) = manager.list_revisions(paragraph=ref, with_location=False)
+        assert rev.paragraph_ref == ref
 
 
 class TestParagraphFilter:

--- a/tests/test_revision_location.py
+++ b/tests/test_revision_location.py
@@ -409,6 +409,12 @@ class TestGetMarkupText:
             "Plain\nKeep [ins#1:A]added[/ins][del#2:B]removed[/del]\n[ins#3:A]kept [del#4:B]gone[/del][/ins]"
         )
 
+    def test_markers_fall_back_on_missing_id_and_author(self, temp_xml):
+        """Malformed revisions render [ins#?:Unknown] instead of [ins#:]."""
+        body = "<w:p><w:ins><w:r><w:t>x</w:t></w:r></w:ins></w:p>"
+        manager = _make_manager(temp_xml(body))
+        assert manager.get_markup_text() == "[ins#?:Unknown]x[/ins]"
+
     def test_document_wrapper_shows_tracked_edit(self, temp_docx):
         with Document.open(temp_docx, author="Test Editor") as doc:
             ref = doc.list_paragraphs()[0].split("|")[0]

--- a/tests/test_revision_location.py
+++ b/tests/test_revision_location.py
@@ -1,0 +1,384 @@
+"""Tests for revision location and nested-state reporting (ISSUES.md #33).
+
+``list_revisions`` populates four location/nesting fields on ``Revision``:
+
+- ``paragraph_ref`` — hash-anchored ref of the containing paragraph, matching
+  ``list_paragraphs()`` output; None outside any ``<w:p>``.
+- ``occurrence`` — 0-based index of the revision's text within its paragraph,
+  in the view where that text lives (accepted for insertions, original for
+  deletions), so it plugs into the ``occurrence=`` parameter of the anchor
+  APIs. None whenever targeting-by-text does not apply (empty text, nested
+  deletions, host insertions partially consumed by a nested deletion).
+- ``nested_under`` / ``contains_ids`` — revision nesting, e.g. a foreign
+  deletion inside another author's pending insertion (produced by this
+  library's author-aware edits and by Word itself).
+
+Also covers ``list_revisions(paragraph=...)`` filtering and the
+``get_markup_text()`` verification view.
+"""
+
+from pathlib import Path
+
+import pytest
+from conftest import NS, find_ref, replace_document_xml
+
+from docx_editor import Document, HashMismatchError, ParagraphIndexError, Revision
+from docx_editor.track_changes import RevisionManager
+from docx_editor.xml_editor import DocxXMLEditor, compute_paragraph_hash
+
+AUTHOR_A = "Reviewer A"
+AUTHOR_B = "Reviewer B"
+DATE_A = "2024-01-01T00:00:00Z"
+DATE_B = "2024-01-02T00:00:00Z"
+
+
+@pytest.fixture
+def temp_xml(tmp_path):
+    """Fixture that returns a function to create temp XML files."""
+
+    def _create_xml(body_xml: str) -> Path:
+        xml = f'<?xml version="1.0" encoding="utf-8"?><w:document {NS}><w:body>{body_xml}</w:body></w:document>'
+        xml_path = tmp_path / "test_doc.xml"
+        xml_path.write_text(xml)
+        return xml_path
+
+    return _create_xml
+
+
+def _make_manager(xml_path: Path, author: str = AUTHOR_B) -> RevisionManager:
+    """Create a RevisionManager editing as ``author``."""
+    editor = DocxXMLEditor(xml_path, rsid="00000000", author=author)
+    return RevisionManager(editor)
+
+
+def _ins(content: str, ins_id: int = 1, author: str = AUTHOR_A) -> str:
+    return f'<w:ins w:id="{ins_id}" w:author="{author}" w:date="{DATE_A}">{content}</w:ins>'
+
+
+def _del(content: str, del_id: int = 2, author: str = AUTHOR_B) -> str:
+    return f'<w:del w:id="{del_id}" w:author="{author}" w:date="{DATE_B}">{content}</w:del>'
+
+
+def _rev(manager_or_doc, rev_id: int) -> Revision:
+    return next(r for r in manager_or_doc.list_revisions() if r.id == rev_id)
+
+
+class TestParagraphRef:
+    """paragraph_ref matches list_paragraphs() refs, including table cells."""
+
+    def test_refs_match_list_paragraphs_across_paragraphs(self, temp_docx):
+        with Document.open(temp_docx, author="Test Editor") as doc:
+            refs = [entry.split("|")[0] for entry in doc.list_paragraphs()]
+            first_ref, second_ref = refs[0], refs[1]
+            first_ref = doc.replace("Sample", "Example", paragraph=first_ref)
+            doc.delete("quick ", paragraph=second_ref)
+
+            revisions = doc.list_revisions()
+            assert revisions, "expected tracked changes"
+            current_refs = [entry.split("|")[0] for entry in doc.list_paragraphs()]
+            # replace() produces a del+ins pair in P1; delete() a del in P2.
+            p1_revs = [r for r in revisions if r.paragraph_ref == current_refs[0]]
+            p2_revs = [r for r in revisions if r.paragraph_ref == current_refs[1]]
+            assert {r.type for r in p1_revs} == {"insertion", "deletion"}
+            assert [r.type for r in p2_revs] == ["deletion"]
+            assert len(p1_revs) + len(p2_revs) == len(revisions)
+            assert first_ref == current_refs[0]
+
+    def test_refs_in_table_cells(self, simple_docx, tmp_path):
+        body = (
+            "<w:p><w:r><w:t>Body para</w:t></w:r></w:p>"
+            "<w:tbl><w:tr>"
+            "<w:tc><w:p><w:r><w:t>Cell alpha text</w:t></w:r></w:p></w:tc>"
+            "<w:tc><w:p><w:r><w:t>Cell beta text</w:t></w:r></w:p></w:tc>"
+            "</w:tr></w:tbl>"
+        )
+        docx_path = tmp_path / "tables.docx"
+        replace_document_xml(
+            simple_docx, docx_path, f'<?xml version="1.0"?><w:document {NS}><w:body>{body}</w:body></w:document>'
+        )
+        with Document.open(docx_path, author="Test Editor") as doc:
+            doc.delete("alpha ", paragraph=find_ref(doc, "Cell alpha"))
+            doc.replace("beta", "BETA", paragraph=find_ref(doc, "Cell beta"))
+
+            del_alpha = next(r for r in doc.list_revisions() if r.text == "alpha ")
+            assert del_alpha.paragraph_ref == find_ref(doc, "Cell text")
+            ins_beta = next(r for r in doc.list_revisions() if r.text == "BETA")
+            assert ins_beta.paragraph_ref == find_ref(doc, "Cell BETA text")
+
+    def test_revision_outside_paragraph_has_no_ref(self, temp_xml):
+        """w:trPr row-insertion markers sit outside any w:p → paragraph_ref None."""
+        body = (
+            "<w:tbl><w:tr>"
+            f'<w:trPr><w:ins w:id="9" w:author="{AUTHOR_A}" w:date="{DATE_A}"/></w:trPr>'
+            "<w:tc><w:p><w:r><w:t>cell</w:t></w:r></w:p></w:tc>"
+            "</w:tr></w:tbl>"
+        )
+        manager = _make_manager(temp_xml(body))
+        rev = _rev(manager, 9)
+        assert rev.paragraph_ref is None
+        assert rev.occurrence is None
+        assert rev.text == ""
+
+
+class TestOccurrence:
+    """0-based occurrence in the view where the revision's text lives."""
+
+    def test_twin_insertions_get_distinct_occurrences(self, temp_xml):
+        body = (
+            "<w:p><w:r><w:t>start </w:t></w:r>"
+            f"{_ins('<w:r><w:t>dup</w:t></w:r>', ins_id=11)}"
+            "<w:r><w:t> mid </w:t></w:r>"
+            f"{_ins('<w:r><w:t>dup</w:t></w:r>', ins_id=12)}"
+            "<w:r><w:t> end</w:t></w:r></w:p>"
+        )
+        manager = _make_manager(temp_xml(body))
+        assert _rev(manager, 11).occurrence == 0
+        assert _rev(manager, 12).occurrence == 1
+        assert _rev(manager, 11).paragraph_ref == _rev(manager, 12).paragraph_ref
+
+    def test_deletion_occurrence_counts_in_original_view(self, temp_xml):
+        """'foo bar foo' with the second 'foo' deleted → occurrence 1."""
+        body = f"<w:p><w:r><w:t>foo bar </w:t></w:r>{_del('<w:r><w:delText>foo</w:delText></w:r>', del_id=5)}</w:p>"
+        manager = _make_manager(temp_xml(body))
+        rev = _rev(manager, 5)
+        assert rev.text == "foo"
+        assert rev.occurrence == 1
+
+    def test_occurrence_targets_intended_span_via_add_comment(self, simple_docx, tmp_path):
+        """rev.occurrence feeds add_comment(...) and hits the revision's own span."""
+        body = (
+            "<w:p><w:r><w:t>start </w:t></w:r>"
+            f"{_ins('<w:r><w:t>dup</w:t></w:r>', ins_id=11)}"
+            "<w:r><w:t> mid </w:t></w:r>"
+            f"{_ins('<w:r><w:t>dup</w:t></w:r>', ins_id=12)}"
+            "<w:r><w:t> end</w:t></w:r></w:p>"
+        )
+        docx_path = tmp_path / "twins.docx"
+        replace_document_xml(
+            simple_docx, docx_path, f'<?xml version="1.0"?><w:document {NS}><w:body>{body}</w:body></w:document>'
+        )
+        with Document.open(docx_path, author="Test Editor") as doc:
+            rev = _rev(doc, 12)
+            assert rev.paragraph_ref is not None
+            assert rev.occurrence is not None
+            doc.add_comment(rev.text, "second twin", paragraph=rev.paragraph_ref, occurrence=rev.occurrence)
+
+            dom = doc._document_editor.dom
+            before: list[str] = []
+            inside: list[str] = []
+            state = "before"
+
+            def walk(node):
+                nonlocal state
+                for child in node.childNodes:
+                    if child.nodeType != child.ELEMENT_NODE:
+                        continue
+                    if child.tagName == "w:commentRangeStart":
+                        state = "inside"
+                    elif child.tagName == "w:commentRangeEnd":
+                        state = "after"
+                    elif child.tagName == "w:t":
+                        text = "".join(c.data for c in child.childNodes if c.nodeType == c.TEXT_NODE)
+                        if state == "before":
+                            before.append(text)
+                        elif state == "inside":
+                            inside.append(text)
+                    else:
+                        walk(child)
+
+            walk(dom.documentElement)
+            assert "".join(inside) == "dup"
+            # The anchor is the SECOND dup: the first one lies before the range.
+            assert "".join(before) == "start dup mid "
+
+
+class TestNestedRevisions:
+    """Foreign-deletion-inside-pending-insertion state is fully reported."""
+
+    def test_nested_full_consume(self, temp_xml):
+        """B deleted ALL of A's insertion: host keeps full text, both unlocatable."""
+        body = (
+            "<w:p><w:r><w:t>Before </w:t></w:r>"
+            f"{_ins(_del('<w:r><w:delText>Hello</w:delText></w:r>', del_id=2), ins_id=1)}"
+            "<w:r><w:t> after</w:t></w:r></w:p>"
+        )
+        manager = _make_manager(temp_xml(body))
+        host = _rev(manager, 1)
+        nested = _rev(manager, 2)
+
+        assert host.text == "Hello"  # full original insertion, not ''
+        assert host.contains_ids == (2,)
+        assert host.nested_under is None
+        assert host.occurrence is None  # visible span no longer matches its text
+
+        assert nested.text == "Hello"
+        assert nested.nested_under == 1
+        assert nested.contains_ids == ()
+        assert nested.occurrence is None  # never existed in the original view
+
+        assert host.paragraph_ref is not None
+        assert host.paragraph_ref == nested.paragraph_ref
+
+    def test_nested_partial_consume(self, temp_xml):
+        """B deleted part of A's insertion: host reports the full original text."""
+        ins_content = "<w:r><w:t>Hello </w:t></w:r>" + _del("<w:r><w:delText>world</w:delText></w:r>", del_id=2)
+        body = f"<w:p>{_ins(ins_content, ins_id=1)}</w:p>"
+        manager = _make_manager(temp_xml(body))
+        host = _rev(manager, 1)
+        assert host.text == "Hello world"
+        assert host.contains_ids == (2,)
+        assert host.occurrence is None
+        assert _rev(manager, 2).nested_under == 1
+
+    def test_unnested_revisions_have_default_nesting_fields(self, temp_xml):
+        body = (
+            "<w:p><w:r><w:t>keep </w:t></w:r>"
+            f"{_ins('<w:r><w:t>new</w:t></w:r>', ins_id=1)}"
+            f"{_del('<w:r><w:delText>old</w:delText></w:r>', del_id=2)}"
+            "</w:p>"
+        )
+        manager = _make_manager(temp_xml(body))
+        for rev_id in (1, 2):
+            rev = _rev(manager, rev_id)
+            assert rev.nested_under is None
+            assert rev.contains_ids == ()
+            assert rev.occurrence == 0
+
+    def test_library_produced_nesting_is_reported(self, temp_xml):
+        """Deleting inside a foreign ins (PR #43 path) round-trips through list_revisions."""
+        xml_path = temp_xml(f"<w:p>{_ins('<w:r><w:t>Hello world</w:t></w:r>', ins_id=1)}</w:p>")
+        manager = _make_manager(xml_path, author=AUTHOR_B)
+        p = manager.editor.dom.getElementsByTagName("w:p")[0]
+        manager.suggest_deletion("world", paragraph=f"P1#{compute_paragraph_hash(p)}")
+
+        revisions = manager.list_revisions()
+        nested_del = next(r for r in revisions if r.type == "deletion")
+        hosts = [r for r in revisions if r.contains_ids]
+        assert len(hosts) == 1
+        assert nested_del.nested_under == hosts[0].id
+        assert nested_del.id in hosts[0].contains_ids
+
+
+class TestParagraphFilter:
+    """list_revisions(paragraph=...) scoping and validation."""
+
+    def test_filters_to_single_paragraph(self, temp_docx):
+        with Document.open(temp_docx, author="Test Editor") as doc:
+            refs = [entry.split("|")[0] for entry in doc.list_paragraphs()]
+            ref1 = doc.replace("Sample", "Example", paragraph=refs[0])
+            doc.delete("quick ", paragraph=refs[1])
+
+            current_refs = [entry.split("|")[0] for entry in doc.list_paragraphs()]
+            p1_revs = doc.list_revisions(paragraph=current_refs[0])
+            p2_revs = doc.list_revisions(paragraph=current_refs[1])
+            assert {r.type for r in p1_revs} == {"insertion", "deletion"}
+            assert [r.type for r in p2_revs] == ["deletion"]
+            assert all(r.paragraph_ref == current_refs[0] for r in p1_revs)
+            assert len(p1_revs) + len(p2_revs) == len(doc.list_revisions())
+            assert ref1 == current_refs[0]
+
+    def test_composes_with_author_filter(self, temp_xml):
+        body = (
+            "<w:p>"
+            f"{_ins('<w:r><w:t>one</w:t></w:r>', ins_id=1, author=AUTHOR_A)}"
+            f"{_ins('<w:r><w:t>two</w:t></w:r>', ins_id=2, author=AUTHOR_B)}"
+            "</w:p>"
+        )
+        manager = _make_manager(temp_xml(body))
+        ref = _rev(manager, 1).paragraph_ref
+        assert ref is not None
+        both = manager.list_revisions(paragraph=ref)
+        assert [r.id for r in both] == [1, 2]
+        only_a = manager.list_revisions(author=AUTHOR_A, paragraph=ref)
+        assert [r.id for r in only_a] == [1]
+
+    def test_invalid_ref_format_raises_value_error(self, temp_docx):
+        with Document.open(temp_docx, author="Test Editor") as doc:
+            with pytest.raises(ValueError, match="Invalid paragraph reference"):
+                doc.list_revisions(paragraph="P#bad")
+
+    def test_out_of_range_index_raises(self, temp_docx):
+        with Document.open(temp_docx, author="Test Editor") as doc:
+            with pytest.raises(ParagraphIndexError):
+                doc.list_revisions(paragraph="P999#abcd")
+
+    def test_stale_hash_raises(self, temp_docx):
+        with Document.open(temp_docx, author="Test Editor") as doc:
+            ref = doc.list_paragraphs()[0].split("|")[0]
+            index, actual_hash = ref.split("#")
+            stale_hash = "0000" if actual_hash != "0000" else "ffff"
+            with pytest.raises(HashMismatchError):
+                doc.list_revisions(paragraph=f"{index}#{stale_hash}")
+
+
+class TestRevisionRepr:
+    """repr spells the type, omits fake ellipses, and shows location/nesting."""
+
+    def test_deletion_id_zero_renders_cleanly(self):
+        rev = Revision(id=0, type="deletion", author="Bob", date=None, text="gone")
+        assert repr(rev) == "Revision(del 0: 'gone' by Bob)"
+
+    def test_short_text_has_no_ellipsis(self):
+        rev = Revision(id=1, type="insertion", author="Ann", date=None, text="short")
+        assert "..." not in repr(rev)
+
+    def test_long_text_is_truncated_with_ellipsis(self):
+        rev = Revision(id=1, type="insertion", author="Ann", date=None, text="x" * 40)
+        assert f"'{'x' * 30}...'" in repr(rev)
+
+    def test_location_and_nesting_shown(self):
+        rev = Revision(
+            id=7,
+            type="deletion",
+            author="Bob",
+            date=None,
+            text="gone",
+            paragraph_ref="P3#a7b2",
+            nested_under=5,
+        )
+        assert repr(rev) == "Revision(del 7 @P3#a7b2: 'gone' by Bob, nested_under=5)"
+
+    def test_contains_shown_when_nonempty(self):
+        rev = Revision(
+            id=5,
+            type="insertion",
+            author="Ann",
+            date=None,
+            text="Hello",
+            paragraph_ref="P3#a7b2",
+            contains_ids=(7,),
+        )
+        assert repr(rev) == "Revision(ins 5 @P3#a7b2: 'Hello' by Ann, contains=[7])"
+
+
+class TestGetMarkupText:
+    """Inline [ins#id:author]/[del#id:author] verification view."""
+
+    def test_markup_renders_plain_ins_del_and_nested(self, temp_xml):
+        body = (
+            "<w:p><w:r><w:t>Plain</w:t></w:r></w:p>"
+            "<w:p><w:r><w:t>Keep </w:t></w:r>"
+            f"{_ins('<w:r><w:t>added</w:t></w:r>', ins_id=1, author='A')}"
+            f"{_del('<w:r><w:delText>removed</w:delText></w:r>', del_id=2, author='B')}"
+            "</w:p>"
+            "<w:p>"
+            f'<w:ins w:id="3" w:author="A" w:date="{DATE_A}">'
+            "<w:r><w:t>kept </w:t></w:r>"
+            f'<w:del w:id="4" w:author="B" w:date="{DATE_B}"><w:r><w:delText>gone</w:delText></w:r></w:del>'
+            "</w:ins>"
+            "</w:p>"
+        )
+        manager = _make_manager(temp_xml(body))
+        assert manager.get_markup_text() == (
+            "Plain\nKeep [ins#1:A]added[/ins][del#2:B]removed[/del]\n[ins#3:A]kept [del#4:B]gone[/del][/ins]"
+        )
+
+    def test_document_wrapper_shows_tracked_edit(self, temp_docx):
+        with Document.open(temp_docx, author="Test Editor") as doc:
+            ref = doc.list_paragraphs()[0].split("|")[0]
+            doc.replace("Sample", "Example", paragraph=ref)
+            markup = doc.get_markup_text()
+            assert "[del#" in markup
+            assert "]Sample[/del]" in markup
+            assert "]Example[/ins]" in markup
+            assert ":Test Editor]" in markup

--- a/tests/test_track_changes.py
+++ b/tests/test_track_changes.py
@@ -11,19 +11,6 @@ from docx_editor.track_changes import Revision, RevisionManager, _escape_xml
 from docx_editor.xml_editor import DocxXMLEditor, build_text_map
 
 
-def _attach_text_node(mock_elem, text):
-    """Configure a MagicMock to look like a w:t element with TEXT_NODE child.
-
-    Mirrors the real minidom structure so methods iterating ``childNodes``
-    and filtering by ``TEXT_NODE`` (e.g. ``_get_node_text``) work.
-    """
-    mock_elem.firstChild = MagicMock()
-    mock_elem.firstChild.data = text
-    # Make nodeType == TEXT_NODE evaluate True without depending on actual ints.
-    mock_elem.firstChild.nodeType = mock_elem.firstChild.TEXT_NODE
-    mock_elem.childNodes = [mock_elem.firstChild]
-
-
 class TestTrackedReplace:
     """Tests for tracked text replacement."""
 
@@ -373,7 +360,7 @@ class TestRevisionRepr:
             text="short text",
         )
         repr_str = repr(rev)
-        assert "+1:" in repr_str
+        assert "ins 1:" in repr_str
         assert "short text" in repr_str
         assert "TestAuthor" in repr_str
 
@@ -387,7 +374,7 @@ class TestRevisionRepr:
             text="deleted text",
         )
         repr_str = repr(rev)
-        assert "-2:" in repr_str
+        assert "del 2:" in repr_str
         assert "deleted text" in repr_str
         assert "TestAuthor" in repr_str
 
@@ -707,97 +694,57 @@ class TestRevisionManagerErrorHandling:
 
 
 class TestRevisionManagerWithMockedEditor:
-    """Tests using mocked editor for edge cases."""
+    """_parse_revision edge cases on real detached elements (editor mocked)."""
+
+    @staticmethod
+    def _revision_elem(xml: str):
+        """Parse an XML fragment and return its first element (w:ins/w:del)."""
+        import defusedxml.minidom
+
+        NS = 'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"'
+        dom = defusedxml.minidom.parseString(f"<root {NS}>{xml}</root>")
+        return dom.documentElement.firstChild
 
     def test_parse_revision_missing_id_returns_none(self):
         """Test _parse_revision returns None when w:id is missing."""
-        mock_editor = MagicMock()
-        manager = RevisionManager(mock_editor)
-
-        mock_elem = MagicMock()
-        mock_elem.getAttribute.return_value = ""  # Empty w:id
-
-        result = manager._parse_revision(mock_elem, "insertion")
-        assert result is None
+        manager = RevisionManager(MagicMock())
+        elem = self._revision_elem('<w:ins w:author="Test"><w:r><w:t>x</w:t></w:r></w:ins>')
+        assert manager._parse_revision(elem, "insertion") is None
 
     def test_parse_revision_invalid_date_uses_none(self):
         """Test _parse_revision handles invalid date gracefully."""
-        mock_editor = MagicMock()
-        manager = RevisionManager(mock_editor)
-
-        mock_elem = MagicMock()
-
-        def get_attr(name):
-            if name == "w:id":
-                return "1"
-            elif name == "w:author":
-                return "Test"
-            elif name == "w:date":
-                return "invalid-date-format"
-            return ""
-
-        mock_elem.getAttribute.side_effect = get_attr
-        mock_elem.getElementsByTagName.return_value = []
-
-        result = manager._parse_revision(mock_elem, "insertion")
+        manager = RevisionManager(MagicMock())
+        elem = self._revision_elem('<w:ins w:id="1" w:author="Test" w:date="invalid-date-format"/>')
+        result = manager._parse_revision(elem, "insertion")
         assert result is not None
         assert result.date is None  # Invalid date should be None
 
     def test_parse_revision_with_text_content(self):
         """Test _parse_revision extracts text content properly."""
-        mock_editor = MagicMock()
-        manager = RevisionManager(mock_editor)
-
-        mock_elem = MagicMock()
-
-        def get_attr(name):
-            if name == "w:id":
-                return "5"
-            elif name == "w:author":
-                return "Author"
-            elif name == "w:date":
-                return "2024-01-15T10:30:00Z"
-            return ""
-
-        mock_elem.getAttribute.side_effect = get_attr
-
-        # Mock text element with content
-        mock_text_elem = MagicMock()
-        _attach_text_node(mock_text_elem, "test content")
-
-        mock_elem.getElementsByTagName.return_value = [mock_text_elem]
-
-        result = manager._parse_revision(mock_elem, "insertion")
+        manager = RevisionManager(MagicMock())
+        elem = self._revision_elem(
+            '<w:ins w:id="5" w:author="Author" w:date="2024-01-15T10:30:00Z"><w:r><w:t>test content</w:t></w:r></w:ins>'
+        )
+        result = manager._parse_revision(elem, "insertion")
         assert result is not None
         assert result.text == "test content"
 
     def test_parse_revision_text_element_no_child(self):
-        """Test _parse_revision handles text elements with no firstChild."""
-        mock_editor = MagicMock()
-        manager = RevisionManager(mock_editor)
-
-        mock_elem = MagicMock()
-
-        def get_attr(name):
-            if name == "w:id":
-                return "6"
-            elif name == "w:author":
-                return "Author"
-            elif name == "w:date":
-                return ""
-            return ""
-
-        mock_elem.getAttribute.side_effect = get_attr
-
-        # Mock text element with no firstChild
-        mock_text_elem = MagicMock()
-        mock_text_elem.firstChild = None
-
-        mock_elem.getElementsByTagName.return_value = [mock_text_elem]
-
-        result = manager._parse_revision(mock_elem, "insertion")
+        """Test _parse_revision handles text elements with no text child."""
+        manager = RevisionManager(MagicMock())
+        elem = self._revision_elem('<w:ins w:id="6" w:author="Author"><w:r><w:t/></w:r></w:ins>')
+        result = manager._parse_revision(elem, "insertion")
         assert result is not None
         assert result.text == ""  # Empty text when no content
+
+    def test_parse_revision_without_ctx_leaves_location_unset(self):
+        """No location context (detached parse) → paragraph_ref/occurrence None."""
+        manager = RevisionManager(MagicMock())
+        elem = self._revision_elem('<w:ins w:id="7" w:author="Author"><w:r><w:t>text</w:t></w:r></w:ins>')
+        result = manager._parse_revision(elem, "insertion")
+        assert result is not None
+        assert result.paragraph_ref is None
+        assert result.occurrence is None
 
 
 class TestRestoreDeletionEdgeCases:


### PR DESCRIPTION
Implements revision location and nested-state reporting (ISSUES.md #33 — repo-local issue list, not a GitHub issue).

## What

`list_revisions()` now tells you *where* each revision lives and how revisions nest, so reviewers can act on a specific revision without text-uniqueness luck:

- **`Revision.paragraph_ref`** — hash-anchored ref (`"P3#a7b2"`) of the containing paragraph, matching `list_paragraphs()` format; `None` for revisions outside any paragraph (e.g. `w:trPr` row markers).
- **`Revision.occurrence`** — 0-based occurrence of the revision's text within its paragraph, counted in the view where that text lives (accepted view for insertions, original view for deletions). For insertions it plugs directly into the `occurrence=` parameter of `replace()`/`delete()`/`add_comment()`; `None` whenever targeting-by-text does not apply.
- **`Revision.nested_under` / `Revision.contains_ids`** — bidirectional nesting state (e.g. a foreign deletion inside another author's pending insertion).
- **`list_revisions(paragraph=...)`** — validated paragraph filter (raises `ValueError` / `ParagraphIndexError` / `HashMismatchError` on bad refs).
- **`get_markup_text()`** — inline `[ins#id:author]…[/ins]` / `[del#id:author]…[/del]` verification view, removing the pandoc/unzip dependency for checking redlines.
- Host insertions partially consumed by a nested deletion now report their full original text (`w:delText` under `w:ins` is included).
- `Revision.__repr__` spells the type, shows location/nesting, and only truncates text that actually exceeds the limit.

## Correctness notes

- Occurrence indexes mirror `find_in_text_map`'s stepping exactly, so they land on the revision's own span when fed back to the anchor APIs (proven end-to-end via `add_comment` + DOM walk in tests).
- All "can't locate by text" cases return `occurrence=None` instead of a wrong index: empty text, nested deletions (text never existed in the original view), partially consumed host insertions.
- Deletion occurrences count in the original view and must not be fed to the anchor APIs (which search the visible view) — documented in the API docstrings and SKILL.md.

## Testing

- 15 new tests in `tests/test_revision_location.py` (location refs incl. table cells, occurrence disambiguation of identical twins, nesting full/partial consume, paragraph filter validation, repr, markup view).
- `test_foreign_revisions.py` ground truth extended with location fields.
- Mock-heavy `_parse_revision` unit tests rewritten against real parsed minidom fragments.
- Full suite: 972 passed, 2 skipped; ruff and ty clean.
