### PR TITLE
fix: open-path robustness — reject directories and missing word/document.xml, self-heal orphan workspaces (ISSUES.md #41)

### DIFF
--- a/docx_editor/document.py
+++ b/docx_editor/document.py
@@ -138,6 +138,10 @@ class Document:
             Document instance ready for editing
 
         Raises:
+            DocumentNotFoundError: If the path does not exist.
+            InvalidDocumentError: If the path is not a valid .docx document:
+                wrong suffix, a directory, not a zip archive, malformed XML in
+                a part, or the required word/document.xml part is missing.
             WorkspaceError: If the workspace cannot be created (unwritable base,
                 undeterminable home directory) or an existing workspace was
                 unpacked from a different document.

--- a/docx_editor/ooxml/unpack.py
+++ b/docx_editor/ooxml/unpack.py
@@ -90,7 +90,7 @@ def unpack_document(input_file: str | Path, output_dir: str | Path) -> str:
         # rejection leaves the filesystem untouched.
         try:
             with zipfile.ZipFile(input_path) as zf:
-                names = set()
+                names: set[str] = set()
                 for info in zf.infolist():
                     if _is_unsafe_zip_path(info.filename):
                         raise InvalidDocumentError(f"Unsafe ZIP entry path: {info.filename!r} in {input_file}")
@@ -101,7 +101,7 @@ def unpack_document(input_file: str | Path, output_dir: str | Path) -> str:
                 # without it, opening would fail later with a raw
                 # FileNotFoundError naming the internal cache path.
                 if "word/document.xml" not in names:
-                    raise InvalidDocumentError(f"{input_file} is not a valid .docx: missing word/document.xml")
+                    raise InvalidDocumentError(f"Not a valid .docx: missing word/document.xml in {input_file}")
                 try:
                     output_path.mkdir(parents=True)
                     created_output_dir = True

--- a/docx_editor/ooxml/unpack.py
+++ b/docx_editor/ooxml/unpack.py
@@ -53,17 +53,22 @@ def unpack_document(input_file: str | Path, output_dir: str | Path) -> str:
 
     Raises:
         DocumentNotFoundError: If the input file doesn't exist
-        InvalidDocumentError: If the file is not a valid zip/docx, contains an
-            unsafe entry path or a symlink entry, a part contains malformed XML
-            or XML constructs refused for security (DTD entity/external
-            declarations), or the output directory is (or contains) a symlink
-            or is an existing non-directory.
+        InvalidDocumentError: If the input path is a directory, the file is not
+            a valid zip/docx, contains an unsafe entry path or a symlink entry,
+            is missing the required word/document.xml part (rejected before
+            extraction), a part contains malformed XML or XML constructs
+            refused for security (DTD entity/external declarations), or the
+            output directory is (or contains) a symlink or is an existing
+            non-directory.
     """
     input_path = Path(input_file)
     output_path = Path(output_dir)
 
     if not input_path.exists():
         raise DocumentNotFoundError(f"Document not found: {input_file}")
+
+    if input_path.is_dir():
+        raise InvalidDocumentError(f"Is a directory, not a .docx file: {input_file}")
 
     # Reject a symlinked destination so extractall cannot write through it.
     if output_path.is_symlink():
@@ -85,11 +90,18 @@ def unpack_document(input_file: str | Path, output_dir: str | Path) -> str:
         # rejection leaves the filesystem untouched.
         try:
             with zipfile.ZipFile(input_path) as zf:
+                names = set()
                 for info in zf.infolist():
                     if _is_unsafe_zip_path(info.filename):
                         raise InvalidDocumentError(f"Unsafe ZIP entry path: {info.filename!r} in {input_file}")
                     if _is_symlink_entry(info):
                         raise InvalidDocumentError(f"Symlink ZIP entry: {info.filename!r} in {input_file}")
+                    names.add(info.filename)
+                # The one part every consumer unconditionally dereferences;
+                # without it, opening would fail later with a raw
+                # FileNotFoundError naming the internal cache path.
+                if "word/document.xml" not in names:
+                    raise InvalidDocumentError(f"{input_file} is not a valid .docx: missing word/document.xml")
                 try:
                     output_path.mkdir(parents=True)
                     created_output_dir = True

--- a/docx_editor/workspace.py
+++ b/docx_editor/workspace.py
@@ -340,9 +340,10 @@ class Workspace:
                         # Clean and in-sync but missing the core part: an
                         # orphan left by a pre-0.6.1 failed open (ISSUES.md
                         # #41) or a manually mangled workspace. The checks
-                        # above proved the content is exactly what the current
-                        # source unpacks to, so discarding and re-unpacking
-                        # loses nothing. A valid source heals; an invalid one
+                        # above proved the source still matches the recorded
+                        # fingerprint and no edits were flagged, so this cache
+                        # can be discarded and rebuilt without losing anything
+                        # the system tracks. A valid source heals; an invalid one
                         # raises InvalidDocumentError from unpack_document
                         # (single message site).
                         shutil.rmtree(self.workspace_path)

--- a/docx_editor/workspace.py
+++ b/docx_editor/workspace.py
@@ -242,7 +242,10 @@ class Workspace:
 
         Raises:
             DocumentNotFoundError: If the source document doesn't exist
-            InvalidDocumentError: If the file is not a .docx file
+            InvalidDocumentError: If the path is not a valid .docx document:
+                wrong suffix, a directory, not a zip archive, a part contains
+                malformed XML, or the required word/document.xml part is
+                missing
             WorkspaceLockedError: If a live session already holds this
                 document's workspace (see _acquire_lock). Checked first: a
                 live holder masks the sync/exists errors below until it
@@ -331,7 +334,19 @@ class Workspace:
                                 f"Document has changed since workspace was created. "
                                 f"Delete {self.workspace_path} or use force_recreate=True"
                             )
-                        # Workspace is valid, just load it
+                        if self.document_xml_path.exists():
+                            # Workspace is valid, just load it
+                            return
+                        # Clean and in-sync but missing the core part: an
+                        # orphan left by a pre-0.6.1 failed open (ISSUES.md
+                        # #41) or a manually mangled workspace. The checks
+                        # above proved the content is exactly what the current
+                        # source unpacks to, so discarding and re-unpacking
+                        # loses nothing. A valid source heals; an invalid one
+                        # raises InvalidDocumentError from unpack_document
+                        # (single message site).
+                        shutil.rmtree(self.workspace_path)
+                        self._create_workspace()
                         return
                     else:
                         raise WorkspaceExistsError(f"Workspace already exists: {self.workspace_path}")

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -5,12 +5,13 @@ import re
 import zipfile
 
 import pytest
-from conftest import ENTITY_DTD_XML, NS, find_ref, replace_document_xml
+from conftest import ENTITY_DTD_XML, NS, find_ref, replace_document_xml, replace_docx_parts
 from defusedxml.common import EntitiesForbidden
 
 import docx_editor
 from docx_editor import Document, SearchResult
 from docx_editor.exceptions import (
+    DocumentNotFoundError,
     DocumentOpenError,
     DocxEditError,
     InvalidDocumentError,
@@ -107,6 +108,56 @@ class TestDocumentOpen:
             Document.open(bad_docx)
 
         assert isinstance(excinfo.value, InvalidDocumentError)
+
+    def test_open_zip_missing_document_xml_raises_invalid_document_error(
+        self, simple_docx, temp_dir, isolated_workspace_base
+    ):
+        """A valid zip missing word/document.xml surfaces as InvalidDocumentError (ISSUES.md #41).
+
+        Previously this escaped as a raw FileNotFoundError naming the internal
+        cache path and left an orphaned workspace behind.
+        """
+        junk = temp_dir / "junk.docx"
+        replace_docx_parts(simple_docx, junk, {"word/document.xml": None})
+
+        with pytest.raises(InvalidDocumentError, match=r"missing word/document\.xml") as excinfo:
+            Document.open(junk)
+
+        # The message names the document the user opened, never the cache path.
+        assert str(junk) in str(excinfo.value)
+        assert str(isolated_workspace_base) not in str(excinfo.value)
+        # No orphaned workspace dir and no .lock sidecar.
+        assert list(isolated_workspace_base.iterdir()) == []
+
+    def test_open_directory_raises_invalid_document_error(self, temp_dir):
+        """A directory named *.docx raises the typed error, not raw IsADirectoryError."""
+        dir_path = temp_dir / "iamadir.docx"
+        dir_path.mkdir()
+
+        with pytest.raises(InvalidDocumentError, match="Is a directory"):
+            Document.open(dir_path)
+
+    def test_open_nonexistent_path_raises_document_not_found(self, temp_dir):
+        """A nonexistent path raises DocumentNotFoundError at the Document.open level."""
+        with pytest.raises(DocumentNotFoundError, match="Document not found"):
+            Document.open(temp_dir / "nonexistent.docx")
+
+    def test_open_repeat_junk_file_deterministic(self, simple_docx, temp_dir, isolated_workspace_base):
+        """Repeat opens of the same junk file fail identically — no orphan adoption.
+
+        On ≤0.6.0 the first failed open orphaned a workspace that every later
+        open adopted, so the failure mode silently changed between attempts.
+        """
+        junk = temp_dir / "junk.docx"
+        replace_docx_parts(simple_docx, junk, {"word/document.xml": None})
+
+        with pytest.raises(InvalidDocumentError) as first:
+            Document.open(junk)
+        with pytest.raises(InvalidDocumentError) as second:
+            Document.open(junk)
+
+        assert str(first.value) == str(second.value)
+        assert list(isolated_workspace_base.iterdir()) == []
 
 
 class TestDocumentSave:

--- a/tests/test_ooxml.py
+++ b/tests/test_ooxml.py
@@ -246,6 +246,51 @@ class TestUnpackParseErrors:
         assert sentinel.read_text() == "user data"
 
 
+class TestUnpackMissingParts:
+    """Structurally deficient input must raise InvalidDocumentError before extraction (ISSUES.md #41)."""
+
+    def test_unpack_missing_document_xml_raises_invalid_document_error(self, temp_dir):
+        """A valid zip without word/document.xml is rejected pre-extraction."""
+        junk_zip = temp_dir / "junk.docx"
+        _build_zip(junk_zip, [("[Content_Types].xml", b"<Types/>")])
+        output = temp_dir / "output"
+
+        with pytest.raises(InvalidDocumentError, match=r"is not a valid \.docx: missing word/document\.xml") as excinfo:
+            unpack_document(junk_zip, output)
+
+        # Message names the document the caller opened, not a cache path.
+        assert str(junk_zip) in str(excinfo.value)
+        # Rejection happens before mkdir/extractall — filesystem untouched.
+        assert not output.exists()
+
+    def test_unpack_missing_part_preserves_preexisting_output_dir(self, temp_dir):
+        """Rejection must never delete a caller's pre-existing output directory."""
+        junk_zip = temp_dir / "junk.docx"
+        _build_zip(junk_zip, [("[Content_Types].xml", b"<Types/>")])
+        output = temp_dir / "output"
+        output.mkdir()
+        sentinel = output / "keep.txt"
+        sentinel.write_text("user data")
+
+        with pytest.raises(InvalidDocumentError, match=r"missing word/document\.xml"):
+            unpack_document(junk_zip, output)
+
+        assert output.exists()
+        assert sentinel.read_text() == "user data"
+
+    def test_unpack_directory_input_raises_invalid_document_error(self, temp_dir):
+        """A directory input raises the typed error, not raw IsADirectoryError."""
+        dir_input = temp_dir / "iamadir.docx"
+        dir_input.mkdir()
+
+        with pytest.raises(InvalidDocumentError, match="Is a directory") as excinfo:
+            unpack_document(dir_input, temp_dir / "output")
+
+        # Rejected by the explicit check, not by IsADirectoryError leaking
+        # out of zipfile and getting wrapped downstream.
+        assert excinfo.value.__cause__ is None
+
+
 SMART_TEXT = "“He said ‘hello’ — it’s fine”"
 
 

--- a/tests/test_ooxml.py
+++ b/tests/test_ooxml.py
@@ -255,7 +255,7 @@ class TestUnpackMissingParts:
         _build_zip(junk_zip, [("[Content_Types].xml", b"<Types/>")])
         output = temp_dir / "output"
 
-        with pytest.raises(InvalidDocumentError, match=r"is not a valid \.docx: missing word/document\.xml") as excinfo:
+        with pytest.raises(InvalidDocumentError, match=r"Not a valid \.docx: missing word/document\.xml") as excinfo:
             unpack_document(junk_zip, output)
 
         # Message names the document the caller opened, not a cache path.

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -11,7 +11,7 @@ import sys
 from pathlib import Path
 
 import pytest
-from conftest import ENTITY_DTD_XML, find_ref, replace_document_xml
+from conftest import ENTITY_DTD_XML, find_ref, replace_document_xml, replace_docx_parts
 
 from docx_editor.document import Document
 from docx_editor.exceptions import (
@@ -21,7 +21,7 @@ from docx_editor.exceptions import (
     WorkspaceLockedError,
     WorkspaceSyncError,
 )
-from docx_editor.workspace import Workspace, _default_cache_dir, _pid_alive
+from docx_editor.workspace import Workspace, _default_cache_dir, _file_sha256, _pid_alive
 
 
 class TestWorkspaceCreation:
@@ -115,6 +115,61 @@ class TestWorkspaceParseFailureCleanup:
         workspace = Workspace(doc_path)
         assert workspace.document_xml_path.exists()
         workspace.close()
+
+
+class TestWorkspaceMissingDocumentXml:
+    """A zip without word/document.xml raises a typed error and leaves no orphan (ISSUES.md #41)."""
+
+    def test_workspace_missing_document_xml_leaves_no_workspace(self, simple_docx, temp_dir, isolated_workspace_base):
+        """The failed open leaves neither a workspace dir nor a .lock sibling."""
+        junk = temp_dir / "junk.docx"
+        replace_docx_parts(simple_docx, junk, {"word/document.xml": None})
+
+        with pytest.raises(InvalidDocumentError, match=r"missing word/document\.xml"):
+            Workspace(junk)
+
+        assert list(isolated_workspace_base.iterdir()) == []
+
+    def test_adopted_workspace_missing_document_xml_self_heals(self, clean_workspace):
+        """A clean, in-sync workspace missing the core part is rebuilt from the source."""
+        workspace = Workspace(clean_workspace)
+        workspace_path = workspace.workspace_path
+        workspace.close(cleanup=False)
+        (workspace_path / "word" / "document.xml").unlink()
+
+        reopened = Workspace(clean_workspace)
+        assert reopened.document_xml_path.exists()
+        reopened.close()
+
+    def test_adopted_orphan_of_junk_source_raises_typed_error_and_cleans_up(
+        self, simple_docx, temp_dir, isolated_workspace_base
+    ):
+        """A pre-0.6.1 orphan of an invalid source raises the typed error and is removed.
+
+        On ≤0.6.0 a failed open of a document.xml-less zip left a fully
+        populated workspace behind, and every later open adopted it and raised
+        the same raw FileNotFoundError forever. Simulate that orphan and check
+        the recreate branch surfaces InvalidDocumentError instead — and
+        removes the orphan.
+        """
+        junk = temp_dir / "junk.docx"
+        replace_docx_parts(simple_docx, junk, {"word/document.xml": None})
+
+        orphan = Workspace._resolve_workspace_path(junk.resolve(), None)
+        orphan.mkdir(parents=True)
+        meta = {
+            "source_path": str(junk.resolve()),
+            "source_mtime": junk.stat().st_mtime,
+            "source_size": junk.stat().st_size,
+            "source_sha256": _file_sha256(junk),
+            "dirty": False,
+        }
+        (orphan / "meta.json").write_text(json.dumps(meta), encoding="utf-8")
+
+        with pytest.raises(InvalidDocumentError, match=r"missing word/document\.xml"):
+            Workspace(junk)
+
+        assert list(isolated_workspace_base.iterdir()) == []
 
 
 class TestWorkspacePersistence:


### PR DESCRIPTION
## Summary

Fixes ISSUES.md #41 (repo-local issue list, not a GitHub issue): `Document.open` failure modes on structurally invalid inputs.

- **Directory input rejected**: `unpack_document` raises typed `InvalidDocumentError` instead of leaking a raw `IsADirectoryError` from `zipfile`.
- **Missing `word/document.xml` rejected pre-extraction**: a zip without the required core part raises `InvalidDocumentError` before `mkdir`/`extractall`, so rejection leaves the filesystem untouched (extends the #35 invariant). Previously this escaped later as a raw `FileNotFoundError` naming the internal cache path and left an orphaned workspace behind.
- **Orphan workspace self-heal**: `Workspace.__init__`'s adopt branch now detects a clean, in-sync workspace missing the core part (debris from a pre-0.6.1 failed open) and rebuilds it from the source. A dirty workspace missing the part still raises `WorkspaceSyncError` first — rescue data is never discarded.
- Error messages name the caller-provided document path, never the internal cache path (asserted by a no-leak regression test).
- `[Content_Types].xml` deliberately not required (YAGNI; existing minimal-zip fixtures contain only `word/document.xml`).

## Tests

10 new tests across all three API levels:
- `TestUnpackMissingParts` (test_ooxml.py, 3): pre-extraction rejection leaves filesystem untouched; pre-existing output dir survives; directory input rejected with `__cause__ is None`.
- `TestWorkspaceMissingDocumentXml` (test_workspace.py, 3): failed open leaves no workspace dir and no `.lock`; clean adopted workspace self-heals; simulated pre-0.6.1 orphan of an invalid source raises typed error and is removed.
- `TestDocumentOpen` (test_document.py, 4): typed error with document path and no cache-path leak; directory rejection; `DocumentNotFoundError` regression guard; repeat opens fail deterministically (no orphan adoption).

## Verification

- `uv run pytest`: 1069 passed, 2 skipped
- `uv run ruff check .` / `ruff format --check .`: clean
- `uv run ty check`: exit 0 (6 pre-existing diagnostics in untouched test files)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for invalid or incomplete DOCX files.
  * Added clear errors when opening directories, nonexistent files, or documents missing required content.
  * Prevented partial workspace creation when document validation fails.
  * Automatically repairs eligible workspaces missing required document content.
* **Documentation**
  * Clarified documented errors and validation conditions for document opening and workspace creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->