### PR TITLE
feat: find_all enumeration, occurrence ambiguity guard, batch operation_index (ISSUES.md #34)

### DIFF
--- a/benchmarks/hash_anchored_vs_plain.py
+++ b/benchmarks/hash_anchored_vs_plain.py
@@ -228,10 +228,13 @@ def benchmark_accuracy():
     shutil.copy(persist_path, d1)
     doc1 = Document.open(d1, force_recreate=True)
 
-    # Disrupting edit: replace BOTH 'committee' in P5
+    # Disrupting edit: replace BOTH 'committee' in P5 (occurrence=0 twice —
+    # after the first replace, the remaining match is the new first one)
     p5_ref = old_refs[5]
-    doc1.replace("committee", "BOARD", paragraph=p5_ref)
-    doc1.replace("committee", "BOARD", paragraph=old_refs[5].split("#")[0] + "#" + _get_fresh_hash(doc1, 5))
+    doc1.replace("committee", "BOARD", paragraph=p5_ref, occurrence=0)
+    doc1.replace(
+        "committee", "BOARD", paragraph=old_refs[5].split("#")[0] + "#" + _get_fresh_hash(doc1, 5), occurrence=0
+    )
 
     # Now try to edit P6-P15 using the OLD occurrence indices
     for para_idx in target_paras:
@@ -283,15 +286,17 @@ def benchmark_accuracy():
     doc2 = Document.open(d2, force_recreate=True)
 
     # Same disrupting edit
-    doc2.replace("committee", "BOARD", paragraph=p5_ref)
-    doc2.replace("committee", "BOARD", paragraph=old_refs[5].split("#")[0] + "#" + _get_fresh_hash(doc2, 5))
+    doc2.replace("committee", "BOARD", paragraph=p5_ref, occurrence=0)
+    doc2.replace(
+        "committee", "BOARD", paragraph=old_refs[5].split("#")[0] + "#" + _get_fresh_hash(doc2, 5), occurrence=0
+    )
 
     # Try to edit P6-P15 using OLD refs (from before edit)
     for para_idx in target_paras:
         old_ref = old_refs[para_idx]
         marker = f"[P{para_idx:02d}]"
         try:
-            doc2.replace("committee", "EDITED", paragraph=old_ref)
+            doc2.replace("committee", "EDITED", paragraph=old_ref, occurrence=0)
             hash_correct += 1
         except HashMismatchError:
             hash_rejected += 1

--- a/docs/api.md
+++ b/docs/api.md
@@ -245,9 +245,13 @@ for r in doc.find_all("30 days"):
                 paragraph=r.paragraph_ref, occurrence=r.paragraph_occurrence)
 ```
 
-Editing a paragraph invalidates its remaining refs — when one paragraph holds
-several matches, re-run `find_all` after each edit or apply the edits with
-`batch_edit()`.
+Editing a paragraph invalidates its remaining refs and shifts the occurrence
+numbers of the matches after the edit. When one paragraph holds several
+matches, either re-run `find_all` after each edit, or apply them in a single
+`batch_edit()` with the same-paragraph ops in **descending** occurrence order —
+an edit never shifts the matches before it. (Ascending order mis-targets;
+descending is not valid for search strings that overlap themselves, e.g.
+`"aa"` in `"aaaa"`.)
 
 #### `count_matches(text)`
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -222,6 +222,33 @@ if match:
     )
 ```
 
+#### `find_all(text, paragraph=None)`
+
+Find every match of `text`, in document order. One call replaces the N+1
+`find_text` probes needed to enumerate N hits, and each result carries exactly
+what a follow-up edit needs.
+
+**Parameters:**
+
+- `text` (str): Text to search for (must be non-empty)
+- `paragraph` (str, optional): Paragraph reference (e.g. `P2#f3c1`) to scope the search. `None` searches the whole document. Defaults to None.
+
+**Returns:** list of [`SearchResult`](#searchresult), empty when nothing matches (no-match is not an error for an enumeration API)
+
+**Raises:** `ValueError` if `text` is empty or `paragraph` is malformed; [`ParagraphIndexError`](#exceptions) / [`HashMismatchError`](#exceptions) for an out-of-range or stale `paragraph`.
+
+**Example:**
+
+```python
+for r in doc.find_all("30 days"):
+    doc.replace(r.text, "60 days",
+                paragraph=r.paragraph_ref, occurrence=r.paragraph_occurrence)
+```
+
+Editing a paragraph invalidates its remaining refs — when one paragraph holds
+several matches, re-run `find_all` after each edit or apply the edits with
+`batch_edit()`.
+
 #### `count_matches(text)`
 
 Count visible text matches across the document.
@@ -239,7 +266,7 @@ if doc.count_matches("Section 5") > 1:
     print("Use paragraph refs and occurrence to target the intended match")
 ```
 
-#### `replace(find, replace_with, *, paragraph, occurrence=0)`
+#### `replace(find, replace_with, *, paragraph, occurrence=None)`
 
 Replace text with tracked changes. When the target sits inside another author's pending insertion, that insertion is preserved: the matched text gets a nested `<w:del>` under your authorship and the replacement lands in your own sibling `<w:ins>` (Word's behavior), instead of silently rewriting the other author's proposal.
 
@@ -248,7 +275,7 @@ Replace text with tracked changes. When the target sits inside another author's 
 - `find` (str): Text to find and replace
 - `replace_with` (str): Replacement text
 - `paragraph` (str): Paragraph reference from `list_paragraphs()`, such as `P2#f3c1`
-- `occurrence` (int): Which occurrence within the paragraph, 0-based (0 = first). Defaults to 0.
+- `occurrence` (int | None): Which occurrence within the paragraph, 0-based (0 = first). Omitted → the target must be unique within the paragraph; if it matches more than once, [`AmbiguousTextError`](#ambiguoustexterror) is raised instead of silently editing the first match.
 
 **Returns:** Updated paragraph reference (str)
 
@@ -259,7 +286,7 @@ ref = doc.replace("30 days", "60 days", paragraph="P2#f3c1")
 doc.replace("net", "gross", paragraph=ref)
 ```
 
-#### `delete(text, *, paragraph, occurrence=0)`
+#### `delete(text, *, paragraph, occurrence=None)`
 
 Mark text as deleted with tracked changes. Deleting text inside another author's pending insertion nests a `<w:del>` under your authorship inside their `<w:ins>`, preserving their proposal; only your own pending insertions are edited in place.
 
@@ -267,7 +294,7 @@ Mark text as deleted with tracked changes. Deleting text inside another author's
 
 - `text` (str): Text to mark as deleted
 - `paragraph` (str): Paragraph reference from `list_paragraphs()`, such as `P2#f3c1`
-- `occurrence` (int): Which occurrence within the paragraph, 0-based (0 = first). Defaults to 0.
+- `occurrence` (int | None): Which occurrence within the paragraph, 0-based (0 = first). Omitted → the target must be unique within the paragraph; if it matches more than once, [`AmbiguousTextError`](#ambiguoustexterror) is raised instead of silently editing the first match.
 
 **Returns:** Updated paragraph reference (str)
 
@@ -277,7 +304,7 @@ Mark text as deleted with tracked changes. Deleting text inside another author's
 ref = doc.delete("obsolete clause", paragraph="P5#d4e5")
 ```
 
-#### `insert_after(anchor, text, *, paragraph, occurrence=0)`
+#### `insert_after(anchor, text, *, paragraph, occurrence=None)`
 
 Insert text after anchor with tracked changes. An anchor inside another author's pending insertion produces your own sibling `<w:ins>` (splitting theirs when the anchor falls mid-content) rather than splicing your words into their proposal.
 
@@ -286,7 +313,7 @@ Insert text after anchor with tracked changes. An anchor inside another author's
 - `anchor` (str): Text to find as insertion point
 - `text` (str): Text to insert after the anchor
 - `paragraph` (str): Paragraph reference from `list_paragraphs()`, such as `P2#f3c1`
-- `occurrence` (int): Which occurrence within the paragraph, 0-based (0 = first). Defaults to 0.
+- `occurrence` (int | None): Which occurrence within the paragraph, 0-based (0 = first). Omitted → the target must be unique within the paragraph; if it matches more than once, [`AmbiguousTextError`](#ambiguoustexterror) is raised instead of silently editing the first match.
 
 **Returns:** Updated paragraph reference (str)
 
@@ -296,7 +323,7 @@ Insert text after anchor with tracked changes. An anchor inside another author's
 ref = doc.insert_after("Section 5", " (as amended)", paragraph="P3#b2c4")
 ```
 
-#### `insert_before(anchor, text, *, paragraph, occurrence=0)`
+#### `insert_before(anchor, text, *, paragraph, occurrence=None)`
 
 Insert text before anchor with tracked changes. Foreign pending insertions are treated the same as in `insert_after()`.
 
@@ -305,7 +332,7 @@ Insert text before anchor with tracked changes. Foreign pending insertions are t
 - `anchor` (str): Text to find as insertion point
 - `text` (str): Text to insert before the anchor
 - `paragraph` (str): Paragraph reference from `list_paragraphs()`, such as `P2#f3c1`
-- `occurrence` (int): Which occurrence within the paragraph, 0-based (0 = first). Defaults to 0.
+- `occurrence` (int | None): Which occurrence within the paragraph, 0-based (0 = first). Omitted → the target must be unique within the paragraph; if it matches more than once, [`AmbiguousTextError`](#ambiguoustexterror) is raised instead of silently editing the first match.
 
 **Returns:** Updated paragraph reference (str)
 
@@ -344,6 +371,8 @@ stale, the entire batch is rejected before any edits are applied.
 
 **Returns:** Updated paragraph references in input order (list[str]); with `dry_run=True`, a list of [`EditValidationResult`](#editvalidationresult) instead
 
+**Raises:** [`BatchOperationError`](#batchoperationerror) — the only exception a non-dry-run batch raises for a failing operation, whatever the underlying cause (stale hash, malformed ref, missing text, ambiguous target). `operation_index` names the failing op; `original` (also `__cause__`) holds the underlying typed exception. The batch is atomic: nothing is applied on failure.
+
 **Example:**
 
 ```python
@@ -380,6 +409,8 @@ Rewrite multiple paragraphs after validating paragraph hashes up front.
 
 **Returns:** Updated paragraph references in input order (list[str])
 
+**Raises:** [`BatchOperationError`](#batchoperationerror) — same single-exception contract as `batch_edit()`.
+
 **Example:**
 
 ```python
@@ -391,7 +422,7 @@ new_refs = doc.batch_rewrite([
 
 ### Comment Methods
 
-#### `add_comment(anchor_text, comment, *, paragraph=None, occurrence=0)`
+#### `add_comment(anchor_text, comment, *, paragraph=None, occurrence=None)`
 
 Add a comment anchored to specific text. Anchors are located with the same
 visible-text search used by `count_matches()` and the tracked-change edit
@@ -403,7 +434,7 @@ smart-quote splits, `w:ins` wrappers) are found.
 - `anchor_text` (str): Text to attach the comment to
 - `comment` (str): The comment content
 - `paragraph` (str, optional): Paragraph reference (e.g. `P3#a7b2`) to scope the search. `None` searches the whole document. Defaults to None.
-- `occurrence` (int): Which occurrence to anchor to, 0-based (0 = first). Defaults to 0.
+- `occurrence` (int | None): Which occurrence to anchor to, 0-based (0 = first), counted within `paragraph` when given and document-wide otherwise. Omitted → the anchor must be unique in the search scope, else [`AmbiguousTextError`](#ambiguoustexterror).
 
 **Returns:** The comment ID (int). IDs are allocated sequentially starting at 0 in a document with no existing comments — always use the returned ID rather than guessing.
 
@@ -697,19 +728,19 @@ from docx_editor import EditOperation
 
 ### Constructors
 
-#### `EditOperation.replace(find, replace_with, *, paragraph, occurrence=0)`
+#### `EditOperation.replace(find, replace_with, *, paragraph, occurrence=None)`
 
 - `find` (str): Text to find and replace. Must be non-empty.
 - `replace_with` (str): Replacement text. Empty string is allowed (replacing
   with nothing is a valid tracked deletion).
 
-#### `EditOperation.delete(text, *, paragraph, occurrence=0)`
+#### `EditOperation.delete(text, *, paragraph, occurrence=None)`
 
 - `text` (str): Text to mark as deleted. Must be non-empty.
 
-#### `EditOperation.insert_after(anchor, text, *, paragraph, occurrence=0)`
+#### `EditOperation.insert_after(anchor, text, *, paragraph, occurrence=None)`
 
-#### `EditOperation.insert_before(anchor, text, *, paragraph, occurrence=0)`
+#### `EditOperation.insert_before(anchor, text, *, paragraph, occurrence=None)`
 
 - `anchor` (str): Text to find as insertion point. Must be non-empty.
 - `text` (str): Text to insert.
@@ -717,7 +748,7 @@ from docx_editor import EditOperation
 All constructors also take:
 
 - `paragraph` (str): Paragraph reference from `list_paragraphs()`, such as `P2#f3c1`
-- `occurrence` (int): Which occurrence within the paragraph, 0-based (0 = first). Defaults to 0. Must be >= 0.
+- `occurrence` (int | None): Which occurrence within the paragraph, 0-based (0 = first). Omitted → the target must be unique within the paragraph at apply time; if it matches more than once, the batch fails with a [`BatchOperationError`](#batchoperationerror) wrapping an [`AmbiguousTextError`](#ambiguoustexterror). Must be >= 0 when given.
 
 **Raises:** `ValueError` at construction time if the paragraph ref is malformed,
 `occurrence` is negative, a search-target argument (`find`, delete `text`,
@@ -777,7 +808,8 @@ if all(r.valid for r in results):
 
 ## SearchResult
 
-The result of `Document.find_text()`. Carries no XML/DOM internals.
+The result of `Document.find_text()` (a single match, or None) and
+`Document.find_all()` (a list of them). Carries no XML/DOM internals.
 
 ```python
 from docx_editor import SearchResult
@@ -833,7 +865,11 @@ genuinely need the internals (raw DOM positions), import them from
 
 ### `TextNotFoundError`
 
-Raised when the specified text is not found in the document.
+Raised when the specified text is not found in the document, or when an
+explicit `occurrence` is out of range — the error then carries `occurrence`
+and `total_occurrences` and its message reports the actual count instead of
+claiming the text is absent. Other structured fields: `search_text`,
+`paragraph_ref`, `paragraph_preview`.
 
 ```python
 from docx_editor.exceptions import TextNotFoundError
@@ -842,6 +878,47 @@ try:
     doc.replace("nonexistent text", "new text", paragraph="P2#f3c1")
 except TextNotFoundError as e:
     print(f"Text not found: {e}")
+```
+
+### `AmbiguousTextError`
+
+Raised when an edit target matches more than once in the search scope and no
+`occurrence` was given. Not a `TextNotFoundError` subclass — the text *was*
+found. Structured fields: `search_text`, `paragraph_ref` (None when
+document-wide), `paragraph_preview` (None when document-wide),
+`total_occurrences`.
+
+```python
+from docx_editor.exceptions import AmbiguousTextError
+
+try:
+    doc.replace("term", "clause", paragraph="P2#f3c1")
+except AmbiguousTextError as e:
+    r = doc.find_all("term", paragraph=e.paragraph_ref)[0]
+    doc.replace("term", "clause", paragraph=r.paragraph_ref,
+                occurrence=r.paragraph_occurrence)
+```
+
+### `BatchOperationError`
+
+The only exception `batch_edit()` / `batch_rewrite()` raise for a failing
+operation. Structured fields: `operation_index` (0-based position of the
+failing op), `reason` (human-readable message), `original` (the underlying
+typed exception, also set as `__cause__`).
+
+```python
+from docx_editor.exceptions import BatchOperationError, HashMismatchError
+
+while ops:
+    try:
+        doc.batch_edit(ops)
+        break
+    except BatchOperationError as e:
+        if isinstance(e.original, HashMismatchError):
+            op = ops[e.operation_index]
+            op.paragraph = f"P{e.original.paragraph_index}#{e.original.actual_hash}"
+        else:
+            ops.pop(e.operation_index)
 ```
 
 ### `CommentError`

--- a/docs/api.md
+++ b/docs/api.md
@@ -240,18 +240,25 @@ what a follow-up edit needs.
 **Example:**
 
 ```python
-for r in doc.find_all("30 days"):
-    doc.replace(r.text, "60 days",
-                paragraph=r.paragraph_ref, occurrence=r.paragraph_occurrence)
+# Edit every match in one atomic batch. reversed() puts same-paragraph ops in
+# the required descending occurrence order, so this is safe however the
+# matches are distributed:
+ops = [
+    EditOperation.replace(r.text, "60 days",
+                          paragraph=r.paragraph_ref, occurrence=r.paragraph_occurrence)
+    for r in reversed(doc.find_all("30 days"))
+]
+doc.batch_edit(ops)
 ```
 
-Editing a paragraph invalidates its remaining refs and shifts the occurrence
-numbers of the matches after the edit. When one paragraph holds several
-matches, either re-run `find_all` after each edit, or apply them in a single
-`batch_edit()` with the same-paragraph ops in **descending** occurrence order —
-an edit never shifts the matches before it. (Ascending order mis-targets;
-descending is not valid for search strings that overlap themselves, e.g.
-`"aa"` in `"aaaa"`.)
+Editing one match at a time (`doc.replace(...)` per result) also works when
+every paragraph holds at most one match. With several matches in one
+paragraph, an edit invalidates the paragraph's remaining refs and shifts the
+occurrence numbers of the matches after it — either re-run `find_all` after
+each edit, or batch the same-paragraph ops in **descending** occurrence order
+as above; an edit never shifts the matches before it. (Ascending order
+mis-targets; descending is not valid for search strings that overlap
+themselves, e.g. `"aa"` in `"aaaa"`.)
 
 #### `count_matches(text)`
 
@@ -908,7 +915,9 @@ except AmbiguousTextError as e:
 The only exception `batch_edit()` / `batch_rewrite()` raise for a failing
 operation. Structured fields: `operation_index` (0-based position of the
 failing op), `reason` (human-readable message), `original` (the underlying
-typed exception, also set as `__cause__`).
+typed exception, also set as `__cause__`; `None` for batch-level rule
+violations that have no underlying exception, e.g. a missing paragraph ref or
+a duplicate paragraph in `batch_rewrite`).
 
 ```python
 from docx_editor.exceptions import BatchOperationError, HashMismatchError

--- a/docx_editor/__init__.py
+++ b/docx_editor/__init__.py
@@ -37,6 +37,7 @@ except PackageNotFoundError:  # pragma: no cover - source tree without installat
 from .comments import Comment
 from .document import Document
 from .exceptions import (
+    AmbiguousTextError,
     BatchOperationError,
     CommentError,
     DocumentNotFoundError,
@@ -88,6 +89,7 @@ __all__ = [
     "RevisionError",
     "CommentError",
     "TextNotFoundError",
+    "AmbiguousTextError",
     "HashMismatchError",
     "ParagraphIndexError",
     "BatchOperationError",

--- a/docx_editor/comments.py
+++ b/docx_editor/comments.py
@@ -159,7 +159,7 @@ class CommentManager:
         """
         if not anchor_text:
             raise CommentError("anchor_text must not be empty")
-        _, match = self._find_anchor(anchor_text, paragraph, occurrence)
+        _, match = self._locate_anchor(anchor_text, paragraph, occurrence)
 
         comment_id = self.next_comment_id
         para_id = _generate_hex_id()
@@ -181,7 +181,7 @@ class CommentManager:
 
         return comment_id
 
-    def _find_anchor(
+    def _locate_anchor(
         self, anchor_text: str, paragraph: str | None, occurrence: int | None
     ) -> tuple[Element, TextMapMatch]:
         """Locate ``anchor_text`` and return its paragraph + text-map match.

--- a/docx_editor/comments.py
+++ b/docx_editor/comments.py
@@ -26,6 +26,7 @@ from .xml_editor import (
     _generate_hex_id,
     build_text_map,
     compute_paragraph_hash,
+    count_in_text_map,
     find_in_text_map,
     get_rPr_xml,
     get_text_node_data,
@@ -207,11 +208,7 @@ class CommentManager:
                     preview += "..."
                 raise HashMismatchError(ref.index, ref.hash, actual, preview)
             text_map = build_text_map(p)
-            total = 0
-            start = 0
-            while (idx := text_map.find(anchor_text, start)) != -1:
-                total += 1
-                start = idx + 1
+            total = count_in_text_map(text_map, anchor_text)
             match = find_in_text_map(text_map, anchor_text, occ)
             if match is not None:
                 if occurrence is None and total > 1:

--- a/docx_editor/comments.py
+++ b/docx_editor/comments.py
@@ -187,7 +187,7 @@ class CommentManager:
         """Locate ``anchor_text`` and return its paragraph + text-map match.
 
         Mirrors ``RevisionManager._locate_in_paragraph`` /
-        ``_find_document_wide`` so comment anchors and edit anchors find the
+        ``_locate_document_wide`` so comment anchors and edit anchors find the
         same text and fail the same way: ``occurrence=None`` requires a unique
         anchor (else AmbiguousTextError), an explicit out-of-range occurrence
         reports the actual total.

--- a/docx_editor/comments.py
+++ b/docx_editor/comments.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from xml.dom.minidom import Element
 
 from .exceptions import (
+    AmbiguousTextError,
     CommentError,
     HashMismatchError,
     ParagraphIndexError,
@@ -126,7 +127,7 @@ class CommentManager:
         comment_text: str,
         *,
         paragraph: str | None = None,
-        occurrence: int = 0,
+        occurrence: int | None = None,
     ) -> int:
         """Add a comment anchored to specific text.
 
@@ -140,13 +141,17 @@ class CommentManager:
             comment_text: The comment content.
             paragraph: Optional paragraph reference (e.g., ``"P3#a7b2"``) to
                 scope the search. ``None`` searches the whole document.
-            occurrence: Which occurrence to anchor (0 = first).
+            occurrence: Which occurrence to anchor (0 = first). Omitted →
+                ``anchor_text`` must be unique in the search scope, else
+                AmbiguousTextError.
 
         Returns:
             The comment ID.
 
         Raises:
             TextNotFoundError: If the anchor text is not found.
+            AmbiguousTextError: If ``occurrence`` is omitted and
+                ``anchor_text`` matches more than once in the search scope.
             HashMismatchError: If a paragraph reference's hash is stale.
             ParagraphIndexError: If a paragraph reference's index is out of range.
             CommentError: If ``anchor_text`` is empty.
@@ -175,13 +180,19 @@ class CommentManager:
 
         return comment_id
 
-    def _find_anchor(self, anchor_text: str, paragraph: str | None, occurrence: int) -> tuple[Element, TextMapMatch]:
+    def _find_anchor(
+        self, anchor_text: str, paragraph: str | None, occurrence: int | None
+    ) -> tuple[Element, TextMapMatch]:
         """Locate ``anchor_text`` and return its paragraph + text-map match.
 
-        Mirrors ``RevisionManager._find_in_paragraph`` /
-        ``_find_across_boundaries`` so comment anchors and edit anchors find
-        the same text.
+        Mirrors ``RevisionManager._locate_in_paragraph`` /
+        ``_find_document_wide`` so comment anchors and edit anchors find the
+        same text and fail the same way: ``occurrence=None`` requires a unique
+        anchor (else AmbiguousTextError), an explicit out-of-range occurrence
+        reports the actual total.
         """
+        occ = occurrence if occurrence is not None else 0
+
         if paragraph is not None:
             ref = ParagraphRef.parse(paragraph)
             paragraphs = self.document_editor.dom.getElementsByTagName("w:p")
@@ -196,29 +207,41 @@ class CommentManager:
                     preview += "..."
                 raise HashMismatchError(ref.index, ref.hash, actual, preview)
             text_map = build_text_map(p)
-            match = find_in_text_map(text_map, anchor_text, occurrence)
+            total = 0
+            start = 0
+            while (idx := text_map.find(anchor_text, start)) != -1:
+                total += 1
+                start = idx + 1
+            match = find_in_text_map(text_map, anchor_text, occ)
             if match is not None:
-                return p, match
-            if occurrence > 0:
-                total = 0
-                while find_in_text_map(text_map, anchor_text, total) is not None:
-                    total += 1
-                if total > 0:
-                    raise TextNotFoundError(
+                if occurrence is None and total > 1:
+                    raise AmbiguousTextError(
                         anchor_text,
                         paragraph_ref=paragraph,
                         paragraph_preview=text_map.text,
-                        occurrence=occurrence,
                         total_occurrences=total,
                     )
+                return p, match
+            if total > 0:
+                raise TextNotFoundError(
+                    anchor_text,
+                    paragraph_ref=paragraph,
+                    paragraph_preview=text_map.text,
+                    occurrence=occ,
+                    total_occurrences=total,
+                )
             raise TextNotFoundError(
                 anchor_text,
                 paragraph_ref=paragraph,
                 paragraph_preview=text_map.text,
             )
 
-        # Document-wide search
+        # Document-wide search. With an explicit occurrence the scan returns at
+        # the requested match; with occurrence=None it runs to the end so
+        # `current` ends up as the document-wide total, which the ambiguity and
+        # out-of-range errors need.
         current = 0
+        found: tuple[Element, TextMapMatch] | None = None
         for p in self.document_editor.dom.getElementsByTagName("w:p"):
             text_map = build_text_map(p)
             local = 0
@@ -226,14 +249,20 @@ class CommentManager:
                 m = find_in_text_map(text_map, anchor_text, local)
                 if m is None:
                     break
-                if current == occurrence:
-                    return p, m
+                if current == occ:
+                    if occurrence is not None:
+                        return p, m
+                    found = (p, m)
                 current += 1
                 local += 1
-        if occurrence > 0 and current > 0:
+        if found is not None:
+            if occurrence is None and current > 1:
+                raise AmbiguousTextError(anchor_text, total_occurrences=current)
+            return found
+        if current > 0:
             raise TextNotFoundError(
                 anchor_text,
-                occurrence=occurrence,
+                occurrence=occ,
                 total_occurrences=current,
             )
         raise TextNotFoundError(anchor_text)

--- a/docx_editor/comments.py
+++ b/docx_editor/comments.py
@@ -190,8 +190,11 @@ class CommentManager:
         ``_locate_document_wide`` so comment anchors and edit anchors find the
         same text and fail the same way: ``occurrence=None`` requires a unique
         anchor (else AmbiguousTextError), an explicit out-of-range occurrence
-        reports the actual total.
+        reports the actual total, and a negative occurrence is rejected with
+        ValueError.
         """
+        if occurrence is not None and occurrence < 0:
+            raise ValueError(f"occurrence must be >= 0, got {occurrence}")
         occ = occurrence if occurrence is not None else 0
 
         if paragraph is not None:

--- a/docx_editor/document.py
+++ b/docx_editor/document.py
@@ -239,22 +239,28 @@ class Document:
             HashMismatchError: If ``paragraph``'s hash is stale.
 
         Example:
-            for r in doc.find_all("30 days"):
-                doc.replace(
+            # Edit every match in one atomic batch. reversed() puts
+            # same-paragraph ops in the required descending occurrence order,
+            # so this is safe however the matches are distributed:
+            ops = [
+                EditOperation.replace(
                     r.text,
                     "60 days",
                     paragraph=r.paragraph_ref,
                     occurrence=r.paragraph_occurrence,
                 )
+                for r in reversed(doc.find_all("30 days"))
+            ]
+            doc.batch_edit(ops)
 
-        Editing a paragraph invalidates its remaining refs and shifts the
-        occurrence numbers of the matches after the edit, so when one
-        paragraph holds several matches either re-run find_all after each
-        edit, or apply them in a single batch_edit with the same-paragraph
-        ops in *descending* occurrence order — an edit never shifts the
-        matches before it. (Ascending order mis-targets; descending is not
-        valid for search strings that overlap themselves, e.g. "aa" in
-        "aaaa".)
+        Editing one match at a time also works when every paragraph holds at
+        most one match; with several matches in one paragraph, an edit
+        invalidates the paragraph's remaining refs and shifts the occurrence
+        numbers of the matches after it, so either re-run find_all after each
+        edit or batch the same-paragraph ops in *descending* occurrence order
+        as above — an edit never shifts the matches before it. (Ascending
+        order mis-targets; descending is not valid for search strings that
+        overlap themselves, e.g. "aa" in "aaaa".)
         """
         self._ensure_open()
         return self._revision_manager.find_all(text, paragraph=paragraph)

--- a/docx_editor/document.py
+++ b/docx_editor/document.py
@@ -247,9 +247,14 @@ class Document:
                     occurrence=r.paragraph_occurrence,
                 )
 
-        Note: editing a paragraph invalidates its remaining refs; when editing
-        several matches in one paragraph, re-run find_all after each edit or
-        apply edits via batch_edit in one pass.
+        Editing a paragraph invalidates its remaining refs and shifts the
+        occurrence numbers of the matches after the edit, so when one
+        paragraph holds several matches either re-run find_all after each
+        edit, or apply them in a single batch_edit with the same-paragraph
+        ops in *descending* occurrence order — an edit never shifts the
+        matches before it. (Ascending order mis-targets; descending is not
+        valid for search strings that overlap themselves, e.g. "aa" in
+        "aaaa".)
         """
         self._ensure_open()
         return self._revision_manager.find_all(text, paragraph=paragraph)

--- a/docx_editor/document.py
+++ b/docx_editor/document.py
@@ -210,9 +210,49 @@ class Document:
                     paragraph=match.paragraph_ref,
                     occurrence=match.paragraph_occurrence,
                 )
+
+        To enumerate every hit in one call, use :meth:`find_all`.
         """
         self._ensure_open()
         return self._revision_manager.find_text(text, occurrence)
+
+    def find_all(self, text: str, paragraph: str | None = None) -> list[SearchResult]:
+        """Find every match of ``text``, in document order.
+
+        One call replaces the N+1 ``find_text`` probes needed to enumerate N
+        hits, and each result carries exactly what a follow-up edit needs:
+        pass ``paragraph_ref`` as ``paragraph=`` and ``paragraph_occurrence``
+        as ``occurrence=`` to target that specific match.
+
+        Args:
+            text: Text to search for (must be non-empty).
+            paragraph: Optional paragraph reference (e.g., "P2#f3c1") to scope
+                the search. None searches the whole document.
+
+        Returns:
+            A list of SearchResult (see :meth:`find_text` for the fields),
+            empty when nothing matches — no-match is not an error here.
+
+        Raises:
+            ValueError: If ``text`` is empty or ``paragraph`` is malformed.
+            ParagraphIndexError: If ``paragraph``'s index is out of range.
+            HashMismatchError: If ``paragraph``'s hash is stale.
+
+        Example:
+            for r in doc.find_all("30 days"):
+                doc.replace(
+                    r.text,
+                    "60 days",
+                    paragraph=r.paragraph_ref,
+                    occurrence=r.paragraph_occurrence,
+                )
+
+        Note: editing a paragraph invalidates its remaining refs; when editing
+        several matches in one paragraph, re-run find_all after each edit or
+        apply edits via batch_edit in one pass.
+        """
+        self._ensure_open()
+        return self._revision_manager.find_all(text, paragraph=paragraph)
 
     def count_matches(self, text: str) -> int:
         """Count how many times a text string appears in the document.
@@ -634,7 +674,7 @@ class Document:
         self._ensure_open()
         return self._revision_manager.get_markup_text()
 
-    def replace(self, find: str, replace_with: str, *, paragraph: str, occurrence: int = 0) -> str:
+    def replace(self, find: str, replace_with: str, *, paragraph: str, occurrence: int | None = None) -> str:
         """Replace text with tracked changes.
 
         Creates a tracked deletion of the old text and insertion of the new text.
@@ -643,11 +683,21 @@ class Document:
             find: Text to find and replace
             replace_with: Replacement text
             paragraph: Paragraph reference from list_paragraphs() (e.g., "P2#f3c1")
-            occurrence: Which occurrence within the paragraph (0 = first, 1 = second, etc.)
+            occurrence: Which occurrence within the paragraph (0 = first,
+                1 = second, etc.). Omitted → ``find`` must be unique in the
+                paragraph, else AmbiguousTextError (use find_all() to
+                enumerate the matches, or pass an explicit occurrence).
 
         Returns:
             New paragraph reference with updated hash (e.g., "P2#c3d4").
             Use this for follow-up edits without calling list_paragraphs().
+
+        Raises:
+            TextNotFoundError: If ``find`` is absent or ``occurrence`` is out
+                of range for the paragraph.
+            AmbiguousTextError: If ``occurrence`` is omitted and ``find``
+                matches more than once in the paragraph.
+            HashMismatchError: If the paragraph hash is stale.
 
         Example:
             new_ref = doc.replace("30 days", "60 days", paragraph="P2#f3c1")
@@ -657,16 +707,25 @@ class Document:
         self._revision_manager.replace_text(find, replace_with, occurrence=occurrence, paragraph=paragraph)
         return self._compute_new_ref(paragraph)
 
-    def delete(self, text: str, *, paragraph: str, occurrence: int = 0) -> str:
+    def delete(self, text: str, *, paragraph: str, occurrence: int | None = None) -> str:
         """Mark text as deleted with tracked changes.
 
         Args:
             text: Text to mark as deleted
             paragraph: Paragraph reference from list_paragraphs() (e.g., "P2#f3c1")
-            occurrence: Which occurrence within the paragraph (0 = first, 1 = second, etc.)
+            occurrence: Which occurrence within the paragraph (0 = first,
+                1 = second, etc.). Omitted → ``text`` must be unique in the
+                paragraph, else AmbiguousTextError.
 
         Returns:
             New paragraph reference with updated hash (e.g., "P2#c3d4").
+
+        Raises:
+            TextNotFoundError: If ``text`` is absent or ``occurrence`` is out
+                of range for the paragraph.
+            AmbiguousTextError: If ``occurrence`` is omitted and ``text``
+                matches more than once in the paragraph.
+            HashMismatchError: If the paragraph hash is stale.
 
         Example:
             new_ref = doc.delete("obsolete clause", paragraph="P2#f3c1")
@@ -675,17 +734,26 @@ class Document:
         self._revision_manager.suggest_deletion(text, occurrence=occurrence, paragraph=paragraph)
         return self._compute_new_ref(paragraph)
 
-    def insert_after(self, anchor: str, text: str, *, paragraph: str, occurrence: int = 0) -> str:
+    def insert_after(self, anchor: str, text: str, *, paragraph: str, occurrence: int | None = None) -> str:
         """Insert text after anchor with tracked changes.
 
         Args:
             anchor: Text to find as insertion point
             text: Text to insert after the anchor
             paragraph: Paragraph reference from list_paragraphs() (e.g., "P2#f3c1")
-            occurrence: Which occurrence of anchor within the paragraph (0 = first)
+            occurrence: Which occurrence of anchor within the paragraph
+                (0 = first). Omitted → ``anchor`` must be unique in the
+                paragraph, else AmbiguousTextError.
 
         Returns:
             New paragraph reference with updated hash (e.g., "P2#c3d4").
+
+        Raises:
+            TextNotFoundError: If ``anchor`` is absent or ``occurrence`` is
+                out of range for the paragraph.
+            AmbiguousTextError: If ``occurrence`` is omitted and ``anchor``
+                matches more than once in the paragraph.
+            HashMismatchError: If the paragraph hash is stale.
 
         Example:
             new_ref = doc.insert_after("Section 5", " (as amended)", paragraph="P2#f3c1")
@@ -694,17 +762,26 @@ class Document:
         self._revision_manager.insert_text_after(anchor, text, occurrence=occurrence, paragraph=paragraph)
         return self._compute_new_ref(paragraph)
 
-    def insert_before(self, anchor: str, text: str, *, paragraph: str, occurrence: int = 0) -> str:
+    def insert_before(self, anchor: str, text: str, *, paragraph: str, occurrence: int | None = None) -> str:
         """Insert text before anchor with tracked changes.
 
         Args:
             anchor: Text to find as insertion point
             text: Text to insert before the anchor
             paragraph: Paragraph reference from list_paragraphs() (e.g., "P2#f3c1")
-            occurrence: Which occurrence of anchor within the paragraph (0 = first)
+            occurrence: Which occurrence of anchor within the paragraph
+                (0 = first). Omitted → ``anchor`` must be unique in the
+                paragraph, else AmbiguousTextError.
 
         Returns:
             New paragraph reference with updated hash (e.g., "P2#c3d4").
+
+        Raises:
+            TextNotFoundError: If ``anchor`` is absent or ``occurrence`` is
+                out of range for the paragraph.
+            AmbiguousTextError: If ``occurrence`` is omitted and ``anchor``
+                matches more than once in the paragraph.
+            HashMismatchError: If the paragraph hash is stale.
 
         Example:
             new_ref = doc.insert_before("Section 6", "New clause: ", paragraph="P2#f3c1")
@@ -743,6 +820,15 @@ class Document:
             When dry_run is False: list of new paragraph references with updated
             hashes, in input order.
             When dry_run is True: list of EditValidationResult, one per operation.
+
+        Raises:
+            BatchOperationError: The only exception a non-dry-run batch raises
+                for a failing operation — validation (malformed ref, stale
+                hash, bad index) and apply (missing text, ambiguous target)
+                failures alike. ``operation_index`` names the failing op and
+                ``original`` (also ``__cause__``) holds the underlying typed
+                exception (e.g. a HashMismatchError with ``actual_hash``).
+                The document is left unchanged.
 
         Example:
             new_refs = doc.batch_edit([
@@ -796,6 +882,10 @@ class Document:
         Returns:
             List of new paragraph references with updated hashes, in input order
 
+        Raises:
+            BatchOperationError: The only exception raised for a failing
+                rewrite; carries ``operation_index`` and ``original``.
+
         Example:
             refs = doc.list_paragraphs()
             new_refs = doc.batch_rewrite([
@@ -815,7 +905,7 @@ class Document:
         comment: str,
         *,
         paragraph: str | None = None,
-        occurrence: int = 0,
+        occurrence: int | None = None,
     ) -> int:
         """Add a comment anchored to specific text.
 
@@ -829,10 +919,19 @@ class Document:
             comment: The comment content.
             paragraph: Optional paragraph reference (e.g., ``"P3#a7b2"``) to
                 scope the search. ``None`` searches the whole document.
-            occurrence: Which occurrence to anchor to (0 = first).
+            occurrence: Which occurrence to anchor to (0 = first). Omitted →
+                ``anchor_text`` must be unique in the search scope, else
+                AmbiguousTextError.
 
         Returns:
             The comment ID.
+
+        Raises:
+            TextNotFoundError: If ``anchor_text`` is absent or ``occurrence``
+                is out of range for the scope.
+            AmbiguousTextError: If ``occurrence`` is omitted and
+                ``anchor_text`` matches more than once in the search scope.
+            HashMismatchError: If ``paragraph``'s hash is stale.
 
         Example:
             doc.add_comment("Section 5", "Please review this section")

--- a/docx_editor/exceptions.py
+++ b/docx_editor/exceptions.py
@@ -142,8 +142,18 @@ def _truncate_preview(text: str, limit: int = 80) -> str:
     return text[:limit] + "..."
 
 
+def _append_preview(msg: str, preview: str) -> str:
+    """Append the 'Current content' suffix with a period-safe separator."""
+    sep = " " if msg.endswith(".") else ". "
+    return f'{msg}{sep}Current content: "{preview}"'
+
+
 class TextNotFoundError(DocxEditError):
     """Raised when the target text cannot be found in the document.
+
+    Also raised when the text exists but an explicit ``occurrence`` is out of
+    range — the message then reports the actual count instead of claiming the
+    text is absent, and ``occurrence``/``total_occurrences`` are set.
 
     Attributes:
         search_text: The text that was being searched for.
@@ -185,8 +195,7 @@ class TextNotFoundError(DocxEditError):
             msg = f"Text not found: '{search_text}'"
 
         if self.paragraph_preview is not None:
-            sep = " " if msg.endswith(".") else ". "
-            msg += f'{sep}Current content: "{self.paragraph_preview}"'
+            msg = _append_preview(msg, self.paragraph_preview)
 
         super().__init__(msg)
 
@@ -228,7 +237,7 @@ class AmbiguousTextError(DocxEditError):
             f"Pass occurrence= (0-based) to pick one, or use find_all() to list every match."
         )
         if self.paragraph_preview is not None:
-            msg += f' Current content: "{self.paragraph_preview}"'
+            msg = _append_preview(msg, self.paragraph_preview)
         super().__init__(msg)
 
 

--- a/docx_editor/exceptions.py
+++ b/docx_editor/exceptions.py
@@ -151,7 +151,7 @@ class TextNotFoundError(DocxEditError):
             if the search was document-wide.
         paragraph_preview: Current visible text of the scoped paragraph
             (truncated to 80 chars with "..." suffix), or None if unscoped.
-        occurrence: 1-indexed occurrence number requested (for nth-match
+        occurrence: 0-based occurrence index requested (for nth-match
             lookups), or None otherwise.
         total_occurrences: Actual number of occurrences found, or None for
             non-occurrence lookups.
@@ -185,8 +185,50 @@ class TextNotFoundError(DocxEditError):
             msg = f"Text not found: '{search_text}'"
 
         if self.paragraph_preview is not None:
-            msg += f'. Current content: "{self.paragraph_preview}"'
+            sep = " " if msg.endswith(".") else ". "
+            msg += f'{sep}Current content: "{self.paragraph_preview}"'
 
+        super().__init__(msg)
+
+
+class AmbiguousTextError(DocxEditError):
+    """Raised when an edit target matches more than once and no occurrence was chosen.
+
+    Edit methods called without an explicit ``occurrence`` require the target
+    text to be unique within the search scope; otherwise the intended match is
+    ambiguous and editing the first one silently risks changing the wrong text.
+    Pass ``occurrence=`` (0-based) to pick a match, or enumerate every match
+    with ``find_all()``.
+
+    Attributes:
+        search_text: The text that matched multiple times.
+        paragraph_ref: Paragraph reference the search was scoped to, or None
+            if the search was document-wide.
+        paragraph_preview: Current visible text of the scoped paragraph
+            (truncated to 80 chars with "..." suffix), or None if unscoped.
+        total_occurrences: Number of matches found in the search scope.
+    """
+
+    def __init__(
+        self,
+        search_text: str,
+        *,
+        paragraph_ref: str | None = None,
+        paragraph_preview: str | None = None,
+        total_occurrences: int,
+    ):
+        self.search_text = search_text
+        self.paragraph_ref = paragraph_ref
+        self.paragraph_preview = _truncate_preview(paragraph_preview) if paragraph_preview is not None else None
+        self.total_occurrences = total_occurrences
+
+        scope = f"paragraph {paragraph_ref}" if paragraph_ref is not None else "the document"
+        msg = (
+            f"'{search_text}' matches {total_occurrences} times in {scope}. "
+            f"Pass occurrence= (0-based) to pick one, or use find_all() to list every match."
+        )
+        if self.paragraph_preview is not None:
+            msg += f' Current content: "{self.paragraph_preview}"'
         super().__init__(msg)
 
 
@@ -213,17 +255,21 @@ class ParagraphIndexError(DocxEditError):
 
 
 class BatchOperationError(DocxEditError):
-    """Raised when a single operation in a batch fails validation.
+    """Raised when a single operation in a batch fails (validation or apply).
 
     Attributes:
         operation_index: 0-indexed position of the failing operation in the
             input list.
         reason: Human-readable description of why the operation was rejected.
+        original: The underlying exception that caused the failure (also set
+            as ``__cause__``), or None. Typed recovery data stays reachable
+            through it, e.g. ``e.original.actual_hash`` for a stale hash.
     """
 
-    def __init__(self, operation_index: int, reason: str):
+    def __init__(self, operation_index: int, reason: str, *, original: Exception | None = None):
         self.operation_index = operation_index
         self.reason = reason
+        self.original = original
         super().__init__(f"Operation {operation_index}: {reason}")
 
 

--- a/docx_editor/track_changes.py
+++ b/docx_editor/track_changes.py
@@ -12,7 +12,9 @@ from typing import Literal
 from xml.dom.minidom import Element
 
 from .exceptions import (
+    AmbiguousTextError,
     BatchOperationError,
+    DocxEditError,
     HashMismatchError,
     ParagraphIndexError,
     RevisionError,
@@ -53,17 +55,17 @@ class EditOperation:
     replace_with: str | None = None  # For replace
     text: str | None = None  # For delete (text to delete) or insert (text to insert)
     anchor: str | None = None  # For insert_after/insert_before
-    occurrence: int = 0
+    occurrence: int | None = None  # None = target must be unique in the paragraph
 
     @staticmethod
-    def _validate_common(constructor: str, paragraph: str, occurrence: int) -> None:
+    def _validate_common(constructor: str, paragraph: str, occurrence: int | None) -> None:
         """Construction-time checks shared by all typed constructors."""
         ParagraphRef.parse(paragraph)
-        if occurrence < 0:
+        if occurrence is not None and occurrence < 0:
             raise ValueError(f"EditOperation.{constructor}(): occurrence must be >= 0, got {occurrence}")
 
     @classmethod
-    def replace(cls, find: str, replace_with: str, *, paragraph: str, occurrence: int = 0) -> "EditOperation":
+    def replace(cls, find: str, replace_with: str, *, paragraph: str, occurrence: int | None = None) -> "EditOperation":
         """Build a validated replace operation (mirrors ``Document.replace``).
 
         Args:
@@ -71,7 +73,9 @@ class EditOperation:
             replace_with: Replacement text (empty string allowed — replacing
                 with nothing is a valid tracked deletion)
             paragraph: Paragraph reference from list_paragraphs() (e.g., "P2#f3c1")
-            occurrence: Which occurrence within the paragraph (0 = first)
+            occurrence: Which occurrence within the paragraph (0 = first).
+                Omitted → ``find`` must be unique in the paragraph, else the
+                batch fails with a wrapped AmbiguousTextError at apply time.
 
         Raises:
             ValueError: If the paragraph ref is malformed, ``occurrence`` is
@@ -91,13 +95,15 @@ class EditOperation:
         )
 
     @classmethod
-    def delete(cls, text: str, *, paragraph: str, occurrence: int = 0) -> "EditOperation":
+    def delete(cls, text: str, *, paragraph: str, occurrence: int | None = None) -> "EditOperation":
         """Build a validated delete operation (mirrors ``Document.delete``).
 
         Args:
             text: Text to mark as deleted (must be non-empty)
             paragraph: Paragraph reference from list_paragraphs() (e.g., "P2#f3c1")
-            occurrence: Which occurrence within the paragraph (0 = first)
+            occurrence: Which occurrence within the paragraph (0 = first).
+                Omitted → ``text`` must be unique in the paragraph, else the
+                batch fails with a wrapped AmbiguousTextError at apply time.
 
         Raises:
             ValueError: If the paragraph ref is malformed, ``occurrence`` is
@@ -115,7 +121,7 @@ class EditOperation:
         anchor: str,
         text: str,
         paragraph: str,
-        occurrence: int,
+        occurrence: int | None,
     ) -> "EditOperation":
         cls._validate_common(action, paragraph, occurrence)
         if not anchor:
@@ -125,14 +131,17 @@ class EditOperation:
         return cls(action=action, paragraph=paragraph, anchor=anchor, text=text, occurrence=occurrence)
 
     @classmethod
-    def insert_after(cls, anchor: str, text: str, *, paragraph: str, occurrence: int = 0) -> "EditOperation":
+    def insert_after(cls, anchor: str, text: str, *, paragraph: str, occurrence: int | None = None) -> "EditOperation":
         """Build a validated insert_after operation (mirrors ``Document.insert_after``).
 
         Args:
             anchor: Text to find as insertion point (must be non-empty)
             text: Text to insert after the anchor
             paragraph: Paragraph reference from list_paragraphs() (e.g., "P2#f3c1")
-            occurrence: Which occurrence of anchor within the paragraph (0 = first)
+            occurrence: Which occurrence of anchor within the paragraph
+                (0 = first). Omitted → ``anchor`` must be unique in the
+                paragraph, else the batch fails with a wrapped
+                AmbiguousTextError at apply time.
 
         Raises:
             ValueError: If the paragraph ref is malformed, ``occurrence`` is
@@ -141,14 +150,17 @@ class EditOperation:
         return cls._insert("insert_after", anchor, text, paragraph, occurrence)
 
     @classmethod
-    def insert_before(cls, anchor: str, text: str, *, paragraph: str, occurrence: int = 0) -> "EditOperation":
+    def insert_before(cls, anchor: str, text: str, *, paragraph: str, occurrence: int | None = None) -> "EditOperation":
         """Build a validated insert_before operation (mirrors ``Document.insert_before``).
 
         Args:
             anchor: Text to find as insertion point (must be non-empty)
             text: Text to insert before the anchor
             paragraph: Paragraph reference from list_paragraphs() (e.g., "P2#f3c1")
-            occurrence: Which occurrence of anchor within the paragraph (0 = first)
+            occurrence: Which occurrence of anchor within the paragraph
+                (0 = first). Omitted → ``anchor`` must be unique in the
+                paragraph, else the batch fails with a wrapped
+                AmbiguousTextError at apply time.
 
         Raises:
             ValueError: If the paragraph ref is malformed, ``occurrence`` is
@@ -169,7 +181,7 @@ class EditValidationResult:
 
 @dataclass(frozen=True)
 class SearchResult:
-    """Public result of ``Document.find_text`` — no DOM internals.
+    """Public result of ``Document.find_text`` / ``find_all`` — no DOM internals.
 
     ``start``/``end`` are character offsets in the *containing paragraph's*
     visible text (text maps are per-paragraph), not document-wide offsets.
@@ -420,18 +432,53 @@ class RevisionManager:
             raise HashMismatchError(ref.index, ref.hash, actual_hash, preview)
         return p
 
-    def _find_in_paragraph(self, paragraph, text: str, occurrence: int = 0) -> TextMapMatch | None:
-        """Find the nth occurrence of text within a single paragraph."""
-        text_map = build_text_map(paragraph)
-        return find_in_text_map(text_map, text, occurrence)
+    def _locate_in_paragraph(self, paragraph, paragraph_ref: str, text: str, occurrence: int | None) -> TextMapMatch:
+        """The single scoped find-or-raise path shared by every paragraph-scoped edit.
 
-    def _paragraph_preview(self, paragraph) -> str:
-        """Visible text of a paragraph, used for scoped TextNotFoundError previews.
+        Args:
+            paragraph: The resolved <w:p> element.
+            paragraph_ref: The caller's ref string (for error messages).
+            text: Text to locate.
+            occurrence: Which occurrence (0 = first). None means the text must
+                be unique within the paragraph.
 
-        Truncation to 80 chars is handled by ``TextNotFoundError._truncate_preview``;
-        callers must not truncate here, to keep a single source of truth.
+        Raises:
+            TextNotFoundError: If the text is absent, or ``occurrence`` is out
+                of range (then with ``occurrence``/``total_occurrences`` set).
+            AmbiguousTextError: If ``occurrence`` is None and the text matches
+                more than once in the paragraph.
         """
-        return build_text_map(paragraph).text
+        text_map = build_text_map(paragraph)
+        total = 0
+        start = 0
+        while (idx := text_map.find(text, start)) != -1:
+            total += 1
+            start = idx + 1
+
+        occ = occurrence if occurrence is not None else 0
+        match = find_in_text_map(text_map, text, occ)
+        if match is None:
+            if total > 0:
+                raise TextNotFoundError(
+                    text,
+                    paragraph_ref=paragraph_ref,
+                    paragraph_preview=text_map.text,
+                    occurrence=occ,
+                    total_occurrences=total,
+                )
+            raise TextNotFoundError(
+                text,
+                paragraph_ref=paragraph_ref,
+                paragraph_preview=text_map.text,
+            )
+        if occurrence is None and total > 1:
+            raise AmbiguousTextError(
+                text,
+                paragraph_ref=paragraph_ref,
+                paragraph_preview=text_map.text,
+                total_occurrences=total,
+            )
+        return match
 
     def batch_edit(self, operations: list[EditOperation]) -> list[int]:
         """Apply multiple edits atomically with upfront hash validation.
@@ -447,9 +494,11 @@ class RevisionManager:
             List of change IDs, one per operation (in original input order)
 
         Raises:
-            HashMismatchError: If any paragraph hash is stale (no edits applied)
-            BatchOperationError: If any operation fails validation (carries
-                ``operation_index`` so the caller knows which op failed).
+            BatchOperationError: If any operation fails — validation (malformed
+                ref, stale hash, bad index) or apply (missing text, ambiguous
+                target). Carries ``operation_index`` so the caller knows which
+                op failed, and ``original`` (also ``__cause__``) with the
+                underlying typed exception. No edits are applied on failure.
         """
         if not operations:
             return []
@@ -459,8 +508,11 @@ class RevisionManager:
         for i, op in enumerate(operations):
             if not op.paragraph:
                 raise BatchOperationError(i, "paragraph reference is required for batch mode")
-            ref = ParagraphRef.parse(op.paragraph)
-            self._resolve_paragraph(ref)  # Raises HashMismatchError if stale
+            try:
+                ref = ParagraphRef.parse(op.paragraph)
+                self._resolve_paragraph(ref)  # Raises HashMismatchError if stale
+            except (ValueError, DocxEditError) as e:
+                raise BatchOperationError(i, str(e), original=e) from e
             parsed.append((i, ref, op))
 
         # Sort by paragraph index descending (reverse order) for application
@@ -475,8 +527,8 @@ class RevisionManager:
             for original_idx, _ref, op in parsed:
                 try:
                     change_id = self._apply_single_edit(op)
-                except ValueError as e:
-                    raise BatchOperationError(original_idx, str(e)) from e
+                except (ValueError, DocxEditError) as e:
+                    raise BatchOperationError(original_idx, str(e), original=e) from e
                 results[original_idx] = change_id
             return results
         except Exception:
@@ -494,14 +546,14 @@ class RevisionManager:
 
         Shared by ``_apply_single_edit`` and ``_validate_single`` so the two
         paths cannot drift out of sync. Rejects a negative ``occurrence`` up
-        front (the one non-well-formed input ``_find_in_paragraph`` chokes on)
+        front (the one non-well-formed input the text-map search chokes on)
         so both paths fail cleanly before the search.
 
         Raises:
             ValueError: If ``occurrence`` is negative, required arguments for
                 op.action are missing, or the action is unrecognized.
         """
-        if op.occurrence < 0:
+        if op.occurrence is not None and op.occurrence < 0:
             raise ValueError(f"occurrence must be >= 0, got {op.occurrence}")
 
         if op.action == "replace":
@@ -525,13 +577,7 @@ class RevisionManager:
         p = self.editor.dom.getElementsByTagName("w:p")[ref.index - 1]
 
         target = self._resolve_action_target(op)
-        match = self._find_in_paragraph(p, target, op.occurrence)
-        if match is None:
-            raise TextNotFoundError(
-                target,
-                paragraph_ref=op.paragraph,
-                paragraph_preview=self._paragraph_preview(p),
-            )
+        match = self._locate_in_paragraph(p, op.paragraph, target, op.occurrence)
 
         if op.action == "replace":
             assert op.replace_with is not None  # guaranteed by _resolve_action_target
@@ -582,8 +628,9 @@ class RevisionManager:
         """Return an error message if ``op`` would fail, or None if it is valid.
 
         Reuses ``_resolve_paragraph``, ``_resolve_action_target``, and
-        ``_find_in_paragraph`` — the same helpers ``_apply_single_edit`` uses —
-        so dry-run validation cannot drift from real application semantics.
+        ``_locate_in_paragraph`` — the same helpers ``_apply_single_edit`` uses —
+        so dry-run validation cannot drift from real application semantics
+        (out-of-range and ambiguous targets produce the same error text).
         Reads only.
         """
         if not op.paragraph:
@@ -602,42 +649,57 @@ class RevisionManager:
         # Resolve required args + the text this op must locate via the same
         # helper _apply_single_edit uses (which also rejects a negative
         # occurrence), so validation cannot drift from application semantics and
-        # the find below never raises.
+        # the locate below only raises the same errors application would.
         try:
             target = self._resolve_action_target(op)
         except ValueError as e:
             return str(e)
 
-        if self._find_in_paragraph(p, target, op.occurrence) is None:
-            return f"text {target!r} not found in paragraph {op.paragraph} ({self._paragraph_preview(p)!r})"
+        try:
+            self._locate_in_paragraph(p, op.paragraph, target, op.occurrence)
+        except DocxEditError as e:
+            return str(e)
 
         return None
 
     def batch_rewrite(self, rewrites: list[tuple[str, str]]) -> None:
-        """Rewrite multiple paragraphs with upfront hash validation."""
+        """Rewrite multiple paragraphs with upfront hash validation.
+
+        Raises:
+            BatchOperationError: If any rewrite fails — validation (malformed
+                ref, duplicate paragraph, stale hash, bad index) or apply.
+                Carries ``operation_index`` and ``original`` (also
+                ``__cause__``) with the underlying typed exception.
+        """
         if not rewrites:
             return
 
         # Parse and validate all refs upfront
-        parsed: list[tuple[ParagraphRef, str]] = []
+        parsed: list[tuple[int, ParagraphRef, str]] = []
         seen_indices: set[int] = set()
         for i, (ref_str, new_text) in enumerate(rewrites):
-            ref = ParagraphRef.parse(ref_str)
+            try:
+                ref = ParagraphRef.parse(ref_str)
+                self._resolve_paragraph(ref)  # Raises HashMismatchError if stale
+            except (ValueError, DocxEditError) as e:
+                raise BatchOperationError(i, str(e), original=e) from e
             if ref.index in seen_indices:
                 raise BatchOperationError(
                     i,
                     f"duplicate paragraph P{ref.index}. Each paragraph can appear at most once in a batch rewrite.",
                 )
             seen_indices.add(ref.index)
-            self._resolve_paragraph(ref)  # Raises HashMismatchError if stale
-            parsed.append((ref, new_text))
+            parsed.append((i, ref, new_text))
 
         # Sort by paragraph index descending
-        parsed.sort(key=lambda x: x[0].index, reverse=True)
+        parsed.sort(key=lambda x: x[1].index, reverse=True)
 
         # Apply rewrites in reverse paragraph order
-        for ref, new_text in parsed:
-            self.rewrite_paragraph(f"P{ref.index}#{ref.hash}", new_text)
+        for original_idx, ref, new_text in parsed:
+            try:
+                self.rewrite_paragraph(f"P{ref.index}#{ref.hash}", new_text)
+            except (ValueError, DocxEditError) as e:
+                raise BatchOperationError(original_idx, str(e), original=e) from e
 
     def rewrite_paragraph(self, ref_str: str, new_text: str) -> None:
         """Rewrite a paragraph's text, generating fine-grained tracked changes.
@@ -847,20 +909,27 @@ class RevisionManager:
                 local_occ += 1
         return count
 
-    def _find_document_wide(self, text: str, occurrence: int = 0) -> TextMapMatch:
+    def _find_document_wide(self, text: str, occurrence: int | None = None) -> TextMapMatch:
         """Document-wide nth-occurrence lookup via text maps.
 
         Raises:
             TextNotFoundError: If the text is not found or occurrence doesn't
                 exist; ``total_occurrences`` matches :meth:`count_matches`.
+            AmbiguousTextError: If ``occurrence`` is None and the text matches
+                more than once in the document.
         """
-        match = self._find_across_boundaries(text, occurrence)
-        if match is not None:
-            return match
-        total = self.count_matches(text)
-        if total:
-            raise TextNotFoundError(text, occurrence=occurrence, total_occurrences=total)
-        raise TextNotFoundError(text)
+        occ = occurrence if occurrence is not None else 0
+        match = self._find_across_boundaries(text, occ)
+        if match is None:
+            total = self.count_matches(text)
+            if total:
+                raise TextNotFoundError(text, occurrence=occ, total_occurrences=total)
+            raise TextNotFoundError(text)
+        if occurrence is None:
+            total = self.count_matches(text)
+            if total > 1:
+                raise AmbiguousTextError(text, total_occurrences=total)
+        return match
 
     def _find_across_boundaries_located(self, text: str, occurrence: int = 0) -> _LocatedMatch | None:
         """Find the nth occurrence of text across element boundaries.
@@ -917,7 +986,60 @@ class RevisionManager:
             spans_revision=located.match.spans_boundary,
         )
 
-    def replace_text(self, find: str, replace_with: str, occurrence: int = 0, paragraph: str | None = None) -> int:
+    def find_all(self, text: str, paragraph: str | None = None) -> list[SearchResult]:
+        """Enumerate every match of ``text`` as a list of SearchResults.
+
+        One call replaces the N+1 ``find_text`` probes needed to enumerate N
+        hits. Each result's ``paragraph_ref``/``paragraph_occurrence`` plug
+        directly into a follow-up edit's ``paragraph=``/``occurrence=``.
+
+        Args:
+            text: Text to search for (must be non-empty).
+            paragraph: Optional paragraph reference (e.g., "P2#f3c1") to scope
+                the search. None searches the whole document.
+
+        Returns:
+            SearchResults in document order; ``[]`` when nothing matches (it
+            is an enumeration API, not a lookup — no-match is not an error).
+
+        Raises:
+            ValueError: If ``text`` is empty, or ``paragraph`` is malformed.
+            ParagraphIndexError: If ``paragraph``'s index is out of range.
+            HashMismatchError: If ``paragraph``'s hash is stale.
+        """
+        if not text:
+            raise ValueError("find_all() requires a non-empty search string")
+
+        if paragraph is not None:
+            ref = ParagraphRef.parse(paragraph)
+            paragraphs = [(ref.index, self._resolve_paragraph(ref))]
+        else:
+            paragraphs = list(enumerate(self.editor.dom.getElementsByTagName("w:p"), start=1))
+
+        results: list[SearchResult] = []
+        for idx, p in paragraphs:
+            text_map = build_text_map(p)
+            paragraph_ref: str | None = None
+            local_occ = 0
+            while (match := find_in_text_map(text_map, text, local_occ)) is not None:
+                if paragraph_ref is None:
+                    paragraph_ref = f"P{idx}#{compute_paragraph_hash(p)}"
+                results.append(
+                    SearchResult(
+                        start=match.start,
+                        end=match.end,
+                        text=match.text,
+                        paragraph_ref=paragraph_ref,
+                        paragraph_occurrence=local_occ,
+                        spans_revision=match.spans_boundary,
+                    )
+                )
+                local_occ += 1
+        return results
+
+    def replace_text(
+        self, find: str, replace_with: str, occurrence: int | None = None, paragraph: str | None = None
+    ) -> int:
         """Replace text with tracked changes (deletion + insertion).
 
         Finds the specified occurrence of `find` text and replaces it with `replace_with`,
@@ -926,7 +1048,9 @@ class RevisionManager:
         Args:
             find: Text to find and replace
             replace_with: Replacement text
-            occurrence: Which occurrence to replace (0 = first, 1 = second, etc.)
+            occurrence: Which occurrence to replace (0 = first, 1 = second,
+                etc.). Omitted → ``find`` must be unique in the search scope,
+                else AmbiguousTextError.
             paragraph: Optional paragraph reference (e.g., "P2#f3c1") to scope the search
 
         Returns:
@@ -934,29 +1058,27 @@ class RevisionManager:
 
         Raises:
             TextNotFoundError: If the text is not found or occurrence doesn't exist
+            AmbiguousTextError: If ``occurrence`` is omitted and ``find``
+                matches more than once in the search scope
             HashMismatchError: If the paragraph hash doesn't match
         """
         if paragraph is not None:
             ref = ParagraphRef.parse(paragraph)
             p = self._resolve_paragraph(ref)
-            match = self._find_in_paragraph(p, find, occurrence)
-            if match is None:
-                raise TextNotFoundError(
-                    find,
-                    paragraph_ref=paragraph,
-                    paragraph_preview=self._paragraph_preview(p),
-                )
+            match = self._locate_in_paragraph(p, paragraph, find, occurrence)
             return self._replace_across_nodes(match, replace_with)
 
         match = self._find_document_wide(find, occurrence)
         return self._replace_across_nodes(match, replace_with)
 
-    def suggest_deletion(self, text: str, occurrence: int = 0, paragraph: str | None = None) -> int:
+    def suggest_deletion(self, text: str, occurrence: int | None = None, paragraph: str | None = None) -> int:
         """Mark text as deleted with tracked changes.
 
         Args:
             text: Text to mark as deleted
-            occurrence: Which occurrence to delete (0 = first, 1 = second, etc.)
+            occurrence: Which occurrence to delete (0 = first, 1 = second,
+                etc.). Omitted → ``text`` must be unique in the search scope,
+                else AmbiguousTextError.
             paragraph: Optional paragraph reference (e.g., "P2#f3c1") to scope the search
 
         Returns:
@@ -964,18 +1086,14 @@ class RevisionManager:
 
         Raises:
             TextNotFoundError: If the text is not found or occurrence doesn't exist
+            AmbiguousTextError: If ``occurrence`` is omitted and ``text``
+                matches more than once in the search scope
             HashMismatchError: If the paragraph hash doesn't match
         """
         if paragraph is not None:
             ref = ParagraphRef.parse(paragraph)
             p = self._resolve_paragraph(ref)
-            match = self._find_in_paragraph(p, text, occurrence)
-            if match is None:
-                raise TextNotFoundError(
-                    text,
-                    paragraph_ref=paragraph,
-                    paragraph_preview=self._paragraph_preview(p),
-                )
+            match = self._locate_in_paragraph(p, paragraph, text, occurrence)
             return self._delete_across_nodes(match)
 
         match = self._find_document_wide(text, occurrence)
@@ -1776,13 +1894,17 @@ class RevisionManager:
 
         return first_del_id
 
-    def insert_text_after(self, anchor: str, text: str, occurrence: int = 0, paragraph: str | None = None) -> int:
+    def insert_text_after(
+        self, anchor: str, text: str, occurrence: int | None = None, paragraph: str | None = None
+    ) -> int:
         """Insert text after anchor with tracked changes.
 
         Args:
             anchor: Text to find as the anchor point
             text: Text to insert after the anchor
-            occurrence: Which occurrence of anchor to use (0 = first, 1 = second, etc.)
+            occurrence: Which occurrence of anchor to use (0 = first,
+                1 = second, etc.). Omitted → ``anchor`` must be unique in the
+                search scope, else AmbiguousTextError.
             paragraph: Optional paragraph reference (e.g., "P2#f3c1") to scope the search
 
         Returns:
@@ -1790,17 +1912,23 @@ class RevisionManager:
 
         Raises:
             TextNotFoundError: If the anchor text is not found or occurrence doesn't exist
+            AmbiguousTextError: If ``occurrence`` is omitted and ``anchor``
+                matches more than once in the search scope
             HashMismatchError: If the paragraph hash doesn't match
         """
         return self._insert_text(anchor, text, position="after", occurrence=occurrence, paragraph=paragraph)
 
-    def insert_text_before(self, anchor: str, text: str, occurrence: int = 0, paragraph: str | None = None) -> int:
+    def insert_text_before(
+        self, anchor: str, text: str, occurrence: int | None = None, paragraph: str | None = None
+    ) -> int:
         """Insert text before anchor with tracked changes.
 
         Args:
             anchor: Text to find as the anchor point
             text: Text to insert before the anchor
-            occurrence: Which occurrence of anchor to use (0 = first, 1 = second, etc.)
+            occurrence: Which occurrence of anchor to use (0 = first,
+                1 = second, etc.). Omitted → ``anchor`` must be unique in the
+                search scope, else AmbiguousTextError.
             paragraph: Optional paragraph reference (e.g., "P2#f3c1") to scope the search
 
         Returns:
@@ -1808,6 +1936,8 @@ class RevisionManager:
 
         Raises:
             TextNotFoundError: If the anchor text is not found or occurrence doesn't exist
+            AmbiguousTextError: If ``occurrence`` is omitted and ``anchor``
+                matches more than once in the search scope
             HashMismatchError: If the paragraph hash doesn't match
         """
         return self._insert_text(anchor, text, position="before", occurrence=occurrence, paragraph=paragraph)
@@ -1817,20 +1947,14 @@ class RevisionManager:
         anchor: str,
         text: str,
         position: Literal["before", "after"],
-        occurrence: int = 0,
+        occurrence: int | None = None,
         paragraph: str | None = None,
     ) -> int:
         """Insert text before or after anchor with tracked changes."""
         if paragraph is not None:
             ref = ParagraphRef.parse(paragraph)
             p = self._resolve_paragraph(ref)
-            match = self._find_in_paragraph(p, anchor, occurrence)
-            if match is None:
-                raise TextNotFoundError(
-                    anchor,
-                    paragraph_ref=paragraph,
-                    paragraph_preview=self._paragraph_preview(p),
-                )
+            match = self._locate_in_paragraph(p, paragraph, anchor, occurrence)
             return self._insert_near_match(match, text, position)
 
         match = self._find_document_wide(anchor, occurrence)

--- a/docx_editor/track_changes.py
+++ b/docx_editor/track_changes.py
@@ -30,6 +30,7 @@ from .xml_editor import (
     build_text_map,
     compute_paragraph_hash,
     compute_text_hash,
+    count_in_text_map,
     find_in_text_map,
     get_rPr_xml,
     get_text_node_data,
@@ -449,11 +450,7 @@ class RevisionManager:
                 more than once in the paragraph.
         """
         text_map = build_text_map(paragraph)
-        total = 0
-        start = 0
-        while (idx := text_map.find(text, start)) != -1:
-            total += 1
-            start = idx + 1
+        total = count_in_text_map(text_map, text)
 
         occ = occurrence if occurrence is not None else 0
         match = find_in_text_map(text_map, text, occ)
@@ -902,11 +899,7 @@ class RevisionManager:
         """
         count = 0
         for paragraph in self.editor.dom.getElementsByTagName("w:p"):
-            text_map = build_text_map(paragraph)
-            local_occ = 0
-            while find_in_text_map(text_map, text, local_occ) is not None:
-                count += 1
-                local_occ += 1
+            count += count_in_text_map(build_text_map(paragraph), text)
         return count
 
     def _find_document_wide(self, text: str, occurrence: int | None = None) -> TextMapMatch:

--- a/docx_editor/track_changes.py
+++ b/docx_editor/track_changes.py
@@ -444,11 +444,14 @@ class RevisionManager:
                 be unique within the paragraph.
 
         Raises:
+            ValueError: If ``occurrence`` is negative.
             TextNotFoundError: If the text is absent, or ``occurrence`` is out
                 of range (then with ``occurrence``/``total_occurrences`` set).
             AmbiguousTextError: If ``occurrence`` is None and the text matches
                 more than once in the paragraph.
         """
+        if occurrence is not None and occurrence < 0:
+            raise ValueError(f"occurrence must be >= 0, got {occurrence}")
         text_map = build_text_map(paragraph)
         total = count_in_text_map(text_map, text)
 
@@ -925,11 +928,14 @@ class RevisionManager:
         the exact total is part of the error contract.
 
         Raises:
+            ValueError: If ``occurrence`` is negative.
             TextNotFoundError: If the text is not found or occurrence doesn't
                 exist; ``total_occurrences`` matches :meth:`count_matches`.
             AmbiguousTextError: If ``occurrence`` is None and the text matches
                 more than once in the document.
         """
+        if occurrence is not None and occurrence < 0:
+            raise ValueError(f"occurrence must be >= 0, got {occurrence}")
         occ = occurrence if occurrence is not None else 0
         match = self._find_across_boundaries(text, occ)
         if match is None:

--- a/docx_editor/track_changes.py
+++ b/docx_editor/track_changes.py
@@ -691,12 +691,26 @@ class RevisionManager:
         # Sort by paragraph index descending
         parsed.sort(key=lambda x: x[1].index, reverse=True)
 
-        # Apply rewrites in reverse paragraph order
-        for original_idx, ref, new_text in parsed:
+        # Snapshot DOM before any mutation so we can roll back on partial
+        # failure — same atomicity contract as batch_edit.
+        snapshot = self.editor.dom.toxml(encoding=self.editor.encoding)
+
+        try:
+            # Apply rewrites in reverse paragraph order
+            for original_idx, ref, new_text in parsed:
+                try:
+                    self.rewrite_paragraph(f"P{ref.index}#{ref.hash}", new_text)
+                except (ValueError, DocxEditError) as e:
+                    raise BatchOperationError(original_idx, str(e), original=e) from e
+        except Exception:
+            # Restore via the line-tracking parser so parse_position is preserved.
+            # If rollback itself fails, surface the original edit error — it is
+            # the actionable one; a rollback failure is a secondary symptom.
             try:
-                self.rewrite_paragraph(f"P{ref.index}#{ref.hash}", new_text)
-            except (ValueError, DocxEditError) as e:
-                raise BatchOperationError(original_idx, str(e), original=e) from e
+                self.editor._reload_dom_from_bytes(snapshot)
+            except Exception:
+                pass
+            raise
 
     def rewrite_paragraph(self, ref_str: str, new_text: str) -> None:
         """Rewrite a paragraph's text, generating fine-grained tracked changes.
@@ -902,8 +916,13 @@ class RevisionManager:
             count += count_in_text_map(build_text_map(paragraph), text)
         return count
 
-    def _find_document_wide(self, text: str, occurrence: int | None = None) -> TextMapMatch:
+    def _locate_document_wide(self, text: str, occurrence: int | None = None) -> TextMapMatch:
         """Document-wide nth-occurrence lookup via text maps.
+
+        Totals come from :meth:`count_matches` rather than a single
+        ``count_in_text_map`` call (as ``_locate_in_paragraph`` uses) because
+        text maps are per-paragraph — there is no one document-wide map — and
+        the exact total is part of the error contract.
 
         Raises:
             TextNotFoundError: If the text is not found or occurrence doesn't
@@ -1061,7 +1080,7 @@ class RevisionManager:
             match = self._locate_in_paragraph(p, paragraph, find, occurrence)
             return self._replace_across_nodes(match, replace_with)
 
-        match = self._find_document_wide(find, occurrence)
+        match = self._locate_document_wide(find, occurrence)
         return self._replace_across_nodes(match, replace_with)
 
     def suggest_deletion(self, text: str, occurrence: int | None = None, paragraph: str | None = None) -> int:
@@ -1089,7 +1108,7 @@ class RevisionManager:
             match = self._locate_in_paragraph(p, paragraph, text, occurrence)
             return self._delete_across_nodes(match)
 
-        match = self._find_document_wide(text, occurrence)
+        match = self._locate_document_wide(text, occurrence)
         return self._delete_across_nodes(match)
 
     def _get_run_info(self, node) -> tuple[Element | None, str]:
@@ -1950,7 +1969,7 @@ class RevisionManager:
             match = self._locate_in_paragraph(p, paragraph, anchor, occurrence)
             return self._insert_near_match(match, text, position)
 
-        match = self._find_document_wide(anchor, occurrence)
+        match = self._locate_document_wide(anchor, occurrence)
         return self._insert_near_match(match, text, position)
 
     def _insert_near_match(self, match: TextMapMatch, text: str, position: Literal["before", "after"]) -> int:

--- a/docx_editor/xml_editor.py
+++ b/docx_editor/xml_editor.py
@@ -91,6 +91,21 @@ def find_in_text_map(text_map: TextMap, search: str, occurrence: int = 0) -> Tex
     )
 
 
+def count_in_text_map(text_map: TextMap, search: str) -> int:
+    """Count occurrences of text in a text map.
+
+    Uses the same overlapping-advance semantics as ``find_in_text_map``
+    (successive matches may overlap), so the result is exactly the number of
+    distinct ``occurrence`` values ``find_in_text_map`` can resolve.
+    """
+    count = 0
+    start = 0
+    while (idx := text_map.find(search, start)) != -1:
+        count += 1
+        start = idx + 1
+    return count
+
+
 _PARAGRAPH_REF_RE = re.compile(r"^P(\d+)#([0-9a-f]{4})$")
 
 

--- a/skills/docx/SKILL.md
+++ b/skills/docx/SKILL.md
@@ -226,6 +226,15 @@ for p in doc.list_paragraphs():
 # occurrence=match.paragraph_occurrence (edits count occurrences per paragraph).
 match = doc.find_text("30 days")
 
+# Enumerate EVERY match in one call (returns list[SearchResult], [] if none).
+# Each result plugs straight into a follow-up edit — no occurrence math needed:
+for r in doc.find_all("30 days"):
+    doc.replace(r.text, "60 days", paragraph=r.paragraph_ref,
+                occurrence=r.paragraph_occurrence)
+# Optionally scope to one paragraph: doc.find_all("term", paragraph="P2#f3c1")
+# (editing a paragraph invalidates its remaining refs — re-run find_all after
+# each edit when a paragraph has several matches, or use batch_edit)
+
 # Get all visible text (inserted text included, deleted text excluded)
 visible = doc.get_visible_text()
 
@@ -255,11 +264,17 @@ locations = doc.list_paragraph_locations()
 new_ref = doc.replace("30 days", "60 days", paragraph="P2#f3c1")
 doc.replace("net", "gross", paragraph=new_ref)  # chain without list_paragraphs()
 
-# occurrence is 0-based everywhere (0 = first, the default). Edit methods
-# count occurrences within the target paragraph; find_text counts document-wide.
-# add_comment counts within the paragraph when paragraph= is given, and
-# document-wide (like find_text) when paragraph=None.
+# occurrence is 0-based everywhere (0 = first). Edit methods count occurrences
+# within the target paragraph; find_text counts document-wide. add_comment
+# counts within the paragraph when paragraph= is given, and document-wide
+# (like find_text) when paragraph=None. find_all bridges the two conventions:
+# each result's paragraph_occurrence is already in edit-method coordinates.
+#
+# OMITTING occurrence means "the target is unique in the search scope".
+# If it matches more than once, the edit raises AmbiguousTextError instead of
+# silently editing the first match. Pick a match explicitly:
 doc.replace("thirty", "sixty", paragraph="P4#a1d2", occurrence=1)  # 2nd "thirty"
+doc.replace("thirty", "sixty", paragraph="P4#a1d2", occurrence=0)  # 1st, chosen on purpose
 
 # Delete text (creates tracked deletion)
 doc.delete("unnecessary clause", paragraph="P5#d4e5")
@@ -280,7 +295,7 @@ doc.close()
 
 **Multi-author documents:** Editing inside *another* author's pending insertion preserves their proposal, matching Word: deletions nest a `<w:del>` under your authorship inside their `<w:ins>`, and replacements/insertions put your text in your own sibling `<w:ins>` (splitting theirs when needed) instead of silently rewriting it. `accept_all(author=...)` / `reject_all(author=...)` then resolve each author's changes independently. Only your own pending insertions are edited in place.
 
-**Raises:** `TextNotFoundError` if the text is not found.
+**Raises:** `TextNotFoundError` if the text is not found (or the requested `occurrence` is out of range — the error then reports `total_occurrences`). `AmbiguousTextError` if `occurrence` is omitted and the target matches more than once in the search scope.
 
 ### Comments API
 
@@ -292,9 +307,11 @@ author = os.environ.get("USER") or "Reviewer"
 doc = Document.open("document.docx", author=author)
 
 # Add a comment anchored to text (returns the new comment's ID).
-# Full signature: add_comment(anchor_text, comment, *, paragraph=None, occurrence=0)
+# Full signature: add_comment(anchor_text, comment, *, paragraph=None, occurrence=None)
 # paragraph=None searches the whole document and counts occurrence document-wide;
 # pass paragraph= to scope both the search and the occurrence count to it.
+# Like the edit methods, an omitted occurrence requires a unique anchor
+# (AmbiguousTextError otherwise).
 # The anchor is located with the same visible-text search the edit
 # methods use, so anchors spanning run boundaries are found.
 cid = doc.add_comment("ambiguous term", "Please clarify this term")
@@ -573,7 +590,11 @@ with Document.open("file.docx", author=author) as doc:
 
 Build operations with the typed constructors (`EditOperation.replace/.delete/.insert_after/.insert_before` — same signatures as the `Document` methods). They validate arguments immediately and raise `ValueError` with a field-specific message, instead of failing later at apply time.
 
-If any hash is stale, the entire batch is rejected before any edits are applied.
+**Single-exception contract:** whatever goes wrong with an operation — stale
+hash, malformed ref, missing text, ambiguous target — `batch_edit` (and
+`batch_rewrite`) raise **only** `BatchOperationError`, with `operation_index`
+naming the failing op and `original` (also `__cause__`) holding the underlying
+typed exception. The batch is atomic: nothing is applied on failure.
 
 **Pre-flight with `dry_run=True`** — validates every operation without applying
 anything and returns `list[EditValidationResult]` (fields: `index`, `paragraph`,
@@ -609,12 +630,14 @@ All LLM-facing errors inherit from `DocxEditError` and carry structured fields s
 | ---------------------- | --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
 | `HashMismatchError`    | `paragraph_index`, `expected_hash`, `actual_hash`, `paragraph_preview`                  | Retry with `P{paragraph_index}#{actual_hash}`.                                                   |
 | `TextNotFoundError`    | `search_text`, `paragraph_ref`, `paragraph_preview`, `occurrence`, `total_occurrences`  | Use `paragraph_preview` to pick a substring that actually appears; if `total_occurrences` is set, retry with an `occurrence` < `total_occurrences`. |
+| `AmbiguousTextError`   | `search_text`, `paragraph_ref`, `paragraph_preview`, `total_occurrences`                | The target matched more than once with no `occurrence` given. Enumerate with `find_all()` and pick, or pass an explicit `occurrence` (0-based).      |
 | `ParagraphIndexError`  | `index`, `total_paragraphs`                                                             | Clamp to `1..total_paragraphs` or call `list_paragraphs()` to pick a valid ref.                 |
-| `BatchOperationError`  | `operation_index`, `reason`                                                             | Fix the op at `operations[operation_index]` (or drop it) and retry the batch.                    |
+| `BatchOperationError`  | `operation_index`, `reason`, `original`                                                 | Fix the op at `operations[operation_index]` (or drop it) and retry the batch; `original` is the underlying typed error (e.g. use its `actual_hash` to re-target a stale ref). Batch methods never raise the inner types directly. |
 | `DocumentOpenError`    | `path`, `owner_file`                                                                    | **Do not retry blindly.** The destination is open in Word. Stop and tell the user to close it. Only pass `force=True` if the user confirms the `~$` lock is stale (crashed session). |
 
 ```python
 from docx_editor import (
+    AmbiguousTextError,
     BatchOperationError,
     HashMismatchError,
     ParagraphIndexError,
@@ -628,6 +651,11 @@ except HashMismatchError as e:
 except TextNotFoundError as e:
     # e.paragraph_preview shows the current paragraph content for recovery
     ...
+except AmbiguousTextError as e:
+    # Target matched e.total_occurrences times — enumerate and pick
+    r = doc.find_all("stale text", paragraph=e.paragraph_ref)[0]
+    doc.replace("stale text", "new text", paragraph=r.paragraph_ref,
+                occurrence=r.paragraph_occurrence)
 except ParagraphIndexError as e:
     # Clamp to a valid 1-indexed paragraph number (guard the empty-doc case)
     if e.total_paragraphs == 0:
@@ -635,10 +663,20 @@ except ParagraphIndexError as e:
     safe_idx = max(1, min(e.index, e.total_paragraphs))
     ref = doc.list_paragraphs()[safe_idx - 1].split("|")[0]
     doc.replace("stale text", "new text", paragraph=ref)
-except BatchOperationError as e:
-    # Drop or fix the failing op and retry the batch
-    ops.pop(e.operation_index)
-    doc.batch_edit(ops)
+
+# Batch recovery — BatchOperationError is the ONLY exception batch_edit raises
+# per failing op, so this loop handles every failure mode:
+while ops:
+    try:
+        doc.batch_edit(ops)
+        break
+    except BatchOperationError as e:
+        if isinstance(e.original, HashMismatchError):
+            # Re-target the stale op instead of dropping it
+            op = ops[e.operation_index]
+            op.paragraph = f"P{e.original.paragraph_index}#{e.original.actual_hash}"
+        else:
+            ops.pop(e.operation_index)  # drop the failing op and retry
 ```
 
 **Saving safely (`DocumentOpenError`).** `save()` is atomic — it writes to a temp

--- a/skills/docx/SKILL.md
+++ b/skills/docx/SKILL.md
@@ -232,8 +232,12 @@ for r in doc.find_all("30 days"):
     doc.replace(r.text, "60 days", paragraph=r.paragraph_ref,
                 occurrence=r.paragraph_occurrence)
 # Optionally scope to one paragraph: doc.find_all("term", paragraph="P2#f3c1")
-# (editing a paragraph invalidates its remaining refs — re-run find_all after
-# each edit when a paragraph has several matches, or use batch_edit)
+# Editing a paragraph invalidates its remaining refs AND shifts the occurrence
+# numbers of the matches after the edit. Several matches in ONE paragraph:
+# re-run find_all after each edit, or batch_edit them in DESCENDING occurrence
+# order (an edit never shifts the matches before it; ascending mis-targets,
+# and descending is not valid for self-overlapping search strings like "aa"
+# in "aaaa").
 
 # Get all visible text (inserted text included, deleted text excluded)
 visible = doc.get_visible_text()

--- a/skills/docx/SKILL.md
+++ b/skills/docx/SKILL.md
@@ -227,17 +227,21 @@ for p in doc.list_paragraphs():
 match = doc.find_text("30 days")
 
 # Enumerate EVERY match in one call (returns list[SearchResult], [] if none).
-# Each result plugs straight into a follow-up edit — no occurrence math needed:
-for r in doc.find_all("30 days"):
-    doc.replace(r.text, "60 days", paragraph=r.paragraph_ref,
-                occurrence=r.paragraph_occurrence)
+# Each result plugs straight into a follow-up edit — no occurrence math needed.
+# Edit them all in one atomic batch; reversed() puts same-paragraph ops in the
+# required DESCENDING occurrence order, safe however the matches are spread:
+ops = [EditOperation.replace(r.text, "60 days", paragraph=r.paragraph_ref,
+                             occurrence=r.paragraph_occurrence)
+       for r in reversed(doc.find_all("30 days"))]
+doc.batch_edit(ops)
 # Optionally scope to one paragraph: doc.find_all("term", paragraph="P2#f3c1")
-# Editing a paragraph invalidates its remaining refs AND shifts the occurrence
-# numbers of the matches after the edit. Several matches in ONE paragraph:
-# re-run find_all after each edit, or batch_edit them in DESCENDING occurrence
-# order (an edit never shifts the matches before it; ascending mis-targets,
-# and descending is not valid for self-overlapping search strings like "aa"
-# in "aaaa").
+# One-at-a-time doc.replace() per result also works when every paragraph has
+# at most one match. Several matches in ONE paragraph: an edit invalidates the
+# paragraph's remaining refs and shifts the occurrence numbers of the matches
+# after it — re-run find_all after each edit, or batch in DESCENDING occurrence
+# order as above (an edit never shifts the matches before it; ascending
+# mis-targets, and descending is not valid for self-overlapping search strings
+# like "aa" in "aaaa").
 
 # Get all visible text (inserted text included, deleted text excluded)
 visible = doc.get_visible_text()
@@ -636,7 +640,7 @@ All LLM-facing errors inherit from `DocxEditError` and carry structured fields s
 | `TextNotFoundError`    | `search_text`, `paragraph_ref`, `paragraph_preview`, `occurrence`, `total_occurrences`  | Use `paragraph_preview` to pick a substring that actually appears; if `total_occurrences` is set, retry with an `occurrence` < `total_occurrences`. |
 | `AmbiguousTextError`   | `search_text`, `paragraph_ref`, `paragraph_preview`, `total_occurrences`                | The target matched more than once with no `occurrence` given. Enumerate with `find_all()` and pick, or pass an explicit `occurrence` (0-based).      |
 | `ParagraphIndexError`  | `index`, `total_paragraphs`                                                             | Clamp to `1..total_paragraphs` or call `list_paragraphs()` to pick a valid ref.                 |
-| `BatchOperationError`  | `operation_index`, `reason`, `original`                                                 | Fix the op at `operations[operation_index]` (or drop it) and retry the batch; `original` is the underlying typed error (e.g. use its `actual_hash` to re-target a stale ref). Batch methods never raise the inner types directly. |
+| `BatchOperationError`  | `operation_index`, `reason`, `original`                                                 | Fix the op at `operations[operation_index]` (or drop it) and retry the batch; `original` is the underlying typed error (e.g. use its `actual_hash` to re-target a stale ref), or None for batch-level rules with no underlying exception (missing paragraph ref, duplicate paragraph). Batch methods never raise the inner types directly. |
 | `DocumentOpenError`    | `path`, `owner_file`                                                                    | **Do not retry blindly.** The destination is open in Word. Stop and tell the user to close it. Only pass `force=True` if the user confirms the `~$` lock is stale (crashed session). |
 
 ```python

--- a/tests/test_batch_edit.py
+++ b/tests/test_batch_edit.py
@@ -745,6 +745,47 @@ class TestSingleExceptionContract:
         assert "MISSING" not in vis
 
 
+class TestSameParagraphBatch:
+    """The documented pattern for several matches in ONE paragraph: batch the
+    ops in DESCENDING occurrence order — an edit never shifts the matches
+    before it. Ascending order breaks because each edit shifts the occurrence
+    numbering of the matches after it in the accepted text view."""
+
+    def test_descending_occurrence_order_hits_every_intended_match(self, multi_para_doc):
+        doc, _ = multi_para_doc
+        results = [r for r in doc.find_all("committee") if r.paragraph_ref.startswith("P3#")]
+        assert [r.paragraph_occurrence for r in results] == [0, 1]
+
+        ops = [
+            EditOperation.replace(
+                r.text, f"EDIT{r.paragraph_occurrence}", paragraph=r.paragraph_ref, occurrence=r.paragraph_occurrence
+            )
+            for r in sorted(results, key=lambda r: r.paragraph_occurrence, reverse=True)
+        ]
+        doc.batch_edit(ops)
+        doc.accept_all()
+        assert (
+            "[P03] The EDIT0 shall review item 3. The report includes findings from the EDIT1."
+            in doc.get_visible_text()
+        )
+
+    def test_ascending_occurrence_order_fails_atomically(self, multi_para_doc):
+        """find_all order (ascending) is NOT batchable within a paragraph: the
+        first edit renumbers the rest, so a later op goes out of range and the
+        atomic contract rolls everything back."""
+        doc, _ = multi_para_doc
+        before = doc.get_visible_text()
+        results = [r for r in doc.find_all("committee") if r.paragraph_ref.startswith("P3#")]
+        ops = [
+            EditOperation.replace(r.text, "X", paragraph=r.paragraph_ref, occurrence=r.paragraph_occurrence)
+            for r in results
+        ]
+        with pytest.raises(BatchOperationError) as exc:
+            doc.batch_edit(ops)
+        assert isinstance(exc.value.original, TextNotFoundError)
+        assert doc.get_visible_text() == before
+
+
 class TestBatchRewriteSingleExceptionContract:
     """batch_rewrite honors the same single-exception contract."""
 

--- a/tests/test_batch_edit.py
+++ b/tests/test_batch_edit.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 from docx_editor import (
+    AmbiguousTextError,
     BatchOperationError,
     Document,
     EditOperation,
@@ -128,8 +129,10 @@ class TestBatchEdit:
             ),
         ]
 
-        with pytest.raises(HashMismatchError):
+        with pytest.raises(BatchOperationError) as exc:
             doc.batch_edit(ops)
+        assert exc.value.operation_index == 1
+        assert isinstance(exc.value.original, HashMismatchError)
 
         # Verify NO edits were applied
         vis = doc.get_visible_text()
@@ -279,12 +282,14 @@ class TestBatchEdit:
             doc.batch_edit(ops)
 
     def test_batch_replace_text_not_found(self, multi_para_doc):
-        """Replace with non-existent text raises TextNotFoundError."""
+        """Replace with non-existent text raises BatchOperationError wrapping TextNotFoundError."""
         doc, _ = multi_para_doc
         ref = doc.list_paragraphs()[0].split("|")[0]
         ops = [EditOperation(action="replace", find="NONEXISTENT", replace_with="x", paragraph=ref)]
-        with pytest.raises(TextNotFoundError):
+        with pytest.raises(BatchOperationError) as exc:
             doc.batch_edit(ops)
+        assert exc.value.operation_index == 0
+        assert isinstance(exc.value.original, TextNotFoundError)
 
     def test_batch_delete_missing_text(self, multi_para_doc):
         """Delete without text raises BatchOperationError."""
@@ -295,12 +300,14 @@ class TestBatchEdit:
             doc.batch_edit(ops)
 
     def test_batch_delete_text_not_found(self, multi_para_doc):
-        """Delete with non-existent text raises TextNotFoundError."""
+        """Delete with non-existent text raises BatchOperationError wrapping TextNotFoundError."""
         doc, _ = multi_para_doc
         ref = doc.list_paragraphs()[0].split("|")[0]
         ops = [EditOperation(action="delete", text="NONEXISTENT", paragraph=ref)]
-        with pytest.raises(TextNotFoundError):
+        with pytest.raises(BatchOperationError) as exc:
             doc.batch_edit(ops)
+        assert exc.value.operation_index == 0
+        assert isinstance(exc.value.original, TextNotFoundError)
 
     def test_batch_insert_missing_anchor(self, multi_para_doc):
         """Insert without anchor raises BatchOperationError."""
@@ -311,12 +318,14 @@ class TestBatchEdit:
             doc.batch_edit(ops)
 
     def test_batch_insert_anchor_not_found(self, multi_para_doc):
-        """Insert with non-existent anchor raises TextNotFoundError."""
+        """Insert with non-existent anchor raises BatchOperationError wrapping TextNotFoundError."""
         doc, _ = multi_para_doc
         ref = doc.list_paragraphs()[0].split("|")[0]
         ops = [EditOperation(action="insert_after", anchor="NONEXISTENT", text="x", paragraph=ref)]
-        with pytest.raises(TextNotFoundError):
+        with pytest.raises(BatchOperationError) as exc:
             doc.batch_edit(ops)
+        assert exc.value.operation_index == 0
+        assert isinstance(exc.value.original, TextNotFoundError)
 
     def test_batch_unknown_action(self, multi_para_doc):
         """Unknown action raises BatchOperationError."""
@@ -654,6 +663,112 @@ class TestStructuredBatchOperationError:
             doc.batch_edit(ops)
 
 
+class TestSingleExceptionContract:
+    """batch_edit raises ONLY BatchOperationError for per-op failures — both
+    phases — so one recovery path (`ops.pop(e.operation_index)`) always works.
+    The underlying typed exception stays reachable via `original`/`__cause__`."""
+
+    def test_malformed_ref_wrapped_with_index(self, multi_para_doc):
+        """Validation-phase ValueError from ParagraphRef.parse is wrapped."""
+        doc, _ = multi_para_doc
+        refs = doc.list_paragraphs()
+        ops = [
+            EditOperation(action="replace", find="item 1", replace_with="x", paragraph=refs[0].split("|")[0]),
+            EditOperation(action="replace", find="item 2", replace_with="x", paragraph="garbage-ref"),
+        ]
+        with pytest.raises(BatchOperationError) as exc:
+            doc.batch_edit(ops)
+        assert exc.value.operation_index == 1
+        assert isinstance(exc.value.original, ValueError)
+        assert exc.value.__cause__ is exc.value.original
+        assert "Invalid paragraph reference" in exc.value.reason
+
+    def test_ambiguous_op_wrapped_and_rolled_back(self, multi_para_doc):
+        """An ambiguous target inside a batch wraps AmbiguousTextError; the
+        document is unchanged afterwards."""
+        doc, _ = multi_para_doc
+        refs = doc.list_paragraphs()
+        before = doc.get_visible_text()
+        ops = [
+            EditOperation(action="replace", find="item 1", replace_with="ONE", paragraph=refs[0].split("|")[0]),
+            # "committee" appears twice in every paragraph — ambiguous without occurrence
+            EditOperation(action="replace", find="committee", replace_with="x", paragraph=refs[1].split("|")[0]),
+        ]
+        with pytest.raises(BatchOperationError) as exc:
+            doc.batch_edit(ops)
+        assert exc.value.operation_index == 1
+        assert isinstance(exc.value.original, AmbiguousTextError)
+        assert exc.value.original.total_occurrences == 2
+        assert doc.get_visible_text() == before
+
+    def test_stale_hash_original_carries_usable_actual_hash(self, multi_para_doc):
+        """`e.original.actual_hash` re-targets the stale op without list_paragraphs()."""
+        doc, _ = multi_para_doc
+        refs = doc.list_paragraphs()
+        stale_ref = refs[4].split("|")[0]
+        doc.replace("item 5", "CHANGED", paragraph=stale_ref)
+
+        ops = [EditOperation(action="replace", find="CHANGED", replace_with="FIXED", paragraph=stale_ref)]
+        with pytest.raises(BatchOperationError) as exc:
+            doc.batch_edit(ops)
+        original = exc.value.original
+        assert isinstance(original, HashMismatchError)
+
+        # Re-target using the structured fields alone.
+        fresh_ref = f"P{original.paragraph_index}#{original.actual_hash}"
+        ops[exc.value.operation_index] = EditOperation(
+            action="replace", find="CHANGED", replace_with="FIXED", paragraph=fresh_ref
+        )
+        doc.batch_edit(ops)
+        assert "FIXED" in doc.get_visible_text()
+
+    def test_documented_recovery_loop(self, multi_para_doc):
+        """The SKILL.md recovery pattern: pop the failing op, retry, succeed."""
+        doc, _ = multi_para_doc
+        refs = doc.list_paragraphs()
+        ops = [
+            EditOperation(action="replace", find="item 2", replace_with="TWO", paragraph=refs[1].split("|")[0]),
+            EditOperation(action="replace", find="MISSING", replace_with="x", paragraph=refs[3].split("|")[0]),
+            EditOperation(action="replace", find="item 6", replace_with="SIX", paragraph=refs[5].split("|")[0]),
+        ]
+
+        while ops:
+            try:
+                doc.batch_edit(ops)
+                break
+            except BatchOperationError as e:
+                ops.pop(e.operation_index)
+
+        vis = doc.get_visible_text()
+        assert "TWO" in vis
+        assert "SIX" in vis
+        assert "MISSING" not in vis
+
+
+class TestBatchRewriteSingleExceptionContract:
+    """batch_rewrite honors the same single-exception contract."""
+
+    def test_stale_hash_wrapped_with_index(self, multi_para_doc):
+        doc, _ = multi_para_doc
+        refs = doc.list_paragraphs()
+        before = doc.get_visible_text()
+        with pytest.raises(BatchOperationError) as exc:
+            doc.batch_rewrite([
+                (refs[0].split("|")[0], "New first paragraph."),
+                ("P5#0000", "Stale hash."),
+            ])
+        assert exc.value.operation_index == 1
+        assert isinstance(exc.value.original, HashMismatchError)
+        assert doc.get_visible_text() == before
+
+    def test_malformed_ref_wrapped_with_index(self, multi_para_doc):
+        doc, _ = multi_para_doc
+        with pytest.raises(BatchOperationError) as exc:
+            doc.batch_rewrite([("bogus", "text")])
+        assert exc.value.operation_index == 0
+        assert isinstance(exc.value.original, ValueError)
+
+
 class TestBatchEditRollback:
     """Mid-batch failure must leave the document untouched (atomic contract)."""
 
@@ -686,8 +801,10 @@ class TestBatchEditRollback:
             ),
         ]
 
-        with pytest.raises(TextNotFoundError):
+        with pytest.raises(BatchOperationError) as exc:
             doc.batch_edit(ops)
+        assert exc.value.operation_index == 1
+        assert isinstance(exc.value.original, TextNotFoundError)
 
         # Reverse-paragraph order means P9 applied before P7 failed; full-text
         # equality proves P9's mutation was rolled back.
@@ -744,7 +861,7 @@ class TestBatchEditRollback:
             ),
         ]
 
-        with pytest.raises(TextNotFoundError):
+        with pytest.raises(BatchOperationError):
             doc.batch_edit(ops)
 
         # The pre-batch P2 ref must still resolve — proves hashes did not drift.
@@ -779,7 +896,7 @@ class TestBatchEditRollback:
             ),
         ]
 
-        with pytest.raises(TextNotFoundError):
+        with pytest.raises(BatchOperationError):
             doc.batch_edit(ops)
 
         # After rollback, parse_position must still be present on every element
@@ -817,8 +934,9 @@ class TestBatchEditRollback:
         ]
 
         # Original edit error wins over the rollback failure.
-        with pytest.raises(TextNotFoundError):
+        with pytest.raises(BatchOperationError) as exc:
             doc.batch_edit(ops)
+        assert isinstance(exc.value.original, TextNotFoundError)
 
         # Reverse-paragraph order means the failing P6 op runs first and
         # raises before any mutation, so visible text is still unchanged

--- a/tests/test_error_quality.py
+++ b/tests/test_error_quality.py
@@ -24,6 +24,7 @@ from pathlib import Path
 import pytest
 
 from docx_editor import (
+    AmbiguousTextError,
     BatchOperationError,
     Document,
     EditOperation,
@@ -40,6 +41,29 @@ def doc_path():
     shutil.copy(test_data, dest)
     yield dest
     shutil.rmtree(tmp, ignore_errors=True)
+
+
+def _build_doc_with_paragraphs(doc_path: Path, texts: list[str]) -> Document:
+    """Replace the fixture document's body with one paragraph per entry."""
+    doc = Document.open(doc_path, force_recreate=True)
+    editor = doc._document_editor
+    body = editor.dom.getElementsByTagName("w:body")[0]
+    for p in list(editor.dom.getElementsByTagName("w:p")):
+        if p.parentNode == body:
+            body.removeChild(p)
+    sect_pr = editor.dom.getElementsByTagName("w:sectPr")
+    insert_before = sect_pr[0] if sect_pr else None
+    for text in texts:
+        xml = f'<w:p><w:r><w:t xml:space="preserve">{text}</w:t></w:r></w:p>'
+        for node in editor._parse_fragment(xml):
+            if insert_before:
+                body.insertBefore(node, insert_before)
+            else:
+                body.appendChild(node)
+    editor.save()
+    saved = doc.save()
+    doc.close()
+    return Document.open(saved, force_recreate=True)
 
 
 class TestTextNotFoundErrorQuality:
@@ -167,25 +191,7 @@ class TestBatchOperationErrorQuality:
     """
 
     def _build_batch_doc(self, doc_path: Path) -> Document:
-        doc = Document.open(doc_path, force_recreate=True)
-        editor = doc._document_editor
-        body = editor.dom.getElementsByTagName("w:body")[0]
-        for p in list(editor.dom.getElementsByTagName("w:p")):
-            if p.parentNode == body:
-                body.removeChild(p)
-        sect_pr = editor.dom.getElementsByTagName("w:sectPr")
-        insert_before = sect_pr[0] if sect_pr else None
-        for i in range(1, 4):
-            xml = f'<w:p><w:r><w:t xml:space="preserve">Paragraph {i} content.</w:t></w:r></w:p>'
-            for node in editor._parse_fragment(xml):
-                if insert_before:
-                    body.insertBefore(node, insert_before)
-                else:
-                    body.appendChild(node)
-        editor.save()
-        saved = doc.save()
-        doc.close()
-        return Document.open(saved, force_recreate=True)
+        return _build_doc_with_paragraphs(doc_path, [f"Paragraph {i} content." for i in range(1, 4)])
 
     def test_predispatch_failure_carries_operation_index(self, doc_path):
         """Structural validation inside batch_edit surfaces the index."""
@@ -229,8 +235,153 @@ class TestBatchOperationErrorQuality:
             doc.close()
 
 
+class TestAmbiguousTextErrorQuality:
+    """
+    Before: every edit method defaulted to occurrence=0, so an ambiguous
+    target was silently resolved to the first match — the agent got no
+    signal that it may have edited the wrong text.
+
+    After: an omitted occurrence requires the target to be unique in the
+    search scope. `AmbiguousTextError` carries `total_occurrences` and
+    names both recovery paths (explicit `occurrence=` or `find_all()`);
+    explicit `occurrence=0` keeps the old first-match behavior per call.
+    """
+
+    AMBIGUOUS = "alpha beta alpha gamma alpha."
+    UNIQUE = "one needle only."
+
+    def _build_doc(self, doc_path: Path) -> Document:
+        return _build_doc_with_paragraphs(doc_path, [self.AMBIGUOUS, self.UNIQUE])
+
+    def _edit_calls(self, doc: Document, paragraph: str):
+        """Every scoped edit method, called with an ambiguous target and no occurrence."""
+        return [
+            lambda: doc.replace("alpha", "x", paragraph=paragraph),
+            lambda: doc.delete("alpha", paragraph=paragraph),
+            lambda: doc.insert_after("alpha", "x", paragraph=paragraph),
+            lambda: doc.insert_before("alpha", "x", paragraph=paragraph),
+            lambda: doc.add_comment("alpha", "note", paragraph=paragraph),
+        ]
+
+    def test_scoped_ambiguous_target_raises_with_totals(self, doc_path):
+        """All five scoped methods raise AmbiguousTextError with the count."""
+        doc = self._build_doc(doc_path)
+        try:
+            ref = doc.list_paragraphs()[0].split("|")[0]
+            for call in self._edit_calls(doc, ref):
+                with pytest.raises(AmbiguousTextError) as exc:
+                    call()
+                err = exc.value
+                assert err.search_text == "alpha"
+                assert err.total_occurrences == 3
+                assert err.paragraph_ref == ref
+                assert err.paragraph_preview is not None
+                msg = str(err)
+                assert "matches 3 times" in msg
+                assert "occurrence=" in msg
+                assert "find_all()" in msg
+        finally:
+            doc.close()
+
+    def test_docwide_ambiguous_anchor_raises(self, doc_path):
+        """Document-wide add_comment with a repeated anchor raises too."""
+        doc = self._build_doc(doc_path)
+        try:
+            with pytest.raises(AmbiguousTextError) as exc:
+                doc.add_comment("alpha", "note")
+            err = exc.value
+            assert err.total_occurrences == 3
+            assert err.paragraph_ref is None
+            assert err.paragraph_preview is None
+            assert "in the document" in str(err)
+        finally:
+            doc.close()
+
+    def test_explicit_occurrence_zero_edits_first_silently(self, doc_path):
+        """occurrence=0 is the per-call opt-out: old first-match behavior."""
+        doc = self._build_doc(doc_path)
+        try:
+            ref = doc.list_paragraphs()[0].split("|")[0]
+            doc.replace("alpha", "FIRST", paragraph=ref, occurrence=0)
+            doc.accept_all()
+            assert "FIRST beta alpha gamma alpha." in doc.get_visible_text()
+        finally:
+            doc.close()
+
+    def test_unique_target_with_omitted_occurrence_works(self, doc_path):
+        """A unique target never trips the ambiguity check."""
+        doc = self._build_doc(doc_path)
+        try:
+            ref = doc.list_paragraphs()[1].split("|")[0]
+            doc.replace("needle", "thread", paragraph=ref)
+            doc.accept_all()
+            assert "one thread only." in doc.get_visible_text()
+        finally:
+            doc.close()
+
+    def test_ambiguity_surfaces_in_dry_run_error(self, doc_path):
+        """batch_edit(dry_run=True) reports the same ambiguity message."""
+        doc = self._build_doc(doc_path)
+        try:
+            ref = doc.list_paragraphs()[0].split("|")[0]
+            ops = [EditOperation.replace("alpha", "x", paragraph=ref)]
+            results = doc.batch_edit(ops, dry_run=True)
+            assert results[0].valid is False
+            error = results[0].error
+            assert error is not None
+            assert "matches 3 times" in error
+        finally:
+            doc.close()
+
+
+class TestOccurrenceOutOfRangeQuality:
+    """
+    Before: a scoped edit with an out-of-range occurrence raised
+    `TextNotFoundError` built with only ref + preview — the message said
+    "Text not found" while the preview visibly contained the text.
+
+    After: the scoped paths count total matches, so the error reports
+    "Only N occurrence(s) ... occurrence=X requested" with both fields
+    populated — never a self-contradicting "not found".
+    """
+
+    TEXT = "term one, term two."
+
+    def test_scoped_out_of_range_names_totals_not_notfound(self, doc_path):
+        doc = _build_doc_with_paragraphs(doc_path, [self.TEXT])
+        try:
+            ref = doc.list_paragraphs()[0].split("|")[0]
+            with pytest.raises(TextNotFoundError) as exc:
+                doc.replace("term", "x", paragraph=ref, occurrence=9)
+            err = exc.value
+            assert err.occurrence == 9
+            assert err.total_occurrences == 2
+            msg = str(err)
+            assert "Only 2 occurrence(s)" in msg
+            assert "occurrence=9" in msg
+            assert "Text not found" not in msg
+        finally:
+            doc.close()
+
+    def test_dry_run_error_gets_the_same_fix(self, doc_path):
+        """EditValidationResult.error also reports totals, not 'not found'."""
+        doc = _build_doc_with_paragraphs(doc_path, [self.TEXT])
+        try:
+            ref = doc.list_paragraphs()[0].split("|")[0]
+            ops = [EditOperation.replace("term", "x", paragraph=ref, occurrence=9)]
+            results = doc.batch_edit(ops, dry_run=True)
+            assert results[0].valid is False
+            error = results[0].error
+            assert error is not None
+            assert "Only 2 occurrence(s)" in error
+            assert "occurrence=9" in error
+            assert "Text not found" not in error
+        finally:
+            doc.close()
+
+
 class TestSharedBaseClass:
-    """All four structured errors inherit from `DocxEditError`.
+    """All structured errors inherit from `DocxEditError`.
 
     This means `except DocxEditError` is a correct catch-all for LLM
     consumers — no need to enumerate the leaf classes.
@@ -240,13 +391,20 @@ class TestSharedBaseClass:
         from docx_editor import DocxEditError, HashMismatchError
 
         assert issubclass(TextNotFoundError, DocxEditError)
+        assert issubclass(AmbiguousTextError, DocxEditError)
         assert issubclass(HashMismatchError, DocxEditError)
         assert issubclass(ParagraphIndexError, DocxEditError)
         assert issubclass(BatchOperationError, DocxEditError)
 
+    def test_ambiguous_is_not_a_textnotfound_subclass(self):
+        """The text WAS found — code catching TextNotFoundError to mean
+        'pick different text' must not swallow ambiguity."""
+        assert not issubclass(AmbiguousTextError, TextNotFoundError)
+
     def test_top_level_import_smoke(self):
         """Every structured error is importable from the top-level package."""
         from docx_editor import (  # noqa: F401
+            AmbiguousTextError,
             BatchOperationError,
             HashMismatchError,
             ParagraphIndexError,

--- a/tests/test_error_quality.py
+++ b/tests/test_error_quality.py
@@ -19,6 +19,7 @@ move from string-parsing into structured fields.
 
 import shutil
 import tempfile
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
@@ -253,7 +254,7 @@ class TestAmbiguousTextErrorQuality:
     def _build_doc(self, doc_path: Path) -> Document:
         return _build_doc_with_paragraphs(doc_path, [self.AMBIGUOUS, self.UNIQUE])
 
-    def _edit_calls(self, doc: Document, paragraph: str):
+    def _edit_calls(self, doc: Document, paragraph: str) -> list[Callable[[], object]]:
         """Every scoped edit method, called with an ambiguous target and no occurrence."""
         return [
             lambda: doc.replace("alpha", "x", paragraph=paragraph),
@@ -376,6 +377,34 @@ class TestOccurrenceOutOfRangeQuality:
             assert "Only 2 occurrence(s)" in error
             assert "occurrence=9" in error
             assert "Text not found" not in error
+        finally:
+            doc.close()
+
+
+class TestNegativeOccurrenceRejected:
+    """
+    Before: a negative occurrence slipped past the direct (non-batch) edit
+    methods into ``find_in_text_map``, where ``range(occurrence + 1)`` never
+    runs and the scoped paths crashed with ``UnboundLocalError`` (the
+    document-wide paths produced a nonsensical "occurrence=-1 requested").
+
+    After: every locate path rejects a negative occurrence up front with the
+    same ValueError the EditOperation constructors raise.
+    """
+
+    def test_all_paths_raise_value_error(self, doc_path):
+        doc = _build_doc_with_paragraphs(doc_path, ["one needle only."])
+        try:
+            ref = doc.list_paragraphs()[0].split("|")[0]
+            calls = [
+                lambda: doc.replace("needle", "x", paragraph=ref, occurrence=-1),
+                lambda: doc.add_comment("needle", "note", paragraph=ref, occurrence=-1),
+                lambda: doc.add_comment("needle", "note", occurrence=-1),
+                lambda: doc._revision_manager.replace_text("needle", "x", occurrence=-1),
+            ]
+            for call in calls:
+                with pytest.raises(ValueError, match="occurrence must be >= 0"):
+                    call()
         finally:
             doc.close()
 

--- a/tests/test_find_all.py
+++ b/tests/test_find_all.py
@@ -1,0 +1,172 @@
+"""Tests for Document.find_all() — one-call enumeration of every match."""
+
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from docx_editor import (
+    Document,
+    HashMismatchError,
+    ParagraphIndexError,
+    SearchResult,
+)
+
+
+@pytest.fixture
+def multi_para_doc():
+    """Build a document with 10 paragraphs, each containing repeated phrases."""
+    test_data = Path(__file__).parent / "test_data" / "simple.docx"
+    tmp = tempfile.mkdtemp(prefix="find_all_test_")
+    dest = Path(tmp) / "test.docx"
+    shutil.copy(test_data, dest)
+
+    doc = Document.open(dest)
+    doc.accept_all()
+    doc.save()
+    doc.close()
+
+    doc = Document.open(dest, force_recreate=True)
+    editor = doc._document_editor
+    body = editor.dom.getElementsByTagName("w:body")[0]
+
+    for p in list(editor.dom.getElementsByTagName("w:p")):
+        if p.parentNode == body:
+            body.removeChild(p)
+
+    sect_pr = editor.dom.getElementsByTagName("w:sectPr")
+    insert_before = sect_pr[0] if sect_pr else None
+
+    for i in range(1, 11):
+        text = f"[P{i:02d}] The committee shall review item {i}. The report includes findings from the committee."
+        p_xml = f'<w:p><w:r><w:t xml:space="preserve">{text}</w:t></w:r></w:p>'
+        nodes = editor._parse_fragment(p_xml)
+        for node in nodes:
+            if insert_before:
+                body.insertBefore(node, insert_before)
+            else:
+                body.appendChild(node)
+
+    editor.save()
+    save_path = doc.save()
+    doc.close()
+
+    doc = Document.open(save_path, force_recreate=True)
+    yield doc, Path(tmp)
+    doc.close()
+    shutil.rmtree(tmp, ignore_errors=True)
+
+
+class TestFindAllDocumentWide:
+    def test_enumerates_every_match(self, multi_para_doc):
+        """Result count matches count_matches; results are SearchResults."""
+        doc, _ = multi_para_doc
+        results = doc.find_all("committee")
+        assert len(results) == doc.count_matches("committee")
+        assert len(results) == 20  # 2 per paragraph x 10
+        assert all(isinstance(r, SearchResult) for r in results)
+        assert all(r.text == "committee" for r in results)
+
+    def test_refs_are_hash_anchored_and_current(self, multi_para_doc):
+        """Each result's paragraph_ref equals the list_paragraphs() ref."""
+        doc, _ = multi_para_doc
+        refs = [r.split("|")[0] for r in doc.list_paragraphs()]
+        results = doc.find_all("committee")
+        assert {r.paragraph_ref for r in results} == set(refs)
+
+    def test_paragraph_occurrence_resets_per_paragraph(self, multi_para_doc):
+        """paragraph_occurrence counts within each paragraph, not document-wide."""
+        doc, _ = multi_para_doc
+        results = doc.find_all("committee")
+        by_ref: dict[str, list[int]] = {}
+        for r in results:
+            by_ref.setdefault(r.paragraph_ref, []).append(r.paragraph_occurrence)
+        assert all(occs == [0, 1] for occs in by_ref.values())
+
+    def test_offsets_are_paragraph_local(self, multi_para_doc):
+        """start/end are offsets in the containing paragraph's visible text."""
+        doc, _ = multi_para_doc
+        results = doc.find_all("[P05]")
+        assert len(results) == 1
+        assert results[0].start == 0
+        assert results[0].end == len("[P05]")
+
+    def test_results_in_document_order(self, multi_para_doc):
+        doc, _ = multi_para_doc
+        results = doc.find_all("item")
+        markers = [int(r.paragraph_ref.split("#")[0][1:]) for r in results]
+        assert markers == sorted(markers)
+
+    def test_result_chains_into_edit(self, multi_para_doc):
+        """paragraph_ref + paragraph_occurrence target exactly that match."""
+        doc, _ = multi_para_doc
+        target = [r for r in doc.find_all("committee") if r.paragraph_ref.startswith("P3#")][1]
+        assert target.paragraph_occurrence == 1
+
+        doc.replace(
+            target.text,
+            "CHANGED",
+            paragraph=target.paragraph_ref,
+            occurrence=target.paragraph_occurrence,
+        )
+        doc.accept_all()
+        vis = doc.get_visible_text()
+        # Exactly the targeted (second) match in P3 changed; the first is untouched.
+        assert "[P03] The committee shall review item 3. The report includes findings from the CHANGED." in vis
+        assert vis.count("CHANGED") == 1
+
+    def test_no_matches_returns_empty_list(self, multi_para_doc):
+        """No-match is not an error for an enumeration API."""
+        doc, _ = multi_para_doc
+        assert doc.find_all("__absent_everywhere__") == []
+
+    def test_empty_text_raises_value_error(self, multi_para_doc):
+        doc, _ = multi_para_doc
+        with pytest.raises(ValueError, match="non-empty"):
+            doc.find_all("")
+
+    def test_match_spanning_revision_sets_flag(self, multi_para_doc):
+        """A match crossing a w:ins boundary reports spans_revision=True."""
+        doc, _ = multi_para_doc
+        ref = doc.list_paragraphs()[0].split("|")[0]
+        doc.insert_after("review", "XX", paragraph=ref)
+
+        results = doc.find_all("reviewXX")
+        assert len(results) == 1
+        assert results[0].spans_revision is True
+
+        plain = doc.find_all("[P01]")
+        assert plain[0].spans_revision is False
+
+
+class TestFindAllScoped:
+    def test_scoped_returns_only_that_paragraphs_hits(self, multi_para_doc):
+        doc, _ = multi_para_doc
+        ref = doc.list_paragraphs()[2].split("|")[0]
+        results = doc.find_all("committee", paragraph=ref)
+        assert len(results) == 2
+        assert all(r.paragraph_ref == ref for r in results)
+        assert [r.paragraph_occurrence for r in results] == [0, 1]
+
+    def test_scoped_no_matches_returns_empty_list(self, multi_para_doc):
+        doc, _ = multi_para_doc
+        ref = doc.list_paragraphs()[0].split("|")[0]
+        assert doc.find_all("item 5", paragraph=ref) == []
+
+    def test_stale_hash_raises(self, multi_para_doc):
+        doc, _ = multi_para_doc
+        ref = doc.list_paragraphs()[0].split("|")[0]
+        doc.replace("item 1", "MUTATED", paragraph=ref)
+        with pytest.raises(HashMismatchError):
+            doc.find_all("committee", paragraph=ref)
+
+    def test_malformed_ref_raises_value_error(self, multi_para_doc):
+        doc, _ = multi_para_doc
+        with pytest.raises(ValueError, match="Invalid paragraph reference"):
+            doc.find_all("committee", paragraph="not-a-ref")
+
+    def test_out_of_range_index_raises(self, multi_para_doc):
+        doc, _ = multi_para_doc
+        with pytest.raises(ParagraphIndexError):
+            doc.find_all("committee", paragraph="P999#0000")

--- a/tests/test_rewrite_paragraph.py
+++ b/tests/test_rewrite_paragraph.py
@@ -807,11 +807,13 @@ class TestBatchRewrite:
         doc, _ = rewrite_doc
         refs = doc.list_paragraphs()
 
-        with pytest.raises(HashMismatchError):
+        with pytest.raises(BatchOperationError) as exc:
             doc.batch_rewrite([
                 (refs[0].split("|")[0], "Good text"),
                 ("P3#0000", "Bad hash"),
             ])
+        assert exc.value.operation_index == 1
+        assert isinstance(exc.value.original, HashMismatchError)
 
         # Verify no changes were applied (P1 unchanged)
         vis = doc.get_visible_text()

--- a/tests/test_rewrite_paragraph.py
+++ b/tests/test_rewrite_paragraph.py
@@ -819,6 +819,34 @@ class TestBatchRewrite:
         vis = doc.get_visible_text()
         assert "The committee shall review" in vis
 
+    def test_apply_phase_failure_rolls_back(self, rewrite_doc, monkeypatch):
+        """A mid-apply failure leaves the document untouched (atomic contract).
+
+        No such failure is reachable today (upfront validation precludes them
+        all), so one is simulated to pin the snapshot/rollback plumbing."""
+        doc, _ = rewrite_doc
+        refs = doc.list_paragraphs()
+        before = doc.get_visible_text()
+        mgr = doc._revision_manager
+        real = mgr.rewrite_paragraph
+        calls = {"n": 0}
+
+        def flaky(ref_str, new_text):
+            calls["n"] += 1
+            if calls["n"] == 2:
+                raise ValueError("simulated mid-batch failure")
+            return real(ref_str, new_text)
+
+        monkeypatch.setattr(mgr, "rewrite_paragraph", flaky)
+        with pytest.raises(BatchOperationError) as exc:
+            doc.batch_rewrite([
+                (refs[0].split("|")[0], "First rewritten."),
+                (refs[2].split("|")[0], "Third rewritten."),
+            ])
+        assert isinstance(exc.value.original, ValueError)
+        # Reverse-index order applied P3 first; its rewrite must be rolled back.
+        assert doc.get_visible_text() == before
+
     def test_batch_rejected_on_duplicate(self, rewrite_doc):
         """Duplicate paragraph in batch raises BatchOperationError."""
         doc, _ = rewrite_doc

--- a/tests/test_run_child_order.py
+++ b/tests/test_run_child_order.py
@@ -275,7 +275,9 @@ class TestTextboxNoDuplication:
         )
         mgr = _make_manager(xml_path)
 
-        mgr.replace_text("x", "X")
+        # "boxed" also contains an "x", so the target is ambiguous without an
+        # explicit occurrence.
+        mgr.replace_text("x", "X", occurrence=0)
 
         paragraph = mgr.editor.dom.getElementsByTagName("w:p")[0]
         assert paragraph.toxml().count("boxed") == 1
@@ -315,7 +317,9 @@ class TestNestedRPrNoLeak:
         )
         mgr = _make_manager(xml_path)
 
-        mgr.replace_text("x", "X")
+        # "boxed" also contains an "x", so the target is ambiguous without an
+        # explicit occurrence.
+        mgr.replace_text("x", "X", occurrence=0)
 
         paragraph = mgr.editor.dom.getElementsByTagName("w:p")[0]
         assert paragraph_tokens(mgr) == ["DEL(x)", "INS(X)", "DRAWING", "y"]


### PR DESCRIPTION
Implements ISSUES.md item #34 (repo-local tracker, not a GitHub issue number).

## What

- **`Document.find_all(text, paragraph=None)`** — enumerate every match in document order as `SearchResult`s. Each result's `paragraph_ref`/`paragraph_occurrence` plug directly into a follow-up edit's `paragraph=`/`occurrence=`, replacing N+1 `find_text` probes. No-match returns `[]` (enumeration, not lookup). Also available on `RevisionManager`.
- **Occurrence ambiguity guard** — `occurrence` is now `int | None = None` across `replace`, `delete`, `insert_after`, `insert_before`, `add_comment`, and the `EditOperation` constructors. An omitted occurrence means the target must be **unique** in the search scope; ambiguous targets raise the new **`AmbiguousTextError`** (`search_text`, `paragraph_ref`, `paragraph_preview`, `total_occurrences`) naming both recovery paths. Deliberately *not* a `TextNotFoundError` subclass — the text was found.
- **Out-of-range occurrences** in scoped edits now report `occurrence`/`total_occurrences` ("Only 2 occurrence(s)… occurrence=9 requested") instead of a self-contradicting "not found" whose preview visibly contains the text. Dry-run (`batch_edit(dry_run=True)`) reports the same messages.
- **Single-exception batch contract** — `batch_edit`/`batch_rewrite` raise only **`BatchOperationError`** for per-op failures in *both* phases (validation and apply, stale hashes included), carrying `operation_index` and the typed underlying exception on `original`/`__cause__` (e.g. `e.original.actual_hash` re-targets a stale ref without `list_paragraphs()`). Batches remain atomic.
- Occurrence handling consolidated into one `_locate_in_paragraph` helper (replaces four duplicated find-or-raise paths); dry-run validation shares it, so messages cannot drift.
- SKILL.md and docs/api.md updated with the new contracts and recovery recipes; benchmarks updated for the new default.

## ⚠️ Breaking changes (0.x, task-sanctioned)

1. **Ambiguous targets without an explicit `occurrence` now raise `AmbiguousTextError`** instead of silently editing the first match. Per-call opt-out: pass `occurrence=0` explicitly.
2. **Batch failures are always `BatchOperationError`** — code catching `HashMismatchError`/`TextNotFoundError` around `batch_edit`/`batch_rewrite` must switch (the typed exception is on `original`/`__cause__`). `except DocxEditError` callers are unaffected.

## Testing

- `uv run pytest`: 1018 passed, 2 skipped (14 new find_all tests; new ambiguity, out-of-range, and single-exception-contract suites; rollback atomicity re-verified under the new contract)
- `uv run ruff check .` / `uv run ruff format --check .`: clean
- `uv run ty check`: 6 diagnostics, identical to the clean-tree baseline (pre-existing, unrelated test files)
- `benchmarks/hash_anchored_vs_plain.py` runs end-to-end with expected results
- End-to-end smoke on a real .docx: doc-wide and scoped ambiguity, out-of-range totals, find_all → chained edit, batch stale-hash recovery via `e.original.actual_hash`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `find_all()` to enumerate all text matches with paragraph references and per-match occurrence details.
  * Editing/commenting APIs now support `occurrence=None` to require unique targets; `AmbiguousTextError` is publicly exposed.

* **Bug Fixes**
  * Improved missing/ambiguous/out-of-range diagnostics (including occurrence totals and clearer guidance).
  * Batch edits/rewrites now fail atomically with `BatchOperationError`, exposing the failing operation index and the original underlying error.

* **Documentation**
  * Updated API docs and skills guidance for `find_all()`, new `occurrence` rules, and batch error/rollback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->