### PR TITLE
feat: revision grouping — EditResult with group_id, accept_group/reject_group (ISSUES.md #37)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -288,7 +288,7 @@ Replace text with tracked changes. When the target sits inside another author's 
 - `paragraph` (str): Paragraph reference from `list_paragraphs()`, such as `P2#f3c1`
 - `occurrence` (int | None): Which occurrence within the paragraph, 0-based (0 = first). Omitted → the target must be unique within the paragraph; if it matches more than once, [`AmbiguousTextError`](#ambiguoustexterror) is raised instead of silently editing the first match.
 
-**Returns:** Updated paragraph reference (str)
+**Returns:** Updated paragraph reference ([`EditResult`](#editresult) — a `str` subclass also carrying the edit's `group_id`/`revision_ids`)
 
 **Example:**
 
@@ -307,7 +307,7 @@ Mark text as deleted with tracked changes. Deleting text inside another author's
 - `paragraph` (str): Paragraph reference from `list_paragraphs()`, such as `P2#f3c1`
 - `occurrence` (int | None): Which occurrence within the paragraph, 0-based (0 = first). Omitted → the target must be unique within the paragraph; if it matches more than once, [`AmbiguousTextError`](#ambiguoustexterror) is raised instead of silently editing the first match.
 
-**Returns:** Updated paragraph reference (str)
+**Returns:** Updated paragraph reference ([`EditResult`](#editresult) — a `str` subclass also carrying the edit's `group_id`/`revision_ids`)
 
 **Example:**
 
@@ -326,7 +326,7 @@ Insert text after anchor with tracked changes. An anchor inside another author's
 - `paragraph` (str): Paragraph reference from `list_paragraphs()`, such as `P2#f3c1`
 - `occurrence` (int | None): Which occurrence within the paragraph, 0-based (0 = first). Omitted → the target must be unique within the paragraph; if it matches more than once, [`AmbiguousTextError`](#ambiguoustexterror) is raised instead of silently editing the first match.
 
-**Returns:** Updated paragraph reference (str)
+**Returns:** Updated paragraph reference ([`EditResult`](#editresult) — a `str` subclass also carrying the edit's `group_id`/`revision_ids`)
 
 **Example:**
 
@@ -345,7 +345,7 @@ Insert text before anchor with tracked changes. Foreign pending insertions are t
 - `paragraph` (str): Paragraph reference from `list_paragraphs()`, such as `P2#f3c1`
 - `occurrence` (int | None): Which occurrence within the paragraph, 0-based (0 = first). Omitted → the target must be unique within the paragraph; if it matches more than once, [`AmbiguousTextError`](#ambiguoustexterror) is raised instead of silently editing the first match.
 
-**Returns:** Updated paragraph reference (str)
+**Returns:** Updated paragraph reference ([`EditResult`](#editresult) — a `str` subclass also carrying the edit's `group_id`/`revision_ids`)
 
 **Example:**
 
@@ -357,17 +357,24 @@ ref = doc.insert_before("Section 6", "New clause: ", paragraph="P4#a7b2")
 
 Rewrite a paragraph using tracked changes generated from a word-level diff.
 
+A rewrite typically produces many revisions (one per diff hunk), none of which
+is a self-contained edit — accepting only some of them by id garbles the
+paragraph. All of one rewrite's revisions therefore share a revision group;
+resolve them as a unit with [`accept_group()`](#accept_groupgroup_id) /
+[`reject_group()`](#reject_groupgroup_id).
+
 **Parameters:**
 
 - `ref` (str): Paragraph reference from `list_paragraphs()`
 - `new_text` (str): Desired paragraph text
 
-**Returns:** Updated paragraph reference (str)
+**Returns:** Updated paragraph reference ([`EditResult`](#editresult) — a `str` subclass also carrying the edit's `group_id`/`revision_ids`; `group_id` is `None` when `new_text` equals the current text)
 
 **Example:**
 
 ```python
-ref = doc.rewrite_paragraph("P2#f3c1", "Payment is due within 60 days after invoice receipt.")
+result = doc.rewrite_paragraph("P2#f3c1", "Payment is due within 60 days after invoice receipt.")
+doc.reject_group(result.group_id)  # changed your mind — undo the whole rewrite
 ```
 
 #### `batch_edit(operations, *, dry_run=False)`
@@ -380,7 +387,7 @@ stale, the entire batch is rejected before any edits are applied.
 - `operations` (list[EditOperation]): Edit operations to apply
 - `dry_run` (bool): If True, validate every operation without applying any edits and return one [`EditValidationResult`](#editvalidationresult) per operation, in input order; the document is left unchanged. Each operation is validated independently against the current document — sequential effects between multiple operations on the same paragraph are **not** simulated. Defaults to False.
 
-**Returns:** Updated paragraph references in input order (list[str]); with `dry_run=True`, a list of [`EditValidationResult`](#editvalidationresult) instead
+**Returns:** Updated paragraph references in input order (list of [`EditResult`](#editresult)) — each operation is its own revision group, so one op can be accepted and another rejected; with `dry_run=True`, a list of [`EditValidationResult`](#editvalidationresult) instead
 
 **Raises:** [`BatchOperationError`](#batchoperationerror) — the only exception a non-dry-run batch raises for a failing operation, whatever the underlying cause (stale hash, malformed ref, missing text, ambiguous target). `operation_index` names the failing op; `original` (also `__cause__`) holds the underlying typed exception. The batch is atomic: nothing is applied on failure.
 
@@ -418,7 +425,7 @@ Rewrite multiple paragraphs after validating paragraph hashes up front.
 
 - `rewrites` (list[tuple[str, str]]): Pairs of paragraph ref and desired text
 
-**Returns:** Updated paragraph references in input order (list[str])
+**Returns:** Updated paragraph references in input order (list of [`EditResult`](#editresult)); each rewrite gets its own revision group
 
 **Raises:** [`BatchOperationError`](#batchoperationerror) — same single-exception contract as `batch_edit()`.
 
@@ -583,6 +590,65 @@ Reject a revision by ID.
 doc.reject_revision(1)
 ```
 
+#### `accept_group(group_id)`
+
+Accept every revision created by one logical edit operation.
+
+Each edit method (`replace()`, `delete()`, `insert_after()`, `insert_before()`,
+`rewrite_paragraph()`, and every operation of a batch) registers the revisions
+it creates as one **revision group**; the returned [`EditResult`](#editresult)
+carries the `group_id`, and `list_revisions()` stamps it on each member
+revision. Accepting the group applies the whole edit — the safe alternative to
+resolving a multi-revision edit (especially a rewrite) revision by revision,
+which garbles the text if only some are applied.
+
+Groups are **in-memory and per-open-Document**: after `close()`/reopen,
+revisions report `group_id=None` and old group ids raise
+[`RevisionError`](#revisionerror). `save()` does not invalidate groups (the
+Document stays open and revision ids are preserved). Revisions authored
+outside the current session (foreign reviewers, previous sessions) have no
+group — accept/reject them by id or author as before. If groups ever need to
+survive across sessions, the workspace `meta.json` (which never enters the
+`.docx`) is the natural extension point; that persistence is intentionally not
+implemented today.
+
+**Parameters:**
+
+- `group_id` (int): Group id from an `EditResult` (or a `Revision.group_id`)
+
+**Returns:** Number of revisions accepted (int). Members already resolved individually are skipped (and not counted).
+
+**Raises:** [`RevisionError`](#revisionerror) if the group id is unknown (never allocated, or allocated by a previous session on this document).
+
+**Example:**
+
+```python
+result = doc.rewrite_paragraph(ref, "New text.")
+doc.accept_group(result.group_id)  # apply the whole rewrite
+```
+
+#### `reject_group(group_id)`
+
+Reject every revision created by one logical edit operation — the counterpart
+of [`accept_group()`](#accept_groupgroup_id). Rejecting the group undoes the
+whole edit, restoring the exact pre-edit text (deletions restored, insertions
+removed). Same group semantics and lifetime as `accept_group()`.
+
+**Parameters:**
+
+- `group_id` (int): Group id from an `EditResult` (or a `Revision.group_id`)
+
+**Returns:** Number of revisions rejected (int). Members already resolved individually are skipped (and not counted).
+
+**Raises:** [`RevisionError`](#revisionerror) if the group id is unknown.
+
+**Example:**
+
+```python
+result = doc.rewrite_paragraph(ref, "New text.")
+doc.reject_group(result.group_id)  # undo the whole rewrite
+```
+
 #### `accept_all(author=None)`
 
 Accept all revisions.
@@ -714,6 +780,7 @@ from docx_editor import Revision
 | `author` | str | The revision author |
 | `date` | datetime or None | When the revision was made |
 | `text` | str | The inserted or deleted text |
+| `group_id` | int or None | Revision group of the edit that created it in this session (see [`accept_group()`](#accept_groupgroup_id)); None for foreign or pre-session revisions |
 
 ### Example
 
@@ -776,6 +843,40 @@ new_refs = doc.batch_edit([
     EditOperation.delete("obsolete clause", paragraph="P5#d4e5"),
     EditOperation.insert_after("Section 5", " (as amended)", paragraph="P7#b1c2"),
 ])
+```
+
+---
+
+## EditResult
+
+The return value of every tracked-edit method (`replace()`, `delete()`,
+`insert_after()`, `insert_before()`, `rewrite_paragraph()`, and the elements of
+`batch_edit()` / `batch_rewrite()` results). A `str` **subclass** — the string
+value is the new hash-anchored paragraph reference (e.g. `"P2#c3d4"`), so an
+`EditResult` works unchanged anywhere a ref string is expected — with the
+edit's revision-group info attached.
+
+```python
+from docx_editor import EditResult
+```
+
+### Attributes
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `group_id` | int or None | Revision group holding every revision this edit created, for [`accept_group()`](#accept_groupgroup_id) / [`reject_group()`](#reject_groupgroup_id). None when the edit created no new revisions (e.g. text spliced into one of your own pending insertions, or a no-change rewrite). Valid only while this Document stays open. |
+| `revision_ids` | tuple[int, ...] | The `w:id`s of the group's member revisions, in creation order; `()` when `group_id` is None |
+
+### Example
+
+```python
+result = doc.replace("30 days", "60 days", paragraph="P2#f3c1")
+print(str(result))         # "P2#c3d4" — the new paragraph ref
+print(result.group_id)     # 1
+print(result.revision_ids) # (0, 1) — the del and the ins
+
+doc.replace("net", "gross", paragraph=result)  # usable as a plain ref
+doc.reject_group(result.group_id)              # undo the first edit entirely
 ```
 
 ---

--- a/docs/api.md
+++ b/docs/api.md
@@ -368,7 +368,7 @@ resolve them as a unit with [`accept_group()`](#accept_groupgroup_id) /
 - `ref` (str): Paragraph reference from `list_paragraphs()`
 - `new_text` (str): Desired paragraph text
 
-**Returns:** Updated paragraph reference ([`EditResult`](#editresult) — a `str` subclass also carrying the edit's `group_id`/`revision_ids`; `group_id` is `None` when `new_text` equals the current text)
+**Returns:** Updated paragraph reference ([`EditResult`](#editresult) — a `str` subclass also carrying the edit's `group_id`/`revision_ids`; `group_id` is `None` when `new_text` equals the current text, or when every change landed inside your own pending insertions and was merged in place)
 
 **Example:**
 
@@ -864,7 +864,7 @@ from docx_editor import EditResult
 
 | Attribute | Type | Description |
 |-----------|------|-------------|
-| `group_id` | int or None | Revision group holding every revision this edit created, for [`accept_group()`](#accept_groupgroup_id) / [`reject_group()`](#reject_groupgroup_id). None when the edit created no new revisions (e.g. text spliced into one of your own pending insertions, or a no-change rewrite). Valid only while this Document stays open. |
+| `group_id` | int or None | Revision group holding every revision this edit created, for [`accept_group()`](#accept_groupgroup_id) / [`reject_group()`](#reject_groupgroup_id). None when the edit created no new revisions (e.g. text spliced into one of your own pending insertions, a no-change rewrite, or a rewrite whose changes all merged into your own pending insertions). Valid only while this Document stays open. |
 | `revision_ids` | tuple[int, ...] | The `w:id`s of the group's member revisions, in creation order; `()` when `group_id` is None |
 
 ### Example

--- a/docs/api.md
+++ b/docs/api.md
@@ -387,7 +387,7 @@ stale, the entire batch is rejected before any edits are applied.
 - `operations` (list[EditOperation]): Edit operations to apply
 - `dry_run` (bool): If True, validate every operation without applying any edits and return one [`EditValidationResult`](#editvalidationresult) per operation, in input order; the document is left unchanged. Each operation is validated independently against the current document — sequential effects between multiple operations on the same paragraph are **not** simulated. Defaults to False.
 
-**Returns:** Updated paragraph references in input order (list of [`EditResult`](#editresult)) — each operation is its own revision group, so one op can be accepted and another rejected; with `dry_run=True`, a list of [`EditValidationResult`](#editvalidationresult) instead
+**Returns:** Updated paragraph references in input order (list of [`EditResult`](#editresult)) — each operation that creates revisions gets its own revision group, so one op can be accepted and another rejected (`group_id` is `None` for an op that created no new revisions, e.g. text spliced into one of your own pending insertions); with `dry_run=True`, a list of [`EditValidationResult`](#editvalidationresult) instead
 
 **Raises:** [`BatchOperationError`](#batchoperationerror) — the only exception a non-dry-run batch raises for a failing operation, whatever the underlying cause (stale hash, malformed ref, missing text, ambiguous target). `operation_index` names the failing op; `original` (also `__cause__`) holds the underlying typed exception. The batch is atomic: nothing is applied on failure.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -425,7 +425,7 @@ Rewrite multiple paragraphs after validating paragraph hashes up front.
 
 - `rewrites` (list[tuple[str, str]]): Pairs of paragraph ref and desired text
 
-**Returns:** Updated paragraph references in input order (list of [`EditResult`](#editresult)); each rewrite gets its own revision group
+**Returns:** Updated paragraph references in input order (list of [`EditResult`](#editresult)); each rewrite gets its own revision group (`group_id` is `None` for a rewrite that made no change or whose changes fully merged into your own pending insertions)
 
 **Raises:** [`BatchOperationError`](#batchoperationerror) — same single-exception contract as `batch_edit()`.
 

--- a/docx_editor/__init__.py
+++ b/docx_editor/__init__.py
@@ -56,7 +56,7 @@ from .exceptions import (
     WorkspaceSyncError,
     XMLError,
 )
-from .track_changes import EditOperation, EditValidationResult, Revision, SearchResult
+from .track_changes import EditOperation, EditResult, EditValidationResult, Revision, SearchResult
 from .xml_editor import (
     ListItem,
     ParagraphInfo,
@@ -70,6 +70,7 @@ __all__ = [
     # Main classes
     "Document",
     "EditOperation",
+    "EditResult",
     "EditValidationResult",
     "Revision",
     "SearchResult",

--- a/docx_editor/document.py
+++ b/docx_editor/document.py
@@ -909,7 +909,8 @@ class Document:
             EditResult — the new paragraph reference with updated hash (e.g.,
             "P2#c3d4"), carrying ``group_id``/``revision_ids`` of all the
             revisions the rewrite created (``group_id`` is None when
-            new_text equals the current text).
+            new_text equals the current text, or when every change landed
+            inside your own pending insertions and was merged in place).
 
         Example:
             result = doc.rewrite_paragraph("P2#f3c1", "The board shall approve the proposal.")

--- a/docx_editor/document.py
+++ b/docx_editor/document.py
@@ -926,7 +926,8 @@ class Document:
         All paragraph hashes are validated before any rewrites are applied.
         If any hash is stale, the entire batch is rejected before any changes
         are made. Once validation passes, rewrites are applied sequentially.
-        Each rewrite gets its own revision group (see rewrite_paragraph).
+        Each rewrite gets its own revision group, or ``group_id=None`` when
+        it created no revisions (see rewrite_paragraph).
 
         Args:
             rewrites: List of (ref, new_text) tuples
@@ -934,7 +935,9 @@ class Document:
         Returns:
             List of EditResult (new paragraph references with updated hashes),
             in input order, each carrying its rewrite's
-            ``group_id``/``revision_ids``.
+            ``group_id``/``revision_ids`` (``group_id`` is None for a rewrite
+            that made no change or whose changes fully merged into your own
+            pending insertions).
 
         Raises:
             BatchOperationError: The only exception raised for a failing

--- a/docx_editor/document.py
+++ b/docx_editor/document.py
@@ -13,7 +13,14 @@ from xml.dom.minidom import Element
 
 from .comments import Comment, CommentManager
 from .exceptions import HashMismatchError, ParagraphIndexError
-from .track_changes import EditOperation, EditValidationResult, Revision, RevisionManager, SearchResult
+from .track_changes import (
+    EditOperation,
+    EditResult,
+    EditValidationResult,
+    Revision,
+    RevisionManager,
+    SearchResult,
+)
 from .workspace import Workspace
 from .xml_editor import (
     DocxXMLEditor,
@@ -46,8 +53,15 @@ class Document:
         from docx_editor import Document
 
         doc = Document.open("contract.docx")
-        doc.replace("30 days", "60 days")
+        ref = doc.find_text("30 days").paragraph_ref
+        result = doc.replace("30 days", "60 days", paragraph=ref)
         doc.add_comment("Section 5", "Please review")
+
+        # Every edit's revisions form a group — accept/reject them as a unit
+        # (group ids live only while this Document is open):
+        result = doc.rewrite_paragraph(result, "The board shall approve.")
+        doc.reject_group(result.group_id)  # undo the whole rewrite
+
         doc.save()
         doc.close()
     """
@@ -291,6 +305,11 @@ class Document:
         p = self._document_editor.dom.getElementsByTagName("w:p")[ref.index - 1]
         new_hash = compute_paragraph_hash(p)
         return f"P{ref.index}#{new_hash}"
+
+    def _edit_result(self, old_ref: str, group_id: int | None) -> EditResult:
+        """Build an EditResult from a mutated paragraph's old ref and its group."""
+        revision_ids = self._revision_manager.group_revisions(group_id) if group_id is not None else ()
+        return EditResult(self._compute_new_ref(old_ref), group_id=group_id, revision_ids=revision_ids)
 
     def paragraph_count(self) -> int:
         """Return the total number of paragraphs in the document.
@@ -685,7 +704,7 @@ class Document:
         self._ensure_open()
         return self._revision_manager.get_markup_text()
 
-    def replace(self, find: str, replace_with: str, *, paragraph: str, occurrence: int | None = None) -> str:
+    def replace(self, find: str, replace_with: str, *, paragraph: str, occurrence: int | None = None) -> EditResult:
         """Replace text with tracked changes.
 
         Creates a tracked deletion of the old text and insertion of the new text.
@@ -700,8 +719,10 @@ class Document:
                 enumerate the matches, or pass an explicit occurrence).
 
         Returns:
-            New paragraph reference with updated hash (e.g., "P2#c3d4").
-            Use this for follow-up edits without calling list_paragraphs().
+            EditResult — the new paragraph reference with updated hash (e.g.,
+            "P2#c3d4"; usable anywhere a ref string is expected), carrying
+            ``group_id``/``revision_ids`` of the revisions this edit created
+            for accept_group()/reject_group().
 
         Raises:
             TextNotFoundError: If ``find`` is absent or ``occurrence`` is out
@@ -715,10 +736,10 @@ class Document:
             doc.replace("other text", "new text", paragraph=new_ref)
         """
         self._ensure_open()
-        self._revision_manager.replace_text(find, replace_with, occurrence=occurrence, paragraph=paragraph)
-        return self._compute_new_ref(paragraph)
+        change_id = self._revision_manager.replace_text(find, replace_with, occurrence=occurrence, paragraph=paragraph)
+        return self._edit_result(paragraph, self._revision_manager.group_id_of(change_id))
 
-    def delete(self, text: str, *, paragraph: str, occurrence: int | None = None) -> str:
+    def delete(self, text: str, *, paragraph: str, occurrence: int | None = None) -> EditResult:
         """Mark text as deleted with tracked changes.
 
         Args:
@@ -729,7 +750,9 @@ class Document:
                 paragraph, else AmbiguousTextError.
 
         Returns:
-            New paragraph reference with updated hash (e.g., "P2#c3d4").
+            EditResult — the new paragraph reference with updated hash (e.g.,
+            "P2#c3d4"), carrying ``group_id``/``revision_ids`` of the
+            revisions this edit created.
 
         Raises:
             TextNotFoundError: If ``text`` is absent or ``occurrence`` is out
@@ -742,10 +765,10 @@ class Document:
             new_ref = doc.delete("obsolete clause", paragraph="P2#f3c1")
         """
         self._ensure_open()
-        self._revision_manager.suggest_deletion(text, occurrence=occurrence, paragraph=paragraph)
-        return self._compute_new_ref(paragraph)
+        change_id = self._revision_manager.suggest_deletion(text, occurrence=occurrence, paragraph=paragraph)
+        return self._edit_result(paragraph, self._revision_manager.group_id_of(change_id))
 
-    def insert_after(self, anchor: str, text: str, *, paragraph: str, occurrence: int | None = None) -> str:
+    def insert_after(self, anchor: str, text: str, *, paragraph: str, occurrence: int | None = None) -> EditResult:
         """Insert text after anchor with tracked changes.
 
         Args:
@@ -757,7 +780,9 @@ class Document:
                 paragraph, else AmbiguousTextError.
 
         Returns:
-            New paragraph reference with updated hash (e.g., "P2#c3d4").
+            EditResult — the new paragraph reference with updated hash (e.g.,
+            "P2#c3d4"), carrying ``group_id``/``revision_ids`` of the
+            revisions this edit created.
 
         Raises:
             TextNotFoundError: If ``anchor`` is absent or ``occurrence`` is
@@ -770,10 +795,10 @@ class Document:
             new_ref = doc.insert_after("Section 5", " (as amended)", paragraph="P2#f3c1")
         """
         self._ensure_open()
-        self._revision_manager.insert_text_after(anchor, text, occurrence=occurrence, paragraph=paragraph)
-        return self._compute_new_ref(paragraph)
+        change_id = self._revision_manager.insert_text_after(anchor, text, occurrence=occurrence, paragraph=paragraph)
+        return self._edit_result(paragraph, self._revision_manager.group_id_of(change_id))
 
-    def insert_before(self, anchor: str, text: str, *, paragraph: str, occurrence: int | None = None) -> str:
+    def insert_before(self, anchor: str, text: str, *, paragraph: str, occurrence: int | None = None) -> EditResult:
         """Insert text before anchor with tracked changes.
 
         Args:
@@ -785,7 +810,9 @@ class Document:
                 paragraph, else AmbiguousTextError.
 
         Returns:
-            New paragraph reference with updated hash (e.g., "P2#c3d4").
+            EditResult — the new paragraph reference with updated hash (e.g.,
+            "P2#c3d4"), carrying ``group_id``/``revision_ids`` of the
+            revisions this edit created.
 
         Raises:
             TextNotFoundError: If ``anchor`` is absent or ``occurrence`` is
@@ -798,18 +825,18 @@ class Document:
             new_ref = doc.insert_before("Section 6", "New clause: ", paragraph="P2#f3c1")
         """
         self._ensure_open()
-        self._revision_manager.insert_text_before(anchor, text, occurrence=occurrence, paragraph=paragraph)
-        return self._compute_new_ref(paragraph)
+        change_id = self._revision_manager.insert_text_before(anchor, text, occurrence=occurrence, paragraph=paragraph)
+        return self._edit_result(paragraph, self._revision_manager.group_id_of(change_id))
 
     @overload
-    def batch_edit(self, operations: list[EditOperation], *, dry_run: Literal[False] = ...) -> list[str]: ...
+    def batch_edit(self, operations: list[EditOperation], *, dry_run: Literal[False] = ...) -> list[EditResult]: ...
 
     @overload
     def batch_edit(self, operations: list[EditOperation], *, dry_run: Literal[True]) -> list[EditValidationResult]: ...
 
     def batch_edit(
         self, operations: list[EditOperation], *, dry_run: bool = False
-    ) -> list[str] | list[EditValidationResult]:
+    ) -> list[EditResult] | list[EditValidationResult]:
         """Apply multiple edits atomically with upfront hash validation.
 
         All paragraph hashes are validated before any edits are applied.
@@ -828,8 +855,10 @@ class Document:
                 RevisionManager.validate_batch).
 
         Returns:
-            When dry_run is False: list of new paragraph references with updated
-            hashes, in input order.
+            When dry_run is False: list of EditResult (new paragraph references
+            with updated hashes), in input order. Each operation gets its own
+            revision group — accept one op and reject another via
+            accept_group()/reject_group().
             When dry_run is True: list of EditValidationResult, one per operation.
 
         Raises:
@@ -856,42 +885,55 @@ class Document:
         self._ensure_open()
         if dry_run:
             return self._revision_manager.validate_batch(operations)
-        self._revision_manager.batch_edit(operations)
-        return [self._compute_new_ref(op.paragraph) for op in operations]
+        change_ids = self._revision_manager.batch_edit(operations)
+        return [
+            self._edit_result(op.paragraph, self._revision_manager.group_id_of(change_id))
+            for op, change_id in zip(operations, change_ids, strict=True)
+        ]
 
-    def rewrite_paragraph(self, ref: str, new_text: str) -> str:
+    def rewrite_paragraph(self, ref: str, new_text: str) -> EditResult:
         """Rewrite a paragraph's text with automatic fine-grained tracked changes.
 
         Diffs the current paragraph text against new_text at word level and
         generates minimal tracked insertions, deletions, and replacements.
+        All revisions from one rewrite share a revision group, so the rewrite
+        can be accepted or rejected as a unit — accepting only some of a
+        rewrite's revisions by id garbles the paragraph (each one is a diff
+        hunk, not a self-contained edit).
 
         Args:
             ref: Paragraph reference from list_paragraphs() (e.g., "P2#f3c1")
             new_text: Desired new text for the paragraph
 
         Returns:
-            The new paragraph reference with updated hash (e.g., "P2#c3d4").
-            Use this ref for follow-up edits without calling list_paragraphs().
+            EditResult — the new paragraph reference with updated hash (e.g.,
+            "P2#c3d4"), carrying ``group_id``/``revision_ids`` of all the
+            revisions the rewrite created (``group_id`` is None when
+            new_text equals the current text).
 
         Example:
-            new_ref = doc.rewrite_paragraph("P2#f3c1", "The board shall approve the proposal.")
+            result = doc.rewrite_paragraph("P2#f3c1", "The board shall approve the proposal.")
+            doc.reject_group(result.group_id)  # undo the whole rewrite
         """
         self._ensure_open()
-        self._revision_manager.rewrite_paragraph(ref, new_text)
-        return self._compute_new_ref(ref)
+        group_id = self._revision_manager.rewrite_paragraph(ref, new_text)
+        return self._edit_result(ref, group_id)
 
-    def batch_rewrite(self, rewrites: list[tuple[str, str]]) -> list[str]:
+    def batch_rewrite(self, rewrites: list[tuple[str, str]]) -> list[EditResult]:
         """Rewrite multiple paragraphs with upfront hash validation.
 
         All paragraph hashes are validated before any rewrites are applied.
         If any hash is stale, the entire batch is rejected before any changes
         are made. Once validation passes, rewrites are applied sequentially.
+        Each rewrite gets its own revision group (see rewrite_paragraph).
 
         Args:
             rewrites: List of (ref, new_text) tuples
 
         Returns:
-            List of new paragraph references with updated hashes, in input order
+            List of EditResult (new paragraph references with updated hashes),
+            in input order, each carrying its rewrite's
+            ``group_id``/``revision_ids``.
 
         Raises:
             BatchOperationError: The only exception raised for a failing
@@ -905,8 +947,8 @@ class Document:
             ])
         """
         self._ensure_open()
-        self._revision_manager.batch_rewrite(rewrites)
-        return [self._compute_new_ref(ref) for ref, _ in rewrites]
+        group_ids = self._revision_manager.batch_rewrite(rewrites)
+        return [self._edit_result(ref, group_id) for (ref, _), group_id in zip(rewrites, group_ids, strict=True)]
 
     # ==================== Comments API ====================
 
@@ -1035,7 +1077,10 @@ class Document:
             must not be passed to those APIs; None when the text is not
             locatable, e.g. nested revisions), plus ``nested_under`` and
             ``contains_ids`` describing revision nesting (e.g. a foreign
-            deletion inside another author's pending insertion).
+            deletion inside another author's pending insertion), and
+            ``group_id`` linking revisions created by the same edit
+            operation in this session (None for foreign or pre-session
+            revisions).
 
         Raises:
             ValueError: If ``paragraph`` is malformed
@@ -1087,6 +1132,65 @@ class Document:
         """
         self._ensure_open()
         return self._revision_manager.reject_revision(revision_id)
+
+    def accept_group(self, group_id: int) -> int:
+        """Accept every revision created by one logical edit operation.
+
+        Each edit method (replace, delete, insert_after/before,
+        rewrite_paragraph, and each operation of a batch) registers the
+        revisions it creates as one revision group; its EditResult carries
+        the ``group_id``. Accepting the group applies the whole edit —
+        resolving a multi-revision edit (especially a rewrite) revision by
+        revision can leave the text garbled if only some are applied.
+
+        Groups are in-memory and live only while this Document is open:
+        after close()/reopen, revisions report ``group_id=None`` and old
+        group ids raise. save() does not invalidate groups.
+
+        Args:
+            group_id: Group id from an EditResult (or a Revision's
+                ``group_id``)
+
+        Returns:
+            Number of revisions accepted. Members already resolved
+            individually are skipped (and not counted).
+
+        Raises:
+            RevisionError: If the group id is unknown (never allocated, or
+                allocated by a previous session on this document).
+
+        Example:
+            result = doc.rewrite_paragraph(ref, "New text.")
+            doc.accept_group(result.group_id)  # apply the whole rewrite
+        """
+        self._ensure_open()
+        return self._revision_manager.accept_group(group_id)
+
+    def reject_group(self, group_id: int) -> int:
+        """Reject every revision created by one logical edit operation.
+
+        The counterpart of :meth:`accept_group` — rejecting the group undoes
+        the whole edit, restoring the exact pre-edit text (deletions are
+        restored, insertions removed).
+
+        Args:
+            group_id: Group id from an EditResult (or a Revision's
+                ``group_id``)
+
+        Returns:
+            Number of revisions rejected. Members already resolved
+            individually are skipped (and not counted).
+
+        Raises:
+            RevisionError: If the group id is unknown (never allocated, or
+                allocated by a previous session on this document).
+
+        Example:
+            result = doc.rewrite_paragraph(ref, "New text.")
+            doc.reject_group(result.group_id)  # undo the whole rewrite
+        """
+        self._ensure_open()
+        return self._revision_manager.reject_group(group_id)
 
     def accept_all(self, author: str | None = None) -> int:
         """Accept all revisions.

--- a/docx_editor/track_changes.py
+++ b/docx_editor/track_changes.py
@@ -6,6 +6,8 @@ Provides RevisionManager for creating and managing tracked changes (insertions/d
 import difflib
 import re
 from collections import OrderedDict
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Literal
@@ -180,6 +182,40 @@ class EditValidationResult:
     error: str | None = None  # human-readable reason when not valid
 
 
+class EditResult(str):
+    """Result of a tracked edit: the new paragraph ref plus revision-group info.
+
+    Subclasses ``str`` — the string value *is* the new hash-anchored
+    paragraph reference (e.g. ``"P2#c3d4"``), so an EditResult works
+    unchanged anywhere a ref string is expected (``paragraph=`` of
+    follow-up edits, equality with plain strings, dict keys).
+
+    Extra attributes:
+
+    - ``group_id``: id of the revision group holding every revision this
+      operation created, usable with ``accept_group``/``reject_group``.
+      None when the operation created no new revisions — e.g. text spliced
+      into one of your own pending insertions (physically merged, so it is
+      inseparable from the earlier operation at the XML level), or a
+      rewrite that found no differences. Groups live only for the current
+      open Document (see ``Document.accept_group``).
+    - ``revision_ids``: the w:ids of the group's member revisions, in
+      creation order, as of this edit's return; ``()`` when ``group_id`` is
+      None. A later edit that splits one of these insertions adds the
+      split-off half to the group — ``Document.list_revisions`` reflects
+      live membership.
+    """
+
+    group_id: int | None
+    revision_ids: tuple[int, ...]
+
+    def __new__(cls, ref: str, group_id: int | None = None, revision_ids: tuple[int, ...] = ()) -> "EditResult":
+        result = super().__new__(cls, ref)
+        result.group_id = group_id
+        result.revision_ids = revision_ids
+        return result
+
+
 @dataclass(frozen=True)
 class SearchResult:
     """Public result of ``Document.find_text`` / ``find_all`` — no DOM internals.
@@ -237,6 +273,10 @@ class Revision:
       deletion inside another author's pending insertion), else None.
     - ``contains_ids``: ids of revisions nested inside this one, in document
       order.
+    - ``group_id``: id of the revision group this revision was created in
+      (all revisions from one logical edit share it — see
+      ``Document.accept_group``). None for revisions that predate the open
+      Document session or were authored elsewhere.
     """
 
     id: int
@@ -248,6 +288,7 @@ class Revision:
     occurrence: int | None = None
     nested_under: int | None = None
     contains_ids: tuple[int, ...] = ()
+    group_id: int | None = None
 
     def __repr__(self) -> str:
         kind = "ins" if self.type == "insertion" else "del"
@@ -255,7 +296,8 @@ class Revision:
         preview = self.text[:30] + ("..." if len(self.text) > 30 else "")
         nested = f", nested_under={self.nested_under}" if self.nested_under is not None else ""
         contains = f", contains={list(self.contains_ids)}" if self.contains_ids else ""
-        return f"Revision({kind} {self.id}{location}: '{preview}' by {self.author}{nested}{contains})"
+        group = f", group={self.group_id}" if self.group_id is not None else ""
+        return f"Revision({kind} {self.id}{location}: '{preview}' by {self.author}{nested}{contains}{group})"
 
 
 def _ancestor_paragraph(elem) -> Element | None:
@@ -335,6 +377,14 @@ def _has_ancestor(node, ancestor) -> bool:
     return False
 
 
+@dataclass
+class _GroupCapture:
+    """Filled in by ``RevisionManager._grouped`` when its with-block exits."""
+
+    group_id: int | None = None
+    revision_ids: tuple[int, ...] = ()
+
+
 def _occurrence_in_text_map(tm: TextMap, elem, text: str) -> int | None:
     """0-based occurrence index of ``text`` at ``elem``'s own span in ``tm``.
 
@@ -406,6 +456,112 @@ class RevisionManager:
             editor: DocxXMLEditor instance for word/document.xml
         """
         self.editor = editor
+        # Revision groups: every revision created by one logical operation
+        # shares a group id, so callers can accept/reject the operation as a
+        # unit. In-memory only — groups live for the lifetime of this manager
+        # (i.e. the open Document); nothing is written into the .docx.
+        self._groups: dict[int, tuple[int, ...]] = {}
+        self._revision_groups: dict[int, int] = {}
+        self._group_counter = 1
+
+    @contextmanager
+    def _grouped(self) -> Iterator[_GroupCapture]:
+        """Register every revision the wrapped operation creates as one group.
+
+        Captures the <w:ins>/<w:del> elements processed by attribute
+        injection during the with-block, then keeps those that are (i)
+        authored by us — a split half of a *foreign* insertion gets a fresh
+        id but keeps the foreign author, and must not join our group —
+        (ii) still attached to the DOM, excluding create-then-remove churn,
+        and (iii) not already registered to an earlier group — a split-off
+        tail of one of our *own* insertions is adopted into its origin
+        group by _adopt_split_tail, not claimed by the splitting operation.
+        A group id is allocated only when that filtered set is non-empty;
+        it is exposed on the yielded _GroupCapture after the block exits.
+        If the operation raises, nothing is registered.
+        """
+        capture = _GroupCapture()
+        with self.editor.collect_tracked_changes() as collected:
+            yield capture
+        members: list[int] = []
+        seen: set[int] = set()
+        for elem in collected:
+            if elem.getAttribute("w:author") != self.editor.author:
+                continue
+            if not _has_ancestor(elem, self.editor.dom):
+                continue
+            try:
+                # Ids we assign are always numeric; a non-numeric one was
+                # copied from a nonconforming producer's element — leave it
+                # ungrouped rather than fail the edit (same tolerance as
+                # _get_next_change_id).
+                rev_id = int(elem.getAttribute("w:id"))
+            except ValueError:
+                continue
+            if rev_id in self._revision_groups:
+                continue
+            if rev_id not in seen:
+                seen.add(rev_id)
+                members.append(rev_id)
+        if members:
+            group_id = self._group_counter
+            self._group_counter += 1
+            self._groups[group_id] = tuple(members)
+            for rev_id in members:
+                self._revision_groups[rev_id] = group_id
+            capture.group_id = group_id
+            capture.revision_ids = tuple(members)
+
+    def _adopt_split_tail(self, original_ins, new_nodes) -> None:
+        """Keep a split-off tail of one of our own insertions in its origin group.
+
+        Editing the middle of our own pending insertion physically splits it:
+        the trailing half is re-created as a fresh <w:ins> with a fresh w:id.
+        That tail is leftover content of the *original* insertion's operation,
+        not of the operation doing the splitting — so it joins the original
+        insertion's group (when it has one), keeping reject_group/accept_group
+        of that earlier operation complete. Registering it here also stops
+        the active ``_grouped`` capture from claiming it (its id is already
+        in ``_revision_groups`` when the capture filters members).
+        """
+        try:
+            origin_group = self._revision_groups.get(int(original_ins.getAttribute("w:id")))
+        except ValueError:  # pragma: no cover - our own ins always has a numeric id
+            return
+        if origin_group is None:
+            return
+        for node in new_nodes:
+            if node.nodeType == node.ELEMENT_NODE and node.tagName == "w:ins":  # pragma: no branch
+                tail_id = int(node.getAttribute("w:id"))
+                self._groups[origin_group] = (*self._groups[origin_group], tail_id)
+                self._revision_groups[tail_id] = origin_group
+
+    def _registry_snapshot(self) -> tuple[int, dict[int, tuple[int, ...]], dict[int, int]]:
+        """Snapshot the group registry for rollback alongside a DOM snapshot."""
+        return (self._group_counter, dict(self._groups), dict(self._revision_groups))
+
+    def _restore_registry(self, snapshot: tuple[int, dict[int, tuple[int, ...]], dict[int, int]]) -> None:
+        """Restore the group registry captured by ``_registry_snapshot``."""
+        self._group_counter, self._groups, self._revision_groups = snapshot
+
+    def group_id_of(self, revision_id: int) -> int | None:
+        """Group id of a revision created through this manager, or None."""
+        return self._revision_groups.get(revision_id)
+
+    def group_revisions(self, group_id: int) -> tuple[int, ...]:
+        """Member revision ids of ``group_id``, in creation order.
+
+        Raises:
+            RevisionError: If the group id is unknown to this manager (groups
+                exist only for edits made through the current open Document).
+        """
+        members = self._groups.get(group_id)
+        if members is None:
+            raise RevisionError(
+                f"Unknown revision group: {group_id}. Groups exist only for edits made "
+                f"through the current open Document; they are not persisted in the file."
+            )
+        return members
 
     def _resolve_paragraph(self, ref: ParagraphRef):
         """Resolve a ParagraphRef to its <w:p> element, validating the hash.
@@ -519,14 +675,20 @@ class RevisionManager:
         # Stable sort preserves original order for same-paragraph edits
         parsed.sort(key=lambda x: x[1].index, reverse=True)
 
-        # Snapshot DOM before any mutation so we can roll back on partial failure.
+        # Snapshot DOM and group registry before any mutation so we can roll
+        # back on partial failure — without the registry snapshot, rollback
+        # would leave ghost groups pointing at reverted revision ids.
         snapshot = self.editor.dom.toxml(encoding=self.editor.encoding)
+        registry_snapshot = self._registry_snapshot()
 
         try:
             results = [0] * len(operations)
             for original_idx, _ref, op in parsed:
                 try:
-                    change_id = self._apply_single_edit(op)
+                    # Each op is its own logical edit: one group per op, so
+                    # callers can accept one op and reject another.
+                    with self._grouped():
+                        change_id = self._apply_single_edit(op)
                 except (ValueError, DocxEditError) as e:
                     raise BatchOperationError(original_idx, str(e), original=e) from e
                 results[original_idx] = change_id
@@ -539,6 +701,7 @@ class RevisionManager:
                 self.editor._reload_dom_from_bytes(snapshot)
             except Exception:
                 pass
+            self._restore_registry(registry_snapshot)
             raise
 
     def _resolve_action_target(self, op: EditOperation) -> str:
@@ -662,8 +825,13 @@ class RevisionManager:
 
         return None
 
-    def batch_rewrite(self, rewrites: list[tuple[str, str]]) -> None:
+    def batch_rewrite(self, rewrites: list[tuple[str, str]]) -> list[int | None]:
         """Rewrite multiple paragraphs with upfront hash validation.
+
+        Returns:
+            One revision group id per rewrite, in input order (None for
+            rewrites that created no revisions) — each rewrite gets its own
+            group via :meth:`rewrite_paragraph`.
 
         Raises:
             BatchOperationError: If any rewrite fails — validation (malformed
@@ -672,7 +840,7 @@ class RevisionManager:
                 ``__cause__``) with the underlying typed exception.
         """
         if not rewrites:
-            return
+            return []
 
         # Parse and validate all refs upfront
         parsed: list[tuple[int, ParagraphRef, str]] = []
@@ -694,17 +862,20 @@ class RevisionManager:
         # Sort by paragraph index descending
         parsed.sort(key=lambda x: x[1].index, reverse=True)
 
-        # Snapshot DOM before any mutation so we can roll back on partial
-        # failure — same atomicity contract as batch_edit.
+        # Snapshot DOM and group registry before any mutation so we can roll
+        # back on partial failure — same atomicity contract as batch_edit.
         snapshot = self.editor.dom.toxml(encoding=self.editor.encoding)
+        registry_snapshot = self._registry_snapshot()
 
         try:
             # Apply rewrites in reverse paragraph order
+            group_ids: list[int | None] = [None] * len(rewrites)
             for original_idx, ref, new_text in parsed:
                 try:
-                    self.rewrite_paragraph(f"P{ref.index}#{ref.hash}", new_text)
+                    group_ids[original_idx] = self.rewrite_paragraph(f"P{ref.index}#{ref.hash}", new_text)
                 except (ValueError, DocxEditError) as e:
                     raise BatchOperationError(original_idx, str(e), original=e) from e
+            return group_ids
         except Exception:
             # Restore via the line-tracking parser so parse_position is preserved.
             # If rollback itself fails, surface the original edit error — it is
@@ -713,22 +884,37 @@ class RevisionManager:
                 self.editor._reload_dom_from_bytes(snapshot)
             except Exception:
                 pass
+            self._restore_registry(registry_snapshot)
             raise
 
-    def rewrite_paragraph(self, ref_str: str, new_text: str) -> None:
+    def rewrite_paragraph(self, ref_str: str, new_text: str) -> int | None:
         """Rewrite a paragraph's text, generating fine-grained tracked changes.
 
         Diffs old vs new text at word level and applies minimal tracked changes
-        (insertions, deletions, replacements) to transform the paragraph.
+        (insertions, deletions, replacements) to transform the paragraph. All
+        revisions created by one call are registered as a single revision
+        group, so ``accept_group``/``reject_group`` can resolve the rewrite
+        as a unit.
 
         Args:
             ref_str: Paragraph reference string (e.g., "P3#a7b2")
             new_text: Desired new text for the paragraph
 
+        Returns:
+            The rewrite's revision group id, or None when no revisions were
+            created (old text already equals ``new_text``, or every change
+            was absorbed into this author's own pending insertions).
+
         Raises:
             HashMismatchError: If the paragraph hash doesn't match
             IndexError: If paragraph index is out of range
         """
+        with self._grouped() as capture:
+            self._rewrite_paragraph_inner(ref_str, new_text)
+        return capture.group_id
+
+    def _rewrite_paragraph_inner(self, ref_str: str, new_text: str) -> None:
+        """Diff-and-apply body of ``rewrite_paragraph`` (runs inside _grouped)."""
         ref = ParagraphRef.parse(ref_str)
         p = self._resolve_paragraph(ref)
         text_map = build_text_map(p)
@@ -1080,14 +1266,15 @@ class RevisionManager:
                 matches more than once in the search scope
             HashMismatchError: If the paragraph hash doesn't match
         """
-        if paragraph is not None:
-            ref = ParagraphRef.parse(paragraph)
-            p = self._resolve_paragraph(ref)
-            match = self._locate_in_paragraph(p, paragraph, find, occurrence)
-            return self._replace_across_nodes(match, replace_with)
+        with self._grouped():
+            if paragraph is not None:
+                ref = ParagraphRef.parse(paragraph)
+                p = self._resolve_paragraph(ref)
+                match = self._locate_in_paragraph(p, paragraph, find, occurrence)
+                return self._replace_across_nodes(match, replace_with)
 
-        match = self._locate_document_wide(find, occurrence)
-        return self._replace_across_nodes(match, replace_with)
+            match = self._locate_document_wide(find, occurrence)
+            return self._replace_across_nodes(match, replace_with)
 
     def suggest_deletion(self, text: str, occurrence: int | None = None, paragraph: str | None = None) -> int:
         """Mark text as deleted with tracked changes.
@@ -1108,14 +1295,15 @@ class RevisionManager:
                 matches more than once in the search scope
             HashMismatchError: If the paragraph hash doesn't match
         """
-        if paragraph is not None:
-            ref = ParagraphRef.parse(paragraph)
-            p = self._resolve_paragraph(ref)
-            match = self._locate_in_paragraph(p, paragraph, text, occurrence)
-            return self._delete_across_nodes(match)
+        with self._grouped():
+            if paragraph is not None:
+                ref = ParagraphRef.parse(paragraph)
+                p = self._resolve_paragraph(ref)
+                match = self._locate_in_paragraph(p, paragraph, text, occurrence)
+                return self._delete_across_nodes(match)
 
-        match = self._locate_document_wide(text, occurrence)
-        return self._delete_across_nodes(match)
+            match = self._locate_document_wide(text, occurrence)
+            return self._delete_across_nodes(match)
 
     def _get_run_info(self, node) -> tuple[Element | None, str]:
         """Get the parent w:r element and its rPr XML for a w:t node."""
@@ -1249,9 +1437,15 @@ class RevisionManager:
                     # ins_elem was fully removed — wrap replacement in a new <w:ins>
                     ins_wrapper_xml = f"<w:ins>{new_run_xml}</w:ins>"
                     if ins_next:
-                        self.editor.insert_before(ins_next, ins_wrapper_xml)
+                        new_nodes = self.editor.insert_before(ins_next, ins_wrapper_xml)
                     else:
-                        self.editor.append_to(ins_parent, ins_wrapper_xml)
+                        new_nodes = self.editor.append_to(ins_parent, ins_wrapper_xml)
+                    # The wrapper is a new revision holding this operation's
+                    # replacement text — return its id so the caller's
+                    # EditResult reaches the group that contains it.
+                    for node in new_nodes:
+                        if node.nodeType == node.ELEMENT_NODE and node.tagName == "w:ins":  # pragma: no branch
+                            return int(node.getAttribute("w:id"))
                 return -1
 
             # Foreign insertion(s) involved — preserve them: nest our deletion
@@ -1674,7 +1868,8 @@ class RevisionManager:
                 if ins_elem and run:
                     rPr_xml = get_rPr_xml(run)
                     after_xml = f"<w:ins><w:r>{rPr_xml}<w:t>{_escape_xml(after_text)}</w:t></w:r></w:ins>"
-                    self.editor.insert_after(ins_elem, after_xml)
+                    new_nodes = self.editor.insert_after(ins_elem, after_xml)
+                    self._adopt_split_tail(ins_elem, new_nodes)
         else:
             # Multi-node: truncate first node to before, last node to after,
             # remove intermediate nodes entirely.
@@ -1969,14 +2164,15 @@ class RevisionManager:
         paragraph: str | None = None,
     ) -> int:
         """Insert text before or after anchor with tracked changes."""
-        if paragraph is not None:
-            ref = ParagraphRef.parse(paragraph)
-            p = self._resolve_paragraph(ref)
-            match = self._locate_in_paragraph(p, paragraph, anchor, occurrence)
-            return self._insert_near_match(match, text, position)
+        with self._grouped():
+            if paragraph is not None:
+                ref = ParagraphRef.parse(paragraph)
+                p = self._resolve_paragraph(ref)
+                match = self._locate_in_paragraph(p, paragraph, anchor, occurrence)
+                return self._insert_near_match(match, text, position)
 
-        match = self._locate_document_wide(anchor, occurrence)
-        return self._insert_near_match(match, text, position)
+            match = self._locate_document_wide(anchor, occurrence)
+            return self._insert_near_match(match, text, position)
 
     def _insert_near_match(self, match: TextMapMatch, text: str, position: Literal["before", "after"]) -> int:
         """Insert text before/after a match, splitting the edge w:t at the match boundary."""
@@ -2192,6 +2388,7 @@ class RevisionManager:
             occurrence=occurrence,
             nested_under=_nearest_revision_ancestor_id(elem),
             contains_ids=_descendant_revision_ids(elem),
+            group_id=self._revision_groups.get(int(rev_id)),
         )
 
     def accept_revision(self, revision_id: int) -> bool:
@@ -2251,6 +2448,57 @@ class RevisionManager:
                 return True
 
         return False
+
+    def _resolve_group(self, group_id: int, resolve: Callable[[int], bool]) -> int:
+        """Apply ``resolve`` (accept/reject_revision) to every member of a group.
+
+        Same reverse-id, loop-until-no-progress pattern as accept_all/
+        reject_all, restricted to the group's members: nested members become
+        resolvable once their host is processed, and members already resolved
+        individually are simply skipped.
+        """
+        members = self.group_revisions(group_id)
+        count = 0
+        while True:
+            progressed = False
+            for rev_id in sorted(members, reverse=True):
+                if resolve(rev_id):
+                    count += 1
+                    progressed = True
+            if not progressed:
+                return count
+
+    def accept_group(self, group_id: int) -> int:
+        """Accept every revision in a revision group.
+
+        Args:
+            group_id: Group id from an edit's :class:`EditResult` (or a
+                Revision's ``group_id``).
+
+        Returns:
+            Number of revisions accepted. Members already resolved
+            individually are skipped (and not counted).
+
+        Raises:
+            RevisionError: If the group id is unknown to this manager.
+        """
+        return self._resolve_group(group_id, self.accept_revision)
+
+    def reject_group(self, group_id: int) -> int:
+        """Reject every revision in a revision group.
+
+        Args:
+            group_id: Group id from an edit's :class:`EditResult` (or a
+                Revision's ``group_id``).
+
+        Returns:
+            Number of revisions rejected. Members already resolved
+            individually are skipped (and not counted).
+
+        Raises:
+            RevisionError: If the group id is unknown to this manager.
+        """
+        return self._resolve_group(group_id, self.reject_revision)
 
     def accept_all(self, author: str | None = None) -> int:
         """Accept all revisions, optionally filtered by author.

--- a/docx_editor/track_changes.py
+++ b/docx_editor/track_changes.py
@@ -196,8 +196,9 @@ class EditResult(str):
       operation created, usable with ``accept_group``/``reject_group``.
       None when the operation created no new revisions — e.g. text spliced
       into one of your own pending insertions (physically merged, so it is
-      inseparable from the earlier operation at the XML level), or a
-      rewrite that found no differences. Groups live only for the current
+      inseparable from the earlier operation at the XML level), a rewrite
+      that found no differences, or a rewrite whose changes all landed
+      inside your own pending insertions. Groups live only for the current
       open Document (see ``Document.accept_group``).
     - ``revision_ids``: the w:ids of the group's member revisions, in
       creation order, as of this edit's return; ``()`` when ``group_id`` is
@@ -471,8 +472,10 @@ class RevisionManager:
     def _grouped(self) -> Iterator[_GroupCapture]:
         """Register every revision the wrapped operation creates as one group.
 
-        Captures the <w:ins>/<w:del> elements processed by attribute
-        injection during the with-block, then keeps those that are (i)
+        Captures the <w:ins>/<w:del> elements newly created during the
+        with-block (freshly assigned ``w:id``; pre-existing revisions
+        re-serialized by insertion splits are never collected), then keeps
+        those that are (i)
         authored by us — a split half of a *foreign* insertion gets a fresh
         id but keeps the foreign author, and must not join our group —
         (ii) still attached to the DOM, excluding create-then-remove churn,
@@ -1451,7 +1454,7 @@ class RevisionManager:
                     for node in new_nodes:
                         if node.nodeType == node.ELEMENT_NODE and node.tagName == "w:ins":  # pragma: no branch
                             return int(node.getAttribute("w:id"))
-                return -1
+                return -1  # pragma: no cover - the wrapper fragment always yields a w:ins
 
             # Foreign insertion(s) involved — preserve them: nest our deletion
             # inside, then place our replacement <w:ins> right after it,

--- a/docx_editor/track_changes.py
+++ b/docx_editor/track_changes.py
@@ -382,7 +382,6 @@ class _GroupCapture:
     """Filled in by ``RevisionManager._grouped`` when its with-block exits."""
 
     group_id: int | None = None
-    revision_ids: tuple[int, ...] = ()
 
 
 def _occurrence_in_text_map(tm: TextMap, elem, text: str) -> int | None:
@@ -461,7 +460,11 @@ class RevisionManager:
         # unit. In-memory only — groups live for the lifetime of this manager
         # (i.e. the open Document); nothing is written into the .docx.
         self._groups: dict[int, tuple[int, ...]] = {}
-        self._revision_groups: dict[int, int] = {}
+        # Maps revision id -> group id. A None value means explicitly
+        # ungrouped: a split-off tail of a pre-session insertion, registered
+        # so the active _grouped capture cannot claim it (membership is
+        # key-based) while group_id_of/list_revisions still report None.
+        self._revision_groups: dict[int, int | None] = {}
         self._group_counter = 1
 
     @contextmanager
@@ -473,9 +476,10 @@ class RevisionManager:
         authored by us — a split half of a *foreign* insertion gets a fresh
         id but keeps the foreign author, and must not join our group —
         (ii) still attached to the DOM, excluding create-then-remove churn,
-        and (iii) not already registered to an earlier group — a split-off
-        tail of one of our *own* insertions is adopted into its origin
-        group by _adopt_split_tail, not claimed by the splitting operation.
+        and (iii) not already registered by ``_adopt_split_tail`` — a
+        split-off tail of one of our *own* insertions is adopted into its
+        origin group (or marked ungrouped when the origin predates this
+        session), never claimed by the splitting operation.
         A group id is allocated only when that filtered set is non-empty;
         it is exposed on the yielded _GroupCapture after the block exits.
         If the operation raises, nothing is registered.
@@ -510,7 +514,6 @@ class RevisionManager:
             for rev_id in members:
                 self._revision_groups[rev_id] = group_id
             capture.group_id = group_id
-            capture.revision_ids = tuple(members)
 
     def _adopt_split_tail(self, original_ins, new_nodes) -> None:
         """Keep a split-off tail of one of our own insertions in its origin group.
@@ -519,28 +522,30 @@ class RevisionManager:
         the trailing half is re-created as a fresh <w:ins> with a fresh w:id.
         That tail is leftover content of the *original* insertion's operation,
         not of the operation doing the splitting — so it joins the original
-        insertion's group (when it has one), keeping reject_group/accept_group
-        of that earlier operation complete. Registering it here also stops
-        the active ``_grouped`` capture from claiming it (its id is already
-        in ``_revision_groups`` when the capture filters members).
+        insertion's group, keeping reject_group/accept_group of that earlier
+        operation complete. When the origin has no group (a pre-session
+        insertion by this author), the tail is registered as explicitly
+        ungrouped (None) instead. Either registration stops the active
+        ``_grouped`` capture from claiming the tail for the splitting
+        operation — otherwise rejecting that operation's group would rip a
+        leftover piece out of a pre-existing insertion.
         """
         try:
             origin_group = self._revision_groups.get(int(original_ins.getAttribute("w:id")))
         except ValueError:  # pragma: no cover - our own ins always has a numeric id
-            return
-        if origin_group is None:
-            return
+            origin_group = None
         for node in new_nodes:
             if node.nodeType == node.ELEMENT_NODE and node.tagName == "w:ins":  # pragma: no branch
                 tail_id = int(node.getAttribute("w:id"))
-                self._groups[origin_group] = (*self._groups[origin_group], tail_id)
                 self._revision_groups[tail_id] = origin_group
+                if origin_group is not None:
+                    self._groups[origin_group] = (*self._groups[origin_group], tail_id)
 
-    def _registry_snapshot(self) -> tuple[int, dict[int, tuple[int, ...]], dict[int, int]]:
+    def _registry_snapshot(self) -> tuple[int, dict[int, tuple[int, ...]], dict[int, int | None]]:
         """Snapshot the group registry for rollback alongside a DOM snapshot."""
         return (self._group_counter, dict(self._groups), dict(self._revision_groups))
 
-    def _restore_registry(self, snapshot: tuple[int, dict[int, tuple[int, ...]], dict[int, int]]) -> None:
+    def _restore_registry(self, snapshot: tuple[int, dict[int, tuple[int, ...]], dict[int, int | None]]) -> None:
         """Restore the group registry captured by ``_registry_snapshot``."""
         self._group_counter, self._groups, self._revision_groups = snapshot
 
@@ -2378,8 +2383,9 @@ class RevisionManager:
                     view: Literal["accepted", "original"] = "accepted" if rev_type == "insertion" else "original"
                     occurrence = _occurrence_in_text_map(ctx.text_map(paragraph, view), elem, text)
 
+        rev_id_int = int(rev_id)
         return Revision(
-            id=int(rev_id),
+            id=rev_id_int,
             type=rev_type,
             author=author,
             date=date,
@@ -2388,7 +2394,7 @@ class RevisionManager:
             occurrence=occurrence,
             nested_under=_nearest_revision_ancestor_id(elem),
             contains_ids=_descendant_revision_ids(elem),
-            group_id=self._revision_groups.get(int(rev_id)),
+            group_id=self._revision_groups.get(rev_id_int),
         )
 
     def accept_revision(self, revision_id: int) -> bool:

--- a/docx_editor/track_changes.py
+++ b/docx_editor/track_changes.py
@@ -1454,7 +1454,8 @@ class RevisionManager:
                     for node in new_nodes:
                         if node.nodeType == node.ELEMENT_NODE and node.tagName == "w:ins":  # pragma: no branch
                             return int(node.getAttribute("w:id"))
-                return -1  # pragma: no cover - the wrapper fragment always yields a w:ins
+                # Reached by the splice-in-place branch: no new revision.
+                return -1
 
             # Foreign insertion(s) involved — preserve them: nest our deletion
             # inside, then place our replacement <w:ins> right after it,

--- a/docx_editor/xml_editor.py
+++ b/docx_editor/xml_editor.py
@@ -1232,13 +1232,15 @@ class DocxXMLEditor(XMLEditor):
 
     @contextmanager
     def collect_tracked_changes(self) -> Iterator[list[Element]]:
-        """Collect every <w:ins>/<w:del> element processed by attribute injection.
+        """Collect every newly created <w:ins>/<w:del> seen by attribute injection.
 
         While the context is active, ``_inject_attributes_to_nodes`` appends
-        each tracked-change element it touches (whether or not its ``w:id``
-        was auto-assigned) to the yielded list. Does not nest — the collector
-        is a single slot, and nested capture would misattribute elements to
-        the outer collection.
+        each tracked-change element whose ``w:id`` it freshly assigned to the
+        yielded list. Elements arriving with a ``w:id`` already set are
+        pre-existing revisions passing back through injection (re-serialized
+        during an insertion split) and are deliberately not collected. Does
+        not nest — the collector is a single slot, and nested capture would
+        misattribute elements to the outer collection.
         """
         if self._tracked_change_collector is not None:
             raise RuntimeError("collect_tracked_changes() does not nest")
@@ -1323,8 +1325,14 @@ class DocxXMLEditor(XMLEditor):
                     elem.setAttribute("w:rsidR", self.rsid)
 
         def add_tracked_change_attrs(elem) -> None:
-            # Auto-assign w:id if not present
-            if not elem.hasAttribute("w:id"):
+            # A pre-set w:id means the element is not new — it is pre-existing
+            # markup passing back through injection (e.g. re-serialized when a
+            # foreign <w:ins> is split around it). Only freshly-created
+            # elements (fragments never pre-set w:id) get ids assigned and are
+            # reported to the collector; collecting re-serialized revisions
+            # would misattribute them to the operation doing the splitting.
+            is_new = not elem.hasAttribute("w:id")
+            if is_new:
                 elem.setAttribute("w:id", str(self._get_next_change_id()))
             if not elem.hasAttribute("w:author"):
                 elem.setAttribute("w:author", self.author)
@@ -1334,7 +1342,7 @@ class DocxXMLEditor(XMLEditor):
             if elem.tagName in ("w:ins", "w:del") and not elem.hasAttribute("w16du:dateUtc"):
                 self._ensure_w16du_namespace()
                 elem.setAttribute("w16du:dateUtc", timestamp)
-            if self._tracked_change_collector is not None:
+            if is_new and self._tracked_change_collector is not None:
                 self._tracked_change_collector.append(elem)
 
         def add_comment_attrs(elem) -> None:

--- a/docx_editor/xml_editor.py
+++ b/docx_editor/xml_editor.py
@@ -9,7 +9,8 @@ import io
 import random
 import re
 import zlib
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -1207,10 +1208,16 @@ class DocxXMLEditor(XMLEditor):
         self.rsid = rsid
         self.author = author
         self.initials = initials or author[0].upper() if author else ""
+        # Highest change id ever seen or assigned by this editor instance.
+        # Keeps id allocation monotonic: removing the max-id element mid-
+        # operation must not let its id be reissued (id-keyed bookkeeping
+        # such as revision groups would silently point at the wrong element).
+        self._max_change_id = -1
+        self._tracked_change_collector: list[Element] | None = None
 
     def _get_next_change_id(self) -> int:
         """Get the next available change ID by checking all tracked change elements."""
-        max_id = -1
+        max_id = self._max_change_id
         for tag in ("w:ins", "w:del"):
             elements = self.dom.getElementsByTagName(tag)
             for elem in elements:
@@ -1220,7 +1227,27 @@ class DocxXMLEditor(XMLEditor):
                         max_id = max(max_id, int(change_id))
                     except ValueError:
                         pass
-        return max_id + 1
+        self._max_change_id = max_id + 1
+        return self._max_change_id
+
+    @contextmanager
+    def collect_tracked_changes(self) -> Iterator[list[Element]]:
+        """Collect every <w:ins>/<w:del> element processed by attribute injection.
+
+        While the context is active, ``_inject_attributes_to_nodes`` appends
+        each tracked-change element it touches (whether or not its ``w:id``
+        was auto-assigned) to the yielded list. Does not nest — the collector
+        is a single slot, and nested capture would misattribute elements to
+        the outer collection.
+        """
+        if self._tracked_change_collector is not None:
+            raise RuntimeError("collect_tracked_changes() does not nest")
+        collected: list[Element] = []
+        self._tracked_change_collector = collected
+        try:
+            yield collected
+        finally:
+            self._tracked_change_collector = None
 
     def _ensure_w16du_namespace(self) -> None:
         """Ensure w16du namespace is declared on the root element."""
@@ -1307,6 +1334,8 @@ class DocxXMLEditor(XMLEditor):
             if elem.tagName in ("w:ins", "w:del") and not elem.hasAttribute("w16du:dateUtc"):
                 self._ensure_w16du_namespace()
                 elem.setAttribute("w16du:dateUtc", timestamp)
+            if self._tracked_change_collector is not None:
+                self._tracked_change_collector.append(elem)
 
         def add_comment_attrs(elem) -> None:
             if not elem.hasAttribute("w:author"):

--- a/skills/docx/SKILL.md
+++ b/skills/docx/SKILL.md
@@ -389,7 +389,7 @@ doc.accept_revision(revisions[0].id)
 doc.reject_revision(their_changes[0].id)
 
 # Accept or reject one edit's revisions as a unit (returns count processed).
-# Every edit method returns an EditResult carrying group_id; ALWAYS prefer
+# Every edit method returns an EditResult carrying group_id; prefer
 # groups over per-id calls for rewrite_paragraph — one rewrite creates many
 # revisions (one per diff hunk), and accepting only some of them by id
 # garbles the paragraph. Raises RevisionError for an unknown group id.

--- a/skills/docx/SKILL.md
+++ b/skills/docx/SKILL.md
@@ -585,7 +585,7 @@ refs_only = doc.list_paragraphs(max_chars=0)         # "P1#a7b2", no preview
 
 The `paragraph` argument is **required** for all edit methods. If the paragraph content has changed since you called `list_paragraphs()`, a `HashMismatchError` is raised — preventing edits to the wrong location.
 
-**Every edit method returns the new paragraph ref as a plain string.** Chain edits without calling `list_paragraphs()` again:
+**Every edit method returns an `EditResult` — a `str` subclass whose value is the new paragraph ref (plus `group_id`/`revision_ids`).** Chain edits without calling `list_paragraphs()` again:
 
 ```python
 # Chain 3 edits on the same paragraph — no list_paragraphs() between them:

--- a/skills/docx/SKILL.md
+++ b/skills/docx/SKILL.md
@@ -267,8 +267,8 @@ print(loc.section)  # 1-based section index; sectPr-carrying paragraph closes it
 # One-pass batch variant: [(ref, ParagraphLocation), ...] for every paragraph
 locations = doc.list_paragraph_locations()
 
-# All edit methods return the new paragraph ref as a plain string.
-# Use it for follow-up edits on the same paragraph:
+# All edit methods return an EditResult — a str subclass whose value is the
+# new paragraph ref. Use it anywhere a ref string is expected:
 new_ref = doc.replace("30 days", "60 days", paragraph="P2#f3c1")
 doc.replace("net", "gross", paragraph=new_ref)  # chain without list_paragraphs()
 
@@ -291,15 +291,15 @@ doc.delete("unnecessary clause", paragraph="P5#d4e5")
 doc.insert_after("Section 3.", " Additional terms apply.", paragraph="P3#b2c4")
 doc.insert_before("Section 3.", "See also: ", paragraph="P3#b2c4")
 
-# To accept/reject a specific edit, use list_revisions() to get the change ID:
-revisions = doc.list_revisions()
-doc.accept_revision(revisions[-1].id)
+# To accept/reject a specific edit as a unit, use its revision group:
+result = doc.replace("30 days", "60 days", paragraph="P2#f3c1")
+doc.reject_group(result.group_id)   # undo the whole edit (del + ins together)
 
 doc.save("edited.docx")
 doc.close()
 ```
 
-**Return values:** All edit methods return the new paragraph reference as a plain `str` (e.g., `"P2#c3d4"`). Use this for follow-up edits on the same paragraph without calling `list_paragraphs()` again. To get change IDs for accept/reject, use `doc.list_revisions()`.
+**Return values:** All edit methods return an `EditResult` — a `str` subclass whose value is the new paragraph reference (e.g., `"P2#c3d4"`); use it for follow-up edits on the same paragraph without calling `list_paragraphs()` again. It also carries `group_id` (the revision group holding every revision the edit created — pass to `accept_group()`/`reject_group()`) and `revision_ids` (the members' change ids). `group_id` is `None` when the edit created no new revisions (e.g. text spliced into one of your own pending insertions).
 
 **Multi-author documents:** Editing inside *another* author's pending insertion preserves their proposal, matching Word: deletions nest a `<w:del>` under your authorship inside their `<w:ins>`, and replacements/insertions put your text in your own sibling `<w:ins>` (splitting theirs when needed) instead of silently rewriting it. `accept_all(author=...)` / `reject_all(author=...)` then resolve each author's changes independently. Only your own pending insertions are edited in place.
 
@@ -367,6 +367,8 @@ for r in revisions:
     print(f"  at {r.paragraph_ref} occurrence={r.occurrence}")
     # Nesting: e.g. a foreign deletion inside another author's insertion
     print(f"  nested_under={r.nested_under} contains_ids={r.contains_ids}")
+    # Group: revisions created by the same edit in this session share it
+    print(f"  group_id={r.group_id}")
 
 # Filter by author
 their_changes = doc.list_revisions(author="OtherUser")
@@ -385,6 +387,20 @@ doc.add_comment(r.text, "please confirm", paragraph=r.paragraph_ref, occurrence=
 # Use IDs from list_revisions() — don't guess numbering.
 doc.accept_revision(revisions[0].id)
 doc.reject_revision(their_changes[0].id)
+
+# Accept or reject one edit's revisions as a unit (returns count processed).
+# Every edit method returns an EditResult carrying group_id; ALWAYS prefer
+# groups over per-id calls for rewrite_paragraph — one rewrite creates many
+# revisions (one per diff hunk), and accepting only some of them by id
+# garbles the paragraph. Raises RevisionError for an unknown group id.
+result = doc.rewrite_paragraph("P3#a7b2", "Entirely new paragraph text.")
+doc.reject_group(result.group_id)   # undo the whole rewrite, or:
+# doc.accept_group(result.group_id) # apply it in full
+
+# Groups are in-memory and per-open-Document: after close()/reopen,
+# revisions report group_id=None and old group ids raise RevisionError.
+# save() keeps groups alive (the Document stays open). Foreign/pre-session
+# revisions never have a group — resolve those by id or author.
 
 # Accept or reject all revisions (returns count of revisions processed)
 doc.accept_all()
@@ -468,7 +484,9 @@ doc.close()
 
 To act on a subset, target revisions by ID: `list_revisions()` (optionally
 `author=`- or `paragraph=`-filtered), pick by `.text`/`.type`/`.paragraph_ref`,
-then `accept_revision(id)` / `reject_revision(id)`.
+then `accept_revision(id)` / `reject_revision(id)`. For edits made in the
+current session, prefer `accept_group()`/`reject_group()` with the
+`EditResult.group_id` — it resolves everything one edit created, in one call.
 
 ## Redlining Workflow (Document Review)
 

--- a/tests/test_revision_groups.py
+++ b/tests/test_revision_groups.py
@@ -1,0 +1,452 @@
+"""Tests for revision grouping (ISSUES.md #37).
+
+Every logical edit operation registers the revisions it creates as one
+in-memory revision group, exposed via EditResult (a str subclass carrying
+``group_id``/``revision_ids``) and resolvable as a unit with
+``accept_group``/``reject_group``. The headline failure this prevents:
+accepting only some of a ``rewrite_paragraph``'s revisions garbles the
+paragraph, because each revision is a diff hunk, not a self-contained edit.
+
+Groups are per-open-Document: foreign or pre-session revisions report
+``group_id=None`` and unknown group ids raise RevisionError.
+"""
+
+import shutil
+from pathlib import Path
+
+import pytest
+from conftest import find_ref
+
+from docx_editor import Document, EditOperation, EditResult, RevisionError
+from docx_editor.exceptions import BatchOperationError, DocxEditError
+from docx_editor.track_changes import RevisionManager
+from docx_editor.xml_editor import DocxXMLEditor
+
+NS = 'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"'
+
+AUTHOR_A = "Reviewer A"
+AUTHOR_B = "Reviewer B"
+DATE_A = "2024-01-01T00:00:00Z"
+
+
+@pytest.fixture
+def doc(temp_docx):
+    """An open Document over the simple.docx copy, closed after the test."""
+    document = Document.open(temp_docx)
+    yield document
+    document.close()
+
+
+@pytest.fixture
+def temp_xml(tmp_path):
+    """Return a factory writing a minimal document.xml with the given body."""
+
+    def _create_xml(body_xml: str) -> Path:
+        xml = f'<?xml version="1.0" encoding="utf-8"?><w:document {NS}><w:body>{body_xml}</w:body></w:document>'
+        xml_path = tmp_path / "test_doc.xml"
+        xml_path.write_text(xml)
+        return xml_path
+
+    return _create_xml
+
+
+def _make_manager(xml_path: Path, author: str = AUTHOR_B) -> RevisionManager:
+    """Create a RevisionManager editing as ``author``."""
+    editor = DocxXMLEditor(xml_path, rsid="00000000", author=author)
+    return RevisionManager(editor)
+
+
+def _paragraph_text(doc: Document, index: int) -> str:
+    """Visible (accepted-view) text of the index-th paragraph line."""
+    return doc.get_visible_text().splitlines()[index]
+
+
+class TestEditResult:
+    """EditResult is a drop-in ref string with group metadata attached."""
+
+    def test_replace_returns_editresult_with_one_group(self, doc):
+        ref = find_ref(doc, "quick brown fox")
+        result = doc.replace("quick", "speedy", paragraph=ref)
+
+        assert isinstance(result, EditResult)
+        assert isinstance(result, str)
+        assert result.group_id is not None
+        # A replace is one deletion + one insertion, grouped together.
+        assert len(result.revision_ids) == 2
+        by_id = {r.id: r for r in doc.list_revisions()}
+        types = sorted(by_id[rid].type for rid in result.revision_ids)
+        assert types == ["deletion", "insertion"]
+
+    def test_result_string_is_usable_as_paragraph_ref(self, doc):
+        ref = find_ref(doc, "quick brown fox")
+        result = doc.replace("quick", "speedy", paragraph=ref)
+
+        # Follow-up edit takes the EditResult where a ref string is expected.
+        result2 = doc.replace("lazy", "sleepy", paragraph=result)
+        assert isinstance(result2, EditResult)
+        assert result2.group_id != result.group_id
+
+    def test_single_revision_ops_get_one_member_group(self, doc):
+        ref = find_ref(doc, "quick brown fox")
+
+        inserted = doc.insert_after("fox", " swiftly", paragraph=ref)
+        assert inserted.group_id is not None
+        assert len(inserted.revision_ids) == 1
+
+        deleted = doc.delete("lazy ", paragraph=inserted)
+        assert deleted.group_id is not None
+        assert deleted.group_id != inserted.group_id
+        assert len(deleted.revision_ids) == 1
+
+    def test_insert_before_gets_group(self, doc):
+        ref = find_ref(doc, "quick brown fox")
+        result = doc.insert_before("The", "Note: ", paragraph=ref)
+        assert result.group_id is not None
+        assert len(result.revision_ids) == 1
+
+
+class TestGroupIdOnRevisions:
+    """list_revisions stamps group_id on session-created revisions."""
+
+    def test_revisions_carry_group_id(self, doc):
+        ref = find_ref(doc, "quick brown fox")
+        result = doc.replace("quick", "speedy", paragraph=ref)
+
+        for rev in doc.list_revisions():
+            assert rev.group_id == result.group_id
+            assert "group=" in repr(rev)
+
+    def test_foreign_revisions_have_no_group(self, test_data_dir, temp_dir):
+        fixture = test_data_dir / "OXML_TrackChanges_Test.docx"
+        dest = temp_dir / "foreign.docx"
+        shutil.copy(fixture, dest)
+        with Document.open(dest) as doc:
+            revisions = doc.list_revisions()
+            assert revisions
+            assert all(rev.group_id is None for rev in revisions)
+            assert all("group=" not in repr(rev) for rev in revisions)
+
+
+class TestAcceptRejectGroup:
+    def test_reject_group_restores_original_text(self, doc):
+        ref = find_ref(doc, "quick brown fox")
+        original = _paragraph_text(doc, 1)
+        result = doc.replace("quick", "speedy", paragraph=ref)
+
+        count = doc.reject_group(result.group_id)
+
+        assert count == 2
+        assert _paragraph_text(doc, 1) == original
+        assert doc.list_revisions() == []
+
+    def test_accept_group_applies_the_edit(self, doc):
+        ref = find_ref(doc, "quick brown fox")
+        result = doc.replace("quick", "speedy", paragraph=ref)
+
+        count = doc.accept_group(result.group_id)
+
+        assert count == 2
+        assert "speedy brown fox" in _paragraph_text(doc, 1)
+        assert doc.list_revisions() == []
+
+    def test_unknown_group_raises_revision_error(self, doc):
+        with pytest.raises(RevisionError, match="Unknown revision group: 999"):
+            doc.accept_group(999)
+        with pytest.raises(RevisionError, match="Unknown revision group: 999"):
+            doc.reject_group(999)
+
+    def test_per_id_interplay_processes_remaining_members(self, doc):
+        ref = find_ref(doc, "quick brown fox")
+        result = doc.replace("quick", "speedy", paragraph=ref)
+
+        # Resolve one member individually first.
+        assert doc.accept_revision(result.revision_ids[0])
+
+        count = doc.accept_group(result.group_id)
+
+        assert count == len(result.revision_ids) - 1
+        assert doc.list_revisions() == []
+        assert "speedy brown fox" in _paragraph_text(doc, 1)
+        # A fully resolved group stays known; a further call processes nothing.
+        assert doc.accept_group(result.group_id) == 0
+
+
+class TestRewriteGrouping:
+    """The headline case: a rewrite's many revisions resolve as one unit."""
+
+    NEW_TEXT = "A slow red cat crawls beneath the energetic dog."
+
+    def test_rewrite_revisions_share_one_group(self, doc):
+        ref = find_ref(doc, "quick brown fox")
+        result = doc.rewrite_paragraph(ref, self.NEW_TEXT)
+
+        assert result.group_id is not None
+        revisions = doc.list_revisions()
+        assert len(revisions) == len(result.revision_ids) > 2
+        assert {rev.group_id for rev in revisions} == {result.group_id}
+
+    def test_reject_group_undoes_whole_rewrite(self, doc):
+        ref = find_ref(doc, "quick brown fox")
+        original = _paragraph_text(doc, 1)
+        result = doc.rewrite_paragraph(ref, self.NEW_TEXT)
+
+        doc.reject_group(result.group_id)
+
+        assert _paragraph_text(doc, 1) == original
+        assert doc.list_revisions() == []
+
+    def test_accept_group_yields_new_text(self, doc):
+        ref = find_ref(doc, "quick brown fox")
+        result = doc.rewrite_paragraph(ref, self.NEW_TEXT)
+
+        doc.accept_group(result.group_id)
+
+        assert _paragraph_text(doc, 1) == self.NEW_TEXT
+        assert doc.list_revisions() == []
+
+    def test_noop_rewrite_creates_no_group(self, doc):
+        ref = find_ref(doc, "quick brown fox")
+        current = _paragraph_text(doc, 1)
+        result = doc.rewrite_paragraph(ref, current)
+
+        assert result.group_id is None
+        assert result.revision_ids == ()
+        assert result == ref  # unchanged paragraph keeps its hash
+
+
+class TestBatchGrouping:
+    def test_batch_edit_one_group_per_operation(self, doc):
+        ref1 = find_ref(doc, "quick brown fox")
+        ref2 = find_ref(doc, "sample document for testing")
+
+        results = doc.batch_edit([
+            EditOperation.replace("quick", "speedy", paragraph=ref1),
+            EditOperation.delete("sample ", paragraph=ref2),
+        ])
+
+        assert all(isinstance(r, EditResult) for r in results)
+        gids = [r.group_id for r in results]
+        assert None not in gids
+        assert gids[0] != gids[1]
+        assert len(results[0].revision_ids) == 2  # replace: del + ins
+        assert len(results[1].revision_ids) == 1  # delete: one del
+
+        # Accept one op, reject the other — the point of per-op groups.
+        doc.accept_group(gids[0])
+        doc.reject_group(gids[1])
+        assert "speedy brown fox" in _paragraph_text(doc, 1)
+        assert "sample document for testing" in doc.get_visible_text()
+        assert doc.list_revisions() == []
+
+    def test_batch_rewrite_one_group_per_rewrite(self, doc):
+        ref1 = find_ref(doc, "quick brown fox")
+        ref2 = find_ref(doc, "sample document for testing")
+
+        results = doc.batch_rewrite([
+            (ref1, "A slow red cat sits."),
+            (ref2, "This paragraph was fully rewritten for the test."),
+        ])
+
+        assert all(isinstance(r, EditResult) for r in results)
+        assert results[0].group_id != results[1].group_id
+        by_group = {rev.id: rev.group_id for rev in doc.list_revisions()}
+        for result in results:
+            for rid in result.revision_ids:
+                assert by_group[rid] == result.group_id
+
+    def test_batch_edit_rollback_restores_registry(self, doc):
+        ref1 = find_ref(doc, "quick brown fox")
+        manager = doc._revision_manager
+        counter_before = manager._group_counter
+        groups_before = dict(manager._groups)
+
+        with pytest.raises(BatchOperationError):
+            doc.batch_edit([
+                EditOperation.replace("quick", "speedy", paragraph=ref1),
+                EditOperation.delete("no such text anywhere", paragraph=ref1),
+            ])
+
+        # No ghost groups pointing at rolled-back revisions.
+        assert manager._group_counter == counter_before
+        assert manager._groups == groups_before
+        assert manager._revision_groups == {}
+        assert doc.list_revisions() == []
+
+    def test_batch_rewrite_rollback_restores_registry(self, doc, monkeypatch):
+        # Both rewrites pass upfront hash validation; the failure must happen
+        # at apply time, after the first rewrite has registered its group.
+        # Applies run in reverse paragraph order, so the failing rewrite goes
+        # on the lower-index paragraph (P2) and the succeeding one on P3.
+        ref1 = find_ref(doc, "quick brown fox")
+        ref2 = find_ref(doc, "sample document for testing")
+        manager = doc._revision_manager
+        counter_before = manager._group_counter
+
+        real_rewrite = RevisionManager.rewrite_paragraph
+
+        def flaky(self, ref_str, new_text):
+            if new_text == "BOOM":
+                raise DocxEditError("simulated apply failure")
+            return real_rewrite(self, ref_str, new_text)
+
+        monkeypatch.setattr(RevisionManager, "rewrite_paragraph", flaky)
+
+        with pytest.raises(BatchOperationError) as exc:
+            doc.batch_rewrite([
+                (ref1, "BOOM"),
+                (ref2, "Rewritten paragraph three."),
+            ])
+        assert exc.value.operation_index == 0
+
+        assert manager._group_counter == counter_before
+        assert manager._groups == {}
+        assert manager._revision_groups == {}
+        assert doc.list_revisions() == []
+
+
+class TestGroupSessionScope:
+    def test_groups_do_not_survive_reopen(self, temp_docx):
+        with Document.open(temp_docx) as doc:
+            ref = find_ref(doc, "quick brown fox")
+            result = doc.replace("quick", "speedy", paragraph=ref)
+            group_id = result.group_id
+            assert group_id is not None
+            doc.save()
+
+        with Document.open(temp_docx) as doc:
+            revisions = doc.list_revisions()
+            assert revisions  # the tracked change persisted in the file
+            assert all(rev.group_id is None for rev in revisions)
+            with pytest.raises(RevisionError):
+                doc.accept_group(group_id)
+
+    def test_save_keeps_groups_alive(self, doc):
+        ref = find_ref(doc, "quick brown fox")
+        result = doc.replace("quick", "speedy", paragraph=ref)
+
+        doc.save()
+
+        assert doc.reject_group(result.group_id) == 2
+
+
+class TestForeignInsGrouping:
+    """Author/attachment filters keep foreign fragments out of our groups."""
+
+    def test_replace_inside_foreign_ins_excludes_split_halves(self, temp_xml):
+        # B replaces the middle of A's pending insertion: A's w:ins splits
+        # into identity-preserving halves (fresh ids, A's author) around
+        # B's nested w:del + sibling w:ins. Only B's elements join the group.
+        body = (
+            f'<w:p><w:ins w:id="1" w:author="{AUTHOR_A}" w:date="{DATE_A}">'
+            "<w:r><w:t>alpha beta gamma</w:t></w:r></w:ins></w:p>"
+        )
+        manager = _make_manager(temp_xml(body), author=AUTHOR_B)
+
+        change_id = manager.replace_text("beta", "delta")
+
+        group_id = manager.group_id_of(change_id)
+        assert group_id is not None
+        members = manager.group_revisions(group_id)
+
+        revisions = {rev.id: rev for rev in manager.list_revisions()}
+        member_authors = {revisions[rid].author for rid in members}
+        assert member_authors == {AUTHOR_B}
+        # A's original + split-off insertions stay out of the group.
+        foreign_ids = {rid for rid, rev in revisions.items() if rev.author == AUTHOR_A}
+        assert foreign_ids and not (foreign_ids & set(members))
+        # B's nested deletion of A's text is part of B's group.
+        member_types = {revisions[rid].type for rid in members}
+        assert member_types == {"deletion", "insertion"}
+
+    def test_delete_inside_foreign_ins_groups_nested_del(self, temp_xml):
+        body = (
+            f'<w:p><w:ins w:id="1" w:author="{AUTHOR_A}" w:date="{DATE_A}">'
+            "<w:r><w:t>alpha beta gamma</w:t></w:r></w:ins></w:p>"
+        )
+        manager = _make_manager(temp_xml(body), author=AUTHOR_B)
+
+        change_id = manager.suggest_deletion("beta ")
+
+        group_id = manager.group_id_of(change_id)
+        assert group_id is not None
+        members = manager.group_revisions(group_id)
+        revisions = {rev.id: rev for rev in manager.list_revisions()}
+        assert [revisions[rid].author for rid in members] == [AUTHOR_B]
+        assert [revisions[rid].type for rid in members] == ["deletion"]
+        # The nested del sits inside A's insertion.
+        assert revisions[members[0]].nested_under == 1
+
+
+class TestOwnInsertionSplits:
+    """Physical edits inside our own pending insertions keep groups truthful."""
+
+    def test_replace_consuming_whole_own_insertion_reports_new_group(self, doc):
+        ref = find_ref(doc, "quick brown fox")
+        first = doc.insert_after("fox", " ZE9", paragraph=ref)
+
+        result = doc.replace(" ZE9", " QX7", paragraph=first)
+
+        # The old insertion is fully consumed and the replacement re-wrapped
+        # in a fresh <w:ins> — a revision this operation created, so its
+        # group must be reachable from the result (not a phantom group).
+        assert result.group_id is not None
+        assert result.group_id != first.group_id
+        revisions = doc.list_revisions()
+        assert len(revisions) == 1
+        assert revisions[0].group_id == result.group_id
+        assert revisions[0].id in result.revision_ids
+
+    def test_middle_delete_adopts_split_tail_into_origin_group(self, doc):
+        ref = find_ref(doc, "quick brown fox")
+        original = _paragraph_text(doc, 1)
+        first = doc.insert_after("fox", " AAA MID BBB", paragraph=ref)
+
+        result = doc.delete("MID ", paragraph=first)
+
+        # The delete physically removed pending text — no new revisions of
+        # its own; the split-off "BBB" tail stays with the insert's group.
+        assert result.group_id is None
+        revisions = doc.list_revisions()
+        assert len(revisions) == 2
+        assert {rev.group_id for rev in revisions} == {first.group_id}
+        members = doc._revision_manager.group_revisions(first.group_id)
+        assert len(members) == 2
+
+        # Rejecting the original insertion's group removes BOTH halves.
+        doc.reject_group(first.group_id)
+        assert _paragraph_text(doc, 1) == original
+        assert doc.list_revisions() == []
+
+
+class TestMonotonicChangeIds:
+    def test_removed_max_id_is_not_reused(self, temp_xml):
+        body = "<w:p><w:r><w:t>one two three</w:t></w:r></w:p>"
+        manager = _make_manager(temp_xml(body))
+
+        first = manager.replace_text("two", "TWO")
+        first_gid = manager.group_id_of(first)
+        assert first_gid is not None
+        first_ids = manager.group_revisions(first_gid)
+
+        # Reject everything: the max-id elements leave the DOM entirely.
+        manager.reject_group(first_gid)
+        assert manager.list_revisions() == []
+
+        second = manager.replace_text("three", "THREE")
+        second_gid = manager.group_id_of(second)
+        assert second_gid is not None
+        second_ids = manager.group_revisions(second_gid)
+
+        # Without the monotonic floor these ids would be reissued and the
+        # registry would point two groups at the same w:id values.
+        assert not (set(first_ids) & set(second_ids))
+        assert min(second_ids) > max(first_ids)
+
+    def test_nested_grouped_raises(self, temp_xml):
+        body = "<w:p><w:r><w:t>one two three</w:t></w:r></w:p>"
+        manager = _make_manager(temp_xml(body))
+
+        with pytest.raises(RuntimeError, match="does not nest"):
+            with manager._grouped():
+                with manager._grouped():
+                    pass  # pragma: no cover

--- a/tests/test_revision_groups.py
+++ b/tests/test_revision_groups.py
@@ -358,6 +358,38 @@ class TestForeignInsGrouping:
         member_types = {revisions[rid].type for rid in members}
         assert member_types == {"deletion", "insertion"}
 
+    def test_split_foreign_ins_does_not_claim_presession_nested_del(self, temp_xml):
+        # A's pending insertion contains B's PRE-SESSION deletion (no group —
+        # e.g. made before a save/reopen). B then inserts inside A's
+        # insertion before the deletion: the split re-serializes A's
+        # trailing content INCLUDING B's old <w:del>, running it back
+        # through attribute injection. That pre-existing deletion must not
+        # join B's insert group — rejecting the insert would silently
+        # resurrect "beta ".
+        body = (
+            f'<w:p><w:ins w:id="1" w:author="{AUTHOR_A}" w:date="{DATE_A}">'
+            "<w:r><w:t>alpha </w:t></w:r>"
+            f'<w:del w:id="2" w:author="{AUTHOR_B}" w:date="{DATE_A}">'
+            "<w:r><w:delText>beta </w:delText></w:r></w:del>"
+            "<w:r><w:t>gamma</w:t></w:r></w:ins></w:p>"
+        )
+        manager = _make_manager(temp_xml(body), author=AUTHOR_B)
+
+        change_id = manager.insert_text_after("alpha", "NEW ")
+
+        group_id = manager.group_id_of(change_id)
+        assert group_id is not None
+        members = manager.group_revisions(group_id)
+        assert members == (change_id,)  # only the new insertion, not del#2
+
+        revisions = {rev.id: rev for rev in manager.list_revisions()}
+        assert revisions[2].group_id is None  # pre-session del stays ungrouped
+
+        # Undoing the insert must leave the pre-existing deletion untouched.
+        manager.reject_group(group_id)
+        remaining = {rev.id for rev in manager.list_revisions()}
+        assert 2 in remaining
+
     def test_delete_inside_foreign_ins_groups_nested_del(self, temp_xml):
         body = (
             f'<w:p><w:ins w:id="1" w:author="{AUTHOR_A}" w:date="{DATE_A}">'

--- a/tests/test_revision_groups.py
+++ b/tests/test_revision_groups.py
@@ -417,6 +417,53 @@ class TestOwnInsertionSplits:
         assert _paragraph_text(doc, 1) == original
         assert doc.list_revisions() == []
 
+    def test_presession_middle_delete_leaves_tail_ungrouped(self, temp_docx):
+        # The origin insertion predates this session (reopen dropped its
+        # group), so its split-off tail has no group to join — and must not
+        # be claimed into a phantom group by the delete operation.
+        with Document.open(temp_docx) as doc:
+            ref = find_ref(doc, "quick brown fox")
+            doc.insert_after("fox", " AAA MID BBB", paragraph=ref)
+            doc.save()
+
+        with Document.open(temp_docx) as doc:
+            ref = find_ref(doc, "quick brown fox")
+            result = doc.delete("MID ", paragraph=ref)
+
+            assert result.group_id is None
+            assert doc._revision_manager._groups == {}
+            revisions = doc.list_revisions()
+            assert len(revisions) == 2  # truncated head + split-off tail
+            assert all(rev.group_id is None for rev in revisions)
+
+    def test_presession_rewrite_does_not_claim_split_tail(self, temp_docx):
+        # Same defect through the public rewrite path: without tail
+        # registration, the rewrite's EditResult.group_id would hold ONLY
+        # the pre-session insertion's tail, and reject_group (the documented
+        # undo idiom) would rip out pre-existing text instead of undoing
+        # the rewrite.
+        with Document.open(temp_docx) as doc:
+            ref = find_ref(doc, "quick brown fox")
+            doc.insert_after("fox", " alpha beta gamma", paragraph=ref)
+            doc.save()
+
+        with Document.open(temp_docx) as doc:
+            ref = find_ref(doc, "quick brown fox")
+            current = _paragraph_text(doc, 1)
+            result = doc.rewrite_paragraph(ref, current.replace("beta", "BETA"))
+
+            # The only physical change happens inside our own pre-session
+            # insertion — no trackable revisions, so no group at all.
+            assert result.group_id is None
+            assert doc._revision_manager._groups == {}
+            assert all(rev.group_id is None for rev in doc.list_revisions())
+            # Placement-agnostic content check: replacement position inside
+            # an own insertion is the pre-existing ISSUES.md #31 ordering
+            # bug, out of scope here.
+            text = _paragraph_text(doc, 1)
+            assert "BETA" in text and "beta" not in text
+            assert "alpha" in text and "gamma" in text
+
 
 class TestMonotonicChangeIds:
     def test_removed_max_id_is_not_reused(self, temp_xml):


### PR DESCRIPTION
## Summary

Implements revision grouping (ISSUES.md item #37 — not a GitHub issue): every logical edit operation registers the revisions it creates as one **revision group**, so a multi-revision edit — especially `rewrite_paragraph`, where each revision is a diff hunk — can be accepted or rejected as a unit instead of hunk-by-hunk, which garbles the paragraph when only partially applied.

## API

- **`EditResult`** (new, exported): return type of `replace` / `delete` / `insert_after` / `insert_before` / `rewrite_paragraph` and the element type of `batch_edit` / `batch_rewrite` results. A `str` subclass whose value is the new paragraph ref, so it is drop-in compatible everywhere a ref string is expected; carries `group_id` and `revision_ids`.
- **`Document.accept_group(group_id)` / `Document.reject_group(group_id)`**: resolve every revision of one edit as a unit (reverse-id, loop-until-no-progress — same pattern as `accept_all`). Members already resolved individually are skipped.
- **`Revision.group_id`**: stamped on session-created revisions by `list_revisions()`; `None` for foreign/pre-session revisions.
- Groups are **in-memory, per-open-Document**: `save()` keeps them; `close()`/reopen drops them (unknown ids raise `RevisionError`). Nothing is written into the `.docx`.

## Implementation

- `RevisionManager._grouped()` context manager captures the `<w:ins>`/`<w:del>` elements processed by attribute injection (via a new single-slot `DocxXMLEditor.collect_tracked_changes()` collector), then filters to elements that are ours, still DOM-attached, and not already registered — foreign split halves and adopted tails stay out.
- Change-id allocation gains a monotonic floor (`_max_change_id`) so ids of removed revisions are never reissued into id-keyed bookkeeping.
- Both batch paths snapshot/restore the group registry alongside the existing DOM snapshot for atomic rollback.
- Own-insertion edge paths keep groups truthful: a replace consuming an entire own pending insertion returns the id of the re-wrapped `<w:ins>` (its group is reachable from the result), and a split-off tail of an own insertion is adopted into its **origin** insertion's group (`_adopt_split_tail`), so rejecting the original edit removes both halves.

## Testing

- 26 new tests in `tests/test_revision_groups.py`: EditResult contract, group stamping, accept/reject as unit, per-id interplay, rewrite grouping (headline case), per-op batch groups, batch rollback registry restore, session scoping across save/reopen, foreign-insertion split-half exclusion, monotonic id floor, own-insertion split adoption.
- Full suite: **1056 passed, 2 skipped**; `ruff check` / `ruff format --check` clean; `ty check` exit 0 (6 pre-existing warnings in untouched test files).
- Docs updated: `docs/api.md` (EditResult, accept_group/reject_group sections) and `skills/docx/SKILL.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tracked-edit methods now return `EditResult` (a paragraph-ref string subclass) that includes revision group details.
  * Added `accept_group(group_id)` and `reject_group(group_id)` to apply or undo all revisions from one logical edit atomically.
  * Batch edits and paragraph rewrites now return an `EditResult` per operation/rewrite.
  * `EditResult` is re-exported from the top-level `docx_editor` package.

* **Documentation**
  * Updated API docs and examples to cover `EditResult`, `group_id`/`revision_ids`, and group lifecycle/behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->