### PR TITLE
feat: error contract completion — DocumentClosedError, error fields, find_text parity (ISSUES.md #42)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -197,16 +197,19 @@ Get flattened original (pre-revision) document text. Deleted text is included an
 text = doc.get_original_text()
 ```
 
-#### `find_text(text, occurrence=0)`
+#### `find_text(text, occurrence=0, paragraph=None)`
 
 Find text in the document, including text spanning XML element boundaries.
 
 **Parameters:**
 
-- `text` (str): Text to search for
-- `occurrence` (int): Which occurrence to return, counted document-wide, 0-based (0 = first). Defaults to 0.
+- `text` (str): Text to search for (must be non-empty)
+- `occurrence` (int): Which occurrence to return, 0-based (0 = first). Counted document-wide when `paragraph` is None, and within the paragraph when scoped. Defaults to 0.
+- `paragraph` (str, optional): Paragraph reference (e.g. `P2#f3c1`) to scope the search — the same scoping `find_all` offers. `None` searches the whole document. Defaults to None.
 
 **Returns:** [`SearchResult`](#searchresult), or None if not found
+
+**Raises:** `ValueError` if `text` is empty or `paragraph` is malformed; [`ParagraphIndexError`](#exceptions) / [`HashMismatchError`](#exceptions) for an out-of-range or stale `paragraph`.
 
 **Example:**
 
@@ -714,6 +717,8 @@ Close the document and clean up workspace. Releases the advisory workspace lock 
 
 > **Warning:** closing without saving discards unsaved edits. There is no dirty check: `close()` (the default `cleanup=True`, including normal context-manager exit) deletes the workspace and everything not yet written by `save()` is silently lost. `close(cleanup=False)` keeps the workspace on disk, but a later `Document.open()` of the same source raises `WorkspaceSyncError` if it holds unsaved changes, rather than silently carrying them over.
 
+Any operation on the document after `close()` raises [`DocumentClosedError`](#documentclosederror).
+
 **Parameters:**
 
 - `cleanup` (bool): If True, delete the workspace folder. Defaults to True.
@@ -943,9 +948,10 @@ from docx_editor import SearchResult
 
 `start`/`end` are offsets within the matched paragraph's visible text, **not**
 document-wide offsets. Coordinate systems differ between search and edit:
-`find_text`'s `occurrence` counts matches document-wide, while edit methods
-count within one paragraph — `paragraph_occurrence` bridges the two, so always
-pass it alongside `paragraph_ref` when chaining into an edit. `paragraph_ref`
+`find_text`'s `occurrence` counts matches document-wide (unless scoped with
+`paragraph=`), while edit methods count within one paragraph —
+`paragraph_occurrence` bridges the two, so always pass it alongside
+`paragraph_ref` when chaining into an edit. `paragraph_ref`
 is computed at search time and — like refs from `list_paragraphs()` — goes
 stale once that paragraph is edited.
 
@@ -1040,7 +1046,7 @@ while ops:
 
 ### `CommentError`
 
-Raised when a comment operation fails.
+Raised when a comment operation fails. Structured field: `comment_id` (the comment id the operation targeted, e.g. the parent id of a failed reply; `None` when no comment id applies).
 
 ```python
 from docx_editor.exceptions import CommentError
@@ -1048,15 +1054,37 @@ from docx_editor.exceptions import CommentError
 try:
     doc.reply_to_comment(999, "reply")
 except CommentError as e:
-    print(f"Comment error: {e}")
+    print(f"Comment {e.comment_id} not found")
 ```
 
 ### `RevisionError`
 
-Raised when a revision operation fails — most commonly an unknown group id passed to `accept_group()` / `reject_group()`. Revision groups are in-memory and per-open-`Document`, so ids from a previous session are unknown; resolve those revisions by id or author instead. No structured fields (message only).
+Raised when a revision operation fails — most commonly an unknown group id passed to `accept_group()` / `reject_group()`. Revision groups are in-memory and per-open-`Document`, so ids from a previous session are unknown; resolve those revisions by id or author instead. Structured fields: `revision_id` and `group_id` — set when the error is about that specific id (`group_id` for unknown-group errors), `None` otherwise.
 
 ```python
 from docx_editor.exceptions import RevisionError
+```
+
+### `DocumentNotFoundError`
+
+Raised by `Document.open()` when the source file does not exist. Structured field: `path` (the path that did not exist).
+
+```python
+from docx_editor.exceptions import DocumentNotFoundError
+```
+
+### `DocumentClosedError`
+
+Raised when any operation is attempted on a `Document` after `close()`. Closing discards the workspace (unless `cleanup=False`), so the object cannot keep serving reads or edits — reopen the source to continue. Structured field: `path` (the source path of the closed document).
+
+```python
+from docx_editor import Document
+from docx_editor.exceptions import DocumentClosedError
+
+try:
+    doc.get_visible_text()
+except DocumentClosedError as e:
+    doc = Document.open(e.path)
 ```
 
 ### `WorkspaceExistsError`
@@ -1069,7 +1097,7 @@ from docx_editor.exceptions import WorkspaceExistsError
 
 ### `WorkspaceSyncError`
 
-Raised when the workspace is out of sync with the source document: the source changed on disk since the workspace was created, or the workspace holds unsaved changes from a previous session that the source never received.
+Raised when the workspace is out of sync with the source document: the source changed on disk since the workspace was created, or the workspace holds unsaved changes from a previous session that the source never received. Structured fields: `workspace_path` and `source_path`.
 
 `Document.open(path, force_recreate=True)` recovers but discards the workspace's unsaved edits. To rescue them first, save the orphaned workspace to a new file (`Workspace` is not exported at the package root — use the deep import):
 

--- a/docx_editor/__init__.py
+++ b/docx_editor/__init__.py
@@ -40,6 +40,7 @@ from .exceptions import (
     AmbiguousTextError,
     BatchOperationError,
     CommentError,
+    DocumentClosedError,
     DocumentNotFoundError,
     DocumentOpenError,
     DocxEditError,
@@ -77,6 +78,7 @@ __all__ = [
     "Comment",
     # Exceptions
     "DocxEditError",
+    "DocumentClosedError",
     "DocumentNotFoundError",
     "DocumentOpenError",
     "InvalidDocumentError",

--- a/docx_editor/comments.py
+++ b/docx_editor/comments.py
@@ -404,7 +404,10 @@ class CommentManager:
             CommentError: If the parent comment is not found
         """
         if parent_comment_id not in self.existing_comments:
-            raise CommentError(f"Parent comment with id={parent_comment_id} not found")
+            raise CommentError(
+                f"Parent comment with id={parent_comment_id} not found",
+                comment_id=parent_comment_id,
+            )
 
         parent_info = self.existing_comments[parent_comment_id]
         comment_id = self.next_comment_id

--- a/docx_editor/document.py
+++ b/docx_editor/document.py
@@ -12,7 +12,7 @@ from typing import Literal, overload
 from xml.dom.minidom import Element
 
 from .comments import Comment, CommentManager
-from .exceptions import HashMismatchError, ParagraphIndexError
+from .exceptions import DocumentClosedError, HashMismatchError, ParagraphIndexError
 from .track_changes import (
     EditOperation,
     EditResult,
@@ -203,12 +203,17 @@ class Document:
 
     # ==================== Track Changes API ====================
 
-    def find_text(self, text: str, occurrence: int = 0) -> SearchResult | None:
+    def find_text(self, text: str, occurrence: int = 0, paragraph: str | None = None) -> SearchResult | None:
         """Find text in the document, including across element boundaries.
 
         Args:
-            text: Text to search for
-            occurrence: Which occurrence document-wide (0 = first, 1 = second, etc.)
+            text: Text to search for (must be non-empty)
+            occurrence: Which occurrence (0 = first, 1 = second, etc.).
+                Counts document-wide when ``paragraph`` is None, and within
+                the paragraph when scoped — the same convention as the edit
+                methods and ``add_comment``.
+            paragraph: Optional paragraph reference (e.g., "P2#f3c1") to scope
+                the search to one paragraph. None searches the whole document.
 
         Returns:
             A SearchResult, or None if the text (or that occurrence) is not
@@ -238,9 +243,14 @@ class Document:
                 )
 
         To enumerate every hit in one call, use :meth:`find_all`.
+
+        Raises:
+            ValueError: If ``text`` is empty, or ``paragraph`` is malformed.
+            ParagraphIndexError: If ``paragraph``'s index is out of range.
+            HashMismatchError: If ``paragraph``'s hash is stale.
         """
         self._ensure_open()
-        return self._revision_manager.find_text(text, occurrence)
+        return self._revision_manager.find_text(text, occurrence, paragraph=paragraph)
 
     def find_all(self, text: str, paragraph: str | None = None) -> list[SearchResult]:
         """Find every match of ``text``, in document order.
@@ -1346,9 +1356,12 @@ class Document:
     # ==================== Private Methods ====================
 
     def _ensure_open(self) -> None:
-        """Raise error if document is closed."""
+        """Raise DocumentClosedError if the document is closed."""
         if self._closed:
-            raise ValueError("Document is closed")
+            raise DocumentClosedError(
+                f"Document is closed. Reopen it with Document.open({str(self.source_path)!r}) to continue.",
+                path=self.source_path,
+            )
 
     def _setup_tracking(self) -> None:
         """Set up tracked changes infrastructure in the document.

--- a/docx_editor/exceptions.py
+++ b/docx_editor/exceptions.py
@@ -10,9 +10,15 @@ class DocxEditError(Exception):
 
 
 class DocumentNotFoundError(DocxEditError):
-    """Raised when the document file cannot be found."""
+    """Raised when the document file cannot be found.
 
-    pass
+    Attributes:
+        path: The path that did not exist, or None if unknown.
+    """
+
+    def __init__(self, message: str, *, path: Path | None = None):
+        self.path = path
+        super().__init__(message)
 
 
 class InvalidDocumentError(DocxEditError):
@@ -39,9 +45,22 @@ class WorkspaceSyncError(WorkspaceError):
     Two triggers: the source changed on disk since the workspace was created,
     or the workspace holds unsaved changes from a previous session that the
     source never received.
+
+    Attributes:
+        workspace_path: The workspace that is out of sync, or None if unknown.
+        source_path: The source document it belongs to, or None if unknown.
     """
 
-    pass
+    def __init__(
+        self,
+        message: str,
+        *,
+        workspace_path: Path | None = None,
+        source_path: Path | None = None,
+    ):
+        self.workspace_path = workspace_path
+        self.source_path = source_path
+        super().__init__(message)
 
 
 class WorkspaceLockedError(WorkspaceError):
@@ -116,6 +135,22 @@ class DocumentOpenError(DocxEditError):
         super().__init__(message)
 
 
+class DocumentClosedError(DocxEditError):
+    """Raised when an operation is attempted on a closed Document.
+
+    ``close()`` discards the workspace (unless ``cleanup=False``), so the
+    object cannot keep serving reads or edits. Reopen the source with
+    ``Document.open(e.path)`` to continue.
+
+    Attributes:
+        path: Source path of the closed document, or None if unknown.
+    """
+
+    def __init__(self, message: str, *, path: Path | None = None):
+        self.path = path
+        super().__init__(message)
+
+
 class XMLError(DocxEditError):
     """Raised when there's an error parsing or manipulating XML."""
 
@@ -135,15 +170,39 @@ class MultipleNodesFoundError(XMLError):
 
 
 class RevisionError(DocxEditError):
-    """Raised when there's an error with revision operations."""
+    """Raised when there's an error with revision operations.
 
-    pass
+    Attributes:
+        revision_id: The revision id the operation targeted, or None if the
+            error is not about a specific revision.
+        group_id: The revision group id the operation targeted (e.g. an
+            unknown group passed to ``accept_group``/``reject_group``), or
+            None if the error is not about a group.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        revision_id: int | None = None,
+        group_id: int | None = None,
+    ):
+        self.revision_id = revision_id
+        self.group_id = group_id
+        super().__init__(message)
 
 
 class CommentError(DocxEditError):
-    """Raised when there's an error with comment operations."""
+    """Raised when there's an error with comment operations.
 
-    pass
+    Attributes:
+        comment_id: The comment id the operation targeted (e.g. the parent id
+            of a failed reply), or None if no comment id applies.
+    """
+
+    def __init__(self, message: str, *, comment_id: int | None = None):
+        self.comment_id = comment_id
+        super().__init__(message)
 
 
 def _truncate_preview(text: str, limit: int = 80) -> str:

--- a/docx_editor/ooxml/unpack.py
+++ b/docx_editor/ooxml/unpack.py
@@ -65,7 +65,7 @@ def unpack_document(input_file: str | Path, output_dir: str | Path) -> str:
     output_path = Path(output_dir)
 
     if not input_path.exists():
-        raise DocumentNotFoundError(f"Document not found: {input_file}")
+        raise DocumentNotFoundError(f"Document not found: {input_file}", path=input_path)
 
     if input_path.is_dir():
         raise InvalidDocumentError(f"Is a directory, not a .docx file: {input_file}")

--- a/docx_editor/track_changes.py
+++ b/docx_editor/track_changes.py
@@ -592,7 +592,8 @@ class RevisionManager:
         if members is None:
             raise RevisionError(
                 f"Unknown revision group: {group_id}. Groups exist only for edits made "
-                f"through the current open Document; they are not persisted in the file."
+                f"through the current open Document; they are not persisted in the file.",
+                group_id=group_id,
             )
         return members
 
@@ -1219,12 +1220,28 @@ class RevisionManager:
         located = self._find_across_boundaries_located(text, occurrence)
         return located.match if located is not None else None
 
-    def find_text(self, text: str, occurrence: int = 0) -> SearchResult | None:
+    def find_text(self, text: str, occurrence: int = 0, paragraph: str | None = None) -> SearchResult | None:
         """Find the nth occurrence of text, as a public SearchResult.
 
-        Searches across element boundaries; ``occurrence`` counts matches
-        document-wide (0 = first). Returns None if not found.
+        Searches across element boundaries. With ``paragraph=None``,
+        ``occurrence`` counts matches document-wide (0 = first); with a
+        paragraph reference, the search is scoped to that paragraph and
+        ``occurrence`` counts within it. Returns None if not found.
+
+        Raises:
+            ValueError: If ``text`` is empty, or ``paragraph`` is malformed.
+            ParagraphIndexError: If ``paragraph``'s index is out of range.
+            HashMismatchError: If ``paragraph``'s hash is stale.
         """
+        if not text:
+            raise ValueError("find_text() requires a non-empty search string")
+
+        if paragraph is not None:
+            results = self.find_all(text, paragraph=paragraph)
+            # 0 <= guard: a bare results[occurrence] would let a negative
+            # index silently return a match from the end.
+            return results[occurrence] if 0 <= occurrence < len(results) else None
+
         located = self._find_across_boundaries_located(text, occurrence)
         if located is None:
             return None

--- a/docx_editor/workspace.py
+++ b/docx_editor/workspace.py
@@ -265,7 +265,7 @@ class Workspace:
         self.source_path = Path(source_path).resolve()
 
         if not self.source_path.exists():
-            raise DocumentNotFoundError(f"Document not found: {source_path}")
+            raise DocumentNotFoundError(f"Document not found: {source_path}", path=self.source_path)
 
         if self.source_path.suffix.lower() != ".docx":
             raise InvalidDocumentError(f"Not a .docx file: {source_path}")
@@ -325,14 +325,18 @@ class Workspace:
                                 f"{self.source_path}. Use force_recreate=True (or delete the "
                                 f"workspace) to discard them, or "
                                 f"Workspace(source, create=False).save(destination=...) to "
-                                f"rescue them first."
+                                f"rescue them first.",
+                                workspace_path=self.workspace_path,
+                                source_path=self.source_path,
                             )
                         # Same staleness predicate as save(), so a workspace can never
                         # open clean here and then fail sync_check() later at save time.
                         if not self.sync_check():
                             raise WorkspaceSyncError(
                                 f"Document has changed since workspace was created. "
-                                f"Delete {self.workspace_path} or use force_recreate=True"
+                                f"Delete {self.workspace_path} or use force_recreate=True",
+                                workspace_path=self.workspace_path,
+                                source_path=self.source_path,
                             )
                         if self.document_xml_path.exists():
                             # Workspace is valid, just load it
@@ -771,7 +775,9 @@ class Workspace:
             raise WorkspaceSyncError(
                 f"Source document changed on disk since the workspace was created: {self.source_path}. "
                 f"Saving would overwrite those changes. Use save(force=True) to overwrite anyway, "
-                f"or save(destination=...) to write elsewhere."
+                f"or save(destination=...) to write elsewhere.",
+                workspace_path=self.workspace_path,
+                source_path=self.source_path,
             )
 
         # Refuse to overwrite a document Word currently has open. Saving into

--- a/skills/docx/SKILL.md
+++ b/skills/docx/SKILL.md
@@ -228,6 +228,8 @@ for p in doc.list_paragraphs():
 # Chain into an edit with paragraph=match.paragraph_ref plus
 # occurrence=match.paragraph_occurrence (edits count occurrences per paragraph).
 match = doc.find_text("30 days")
+# Optionally scope to one paragraph — occurrence then counts within it:
+match = doc.find_text("30 days", paragraph="P2#f3c1")
 
 # Enumerate EVERY match in one call (returns list[SearchResult], [] if none).
 # Each result plugs straight into a follow-up edit — no occurrence math needed.
@@ -276,10 +278,10 @@ new_ref = doc.replace("30 days", "60 days", paragraph="P2#f3c1")
 doc.replace("net", "gross", paragraph=new_ref)  # chain without list_paragraphs()
 
 # occurrence is 0-based everywhere (0 = first). Edit methods count occurrences
-# within the target paragraph; find_text counts document-wide. add_comment
-# counts within the paragraph when paragraph= is given, and document-wide
-# (like find_text) when paragraph=None. find_all bridges the two conventions:
-# each result's paragraph_occurrence is already in edit-method coordinates.
+# within the target paragraph. find_text and add_comment count within the
+# paragraph when paragraph= is given, and document-wide when paragraph=None.
+# find_all bridges the two conventions: each result's paragraph_occurrence is
+# already in edit-method coordinates.
 #
 # OMITTING occurrence means "the target is unique in the search scope".
 # If it matches more than once, the edit raises AmbiguousTextError instead of
@@ -698,7 +700,7 @@ behavior that keeps one `list_paragraphs()` snapshot valid for the whole batch.
 
 ### Error Handling & Recovery
 
-All LLM-facing errors inherit from `DocxEditError` and (except `RevisionError`, message-only) carry structured fields so you can retry in-loop without re-reading the document. Catch the specific class or the base — both work.
+All LLM-facing errors inherit from `DocxEditError` and carry structured fields so you can retry in-loop without re-reading the document. Catch the specific class or the base — both work.
 
 | Error                  | Fields                                                                                  | Recovery                                                                                         |
 | ---------------------- | --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
@@ -707,7 +709,11 @@ All LLM-facing errors inherit from `DocxEditError` and (except `RevisionError`, 
 | `AmbiguousTextError`   | `search_text`, `paragraph_ref`, `paragraph_preview`, `total_occurrences`                | The target matched more than once with no `occurrence` given. Enumerate with `find_all()` and pick, or pass an explicit `occurrence` (0-based).      |
 | `ParagraphIndexError`  | `index`, `total_paragraphs`                                                             | Clamp to `1..total_paragraphs` or call `list_paragraphs()` to pick a valid ref.                 |
 | `BatchOperationError`  | `operation_index`, `reason`, `original`                                                 | Fix the op at `operations[operation_index]` (or drop it) and retry the batch; `original` is the underlying typed error (e.g. use its `actual_hash` to re-target a stale ref), or None for batch-level rules with no underlying exception (a missing paragraph ref, an element that is not an `EditOperation`, or a duplicate paragraph in `batch_rewrite` — `batch_edit` allows repeats, applied sequentially). Batch methods never raise the inner types directly. |
-| `RevisionError`        | (message only)                                                                          | Unknown `group_id` passed to `accept_group()`/`reject_group()`. Groups are in-memory and per-open-Document: use the `EditResult.group_id` you were handed in this session; after `close()`/reopen resolve by revision id or author instead. |
+| `RevisionError`        | `revision_id`, `group_id` (set when the error is about that id, else None)              | Unknown `group_id` passed to `accept_group()`/`reject_group()`. Groups are in-memory and per-open-Document: use the `EditResult.group_id` you were handed in this session; after `close()`/reopen resolve by revision id or author instead. |
+| `CommentError`         | `comment_id` (set when a comment id was targeted, else None)                            | Replying to a nonexistent comment id — call `list_comments()` and retry with a real id. With `comment_id=None` the arguments themselves were invalid; fix them per the message. |
+| `DocumentClosedError`  | `path`                                                                                  | The `Document` was used after `close()`. Reopen with `Document.open(e.path)`; edits not saved before the `close()` were discarded with the workspace. |
+| `DocumentNotFoundError`| `path`                                                                                  | The file doesn't exist at `path` — fix the path (typo, wrong cwd) before retrying. |
+| `WorkspaceSyncError`   | `workspace_path`, `source_path`                                                         | Workspace and source disagree (unsaved edits from a previous session, or the source changed on disk). **Do not retry blindly** — `force_recreate=True` (open) / `force=True` (save) DISCARDS one side; to rescue the workspace's edits first, save them elsewhere: `Workspace(source, create=False).save("rescued.docx")`. |
 | `DocumentOpenError`    | `path`, `owner_file`                                                                    | **Do not retry blindly.** The destination is open in Word. Stop and tell the user to close it. Only pass `force=True` if the user confirms the `~$` lock is stale (crashed session). |
 
 ```python

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -11,6 +11,7 @@ from defusedxml.common import EntitiesForbidden
 import docx_editor
 from docx_editor import Document, SearchResult
 from docx_editor.exceptions import (
+    DocumentClosedError,
     DocumentNotFoundError,
     DocumentOpenError,
     DocxEditError,
@@ -328,7 +329,7 @@ class TestDocumentClose:
         doc = Document.open(clean_workspace)
         doc.close()
 
-        with pytest.raises(ValueError, match="closed"):
+        with pytest.raises(DocumentClosedError, match="closed"):
             doc.list_revisions()
 
 
@@ -432,49 +433,49 @@ class TestDocumentEdgeCases:
         doc = Document.open(clean_workspace)
         doc.close()
 
-        with pytest.raises(ValueError, match="closed"):
+        with pytest.raises(DocumentClosedError, match="closed"):
             doc.count_matches("test")
 
-        with pytest.raises(ValueError, match="closed"):
+        with pytest.raises(DocumentClosedError, match="closed"):
             doc.replace("old", "new", paragraph="P1#0000")
 
-        with pytest.raises(ValueError, match="closed"):
+        with pytest.raises(DocumentClosedError, match="closed"):
             doc.delete("text", paragraph="P1#0000")
 
-        with pytest.raises(ValueError, match="closed"):
+        with pytest.raises(DocumentClosedError, match="closed"):
             doc.insert_after("anchor", "text", paragraph="P1#0000")
 
-        with pytest.raises(ValueError, match="closed"):
+        with pytest.raises(DocumentClosedError, match="closed"):
             doc.insert_before("anchor", "text", paragraph="P1#0000")
 
-        with pytest.raises(ValueError, match="closed"):
+        with pytest.raises(DocumentClosedError, match="closed"):
             doc.add_comment("anchor", "comment")
 
-        with pytest.raises(ValueError, match="closed"):
+        with pytest.raises(DocumentClosedError, match="closed"):
             doc.reply_to_comment(0, "reply")
 
-        with pytest.raises(ValueError, match="closed"):
+        with pytest.raises(DocumentClosedError, match="closed"):
             doc.list_comments()
 
-        with pytest.raises(ValueError, match="closed"):
+        with pytest.raises(DocumentClosedError, match="closed"):
             doc.resolve_comment(0)
 
-        with pytest.raises(ValueError, match="closed"):
+        with pytest.raises(DocumentClosedError, match="closed"):
             doc.delete_comment(0)
 
-        with pytest.raises(ValueError, match="closed"):
+        with pytest.raises(DocumentClosedError, match="closed"):
             doc.accept_revision(0)
 
-        with pytest.raises(ValueError, match="closed"):
+        with pytest.raises(DocumentClosedError, match="closed"):
             doc.reject_revision(0)
 
-        with pytest.raises(ValueError, match="closed"):
+        with pytest.raises(DocumentClosedError, match="closed"):
             doc.accept_all()
 
-        with pytest.raises(ValueError, match="closed"):
+        with pytest.raises(DocumentClosedError, match="closed"):
             doc.reject_all()
 
-        with pytest.raises(ValueError, match="closed"):
+        with pytest.raises(DocumentClosedError, match="closed"):
             doc.save()
 
 
@@ -717,10 +718,10 @@ class TestDocumentGetVisibleText:
         doc.close()
 
     def test_get_visible_text_after_close_raises(self, clean_workspace):
-        """Should raise ValueError after document is closed."""
+        """Should raise DocumentClosedError after document is closed."""
         doc = Document.open(clean_workspace)
         doc.close()
-        with pytest.raises(ValueError, match="closed"):
+        with pytest.raises(DocumentClosedError, match="closed"):
             doc.get_visible_text()
 
 
@@ -765,10 +766,10 @@ class TestDocumentGetOriginalText:
         doc.close()
 
     def test_get_original_text_after_close_raises(self, clean_workspace):
-        """Should raise ValueError after document is closed."""
+        """Should raise DocumentClosedError after document is closed."""
         doc = Document.open(clean_workspace)
         doc.close()
-        with pytest.raises(ValueError, match="closed"):
+        with pytest.raises(DocumentClosedError, match="closed"):
             doc.get_original_text()
 
 
@@ -838,7 +839,7 @@ class TestDocumentFindText:
     def test_find_text_after_close_raises(self, clean_workspace):
         doc = Document.open(clean_workspace)
         doc.close()
-        with pytest.raises(ValueError, match="closed"):
+        with pytest.raises(DocumentClosedError, match="closed"):
             doc.find_text("test")
 
 

--- a/tests/test_error_quality.py
+++ b/tests/test_error_quality.py
@@ -27,10 +27,16 @@ import pytest
 from docx_editor import (
     AmbiguousTextError,
     BatchOperationError,
+    CommentError,
     Document,
+    DocumentClosedError,
+    DocumentNotFoundError,
+    DocxEditError,
     EditOperation,
     ParagraphIndexError,
+    RevisionError,
     TextNotFoundError,
+    WorkspaceSyncError,
 )
 
 
@@ -766,13 +772,14 @@ class TestSharedBaseClass:
     """
 
     def test_all_structured_errors_share_docx_edit_error_base(self):
-        from docx_editor import DocxEditError, HashMismatchError
+        from docx_editor import HashMismatchError
 
         assert issubclass(TextNotFoundError, DocxEditError)
         assert issubclass(AmbiguousTextError, DocxEditError)
         assert issubclass(HashMismatchError, DocxEditError)
         assert issubclass(ParagraphIndexError, DocxEditError)
         assert issubclass(BatchOperationError, DocxEditError)
+        assert issubclass(DocumentClosedError, DocxEditError)
 
     def test_ambiguous_is_not_a_textnotfound_subclass(self):
         """The text WAS found — code catching TextNotFoundError to mean
@@ -784,7 +791,121 @@ class TestSharedBaseClass:
         from docx_editor import (  # noqa: F401
             AmbiguousTextError,
             BatchOperationError,
+            CommentError,
+            DocumentClosedError,
+            DocumentNotFoundError,
             HashMismatchError,
             ParagraphIndexError,
+            RevisionError,
             TextNotFoundError,
+            WorkspaceSyncError,
         )
+
+
+class TestDocumentClosedError:
+    """
+    Before: any operation on a closed Document raised a bare
+    ``ValueError("Document is closed")`` — outside the DocxEditError
+    hierarchy, indistinguishable from argument-validation ValueErrors, with
+    no path to reopen and no hint that reopening is the recovery.
+
+    After: DocumentClosedError(DocxEditError) carries ``path`` (the source
+    document) and the message says how to recover (Document.open).
+    """
+
+    def test_every_operation_kind_raises_typed_error(self, doc_path):
+        doc = Document.open(doc_path)
+        source = doc.source_path
+        doc.close()
+        calls = [
+            lambda: doc.replace("a", "b", paragraph="P1#0000"),  # edit
+            lambda: doc.get_visible_text(),  # read
+            lambda: doc.list_paragraphs(),  # read
+            lambda: doc.find_text("a"),  # search
+            lambda: doc.add_comment("a", "note"),  # comment
+            lambda: doc.accept_group(0),  # revision op
+            lambda: doc.save(),  # save
+        ]
+        for call in calls:
+            with pytest.raises(DocumentClosedError) as exc_info:
+                call()
+            e = exc_info.value
+            assert isinstance(e, DocxEditError)
+            assert e.path == source
+            assert "Document.open" in str(e)
+
+
+class TestLifecycleErrorFields:
+    """
+    Before: DocumentNotFoundError, WorkspaceSyncError, CommentError and
+    RevisionError were message-only — the recovery data (which path? which
+    id?) had to be parsed back out of the string.
+
+    After: each carries keyword-only typed fields, populated at every raise
+    site that has the value in scope; sites with no meaningful value leave
+    the field None rather than inventing one. Messages are unchanged.
+    """
+
+    def test_document_not_found_carries_path(self, doc_path):
+        missing = doc_path.parent / "no_such_file.docx"
+        with pytest.raises(DocumentNotFoundError) as exc_info:
+            Document.open(missing)
+        assert exc_info.value.path == missing.resolve()
+
+    def test_workspace_sync_error_at_open_carries_both_paths(self, doc_path):
+        """Dirty-workspace adoption refusal names workspace AND source."""
+        doc = Document.open(doc_path)
+        workspace_path = doc.workspace_path
+        doc.save(doc_path.parent / "elsewhere.docx")  # workspace now ahead of source
+        doc.close(cleanup=False)
+        try:
+            with pytest.raises(WorkspaceSyncError) as exc_info:
+                Document.open(doc_path)
+            e = exc_info.value
+            assert e.workspace_path == workspace_path
+            assert e.source_path == doc_path.resolve()
+        finally:
+            Document.open(doc_path, force_recreate=True).close()
+
+    def test_workspace_sync_error_at_save_carries_both_paths(self, doc_path):
+        doc = Document.open(doc_path)
+        try:
+            # Simulate an external edit: change the source file's content.
+            doc_path.write_bytes(doc_path.read_bytes() + b"\x00")
+            with pytest.raises(WorkspaceSyncError) as exc_info:
+                doc.save()
+            e = exc_info.value
+            assert e.workspace_path == doc.workspace_path
+            assert e.source_path == doc_path.resolve()
+        finally:
+            doc.close()
+
+    def test_comment_error_carries_parent_comment_id(self, doc_path):
+        doc = Document.open(doc_path)
+        try:
+            with pytest.raises(CommentError) as exc_info:
+                doc.reply_to_comment(999, "reply")
+            assert exc_info.value.comment_id == 999
+        finally:
+            doc.close()
+
+    def test_comment_error_validation_sites_leave_id_none(self, doc_path):
+        """No comment id exists yet at argument-validation time — field stays None."""
+        doc = Document.open(doc_path)
+        try:
+            with pytest.raises(CommentError) as exc_info:
+                doc.add_comment("", "note")
+            assert exc_info.value.comment_id is None
+        finally:
+            doc.close()
+
+    def test_revision_error_carries_group_id(self, doc_path):
+        doc = Document.open(doc_path)
+        try:
+            with pytest.raises(RevisionError) as exc_info:
+                doc.accept_group(424242)
+            e = exc_info.value
+            assert e.group_id == 424242
+            assert e.revision_id is None  # the error is about a group, not a revision
+        finally:
+            doc.close()

--- a/tests/test_find_all.py
+++ b/tests/test_find_all.py
@@ -170,3 +170,63 @@ class TestFindAllScoped:
         doc, _ = multi_para_doc
         with pytest.raises(ParagraphIndexError):
             doc.find_all("committee", paragraph="P999#0000")
+
+
+class TestFindTextScoped:
+    """find_text(paragraph=) — same scoping contract as find_all (ISSUES.md #42)."""
+
+    def test_scoped_occurrence_counts_within_paragraph(self, multi_para_doc):
+        doc, _ = multi_para_doc
+        ref = doc.list_paragraphs()[2].split("|")[0]
+        match = doc.find_text("committee", occurrence=1, paragraph=ref)
+        assert match is not None
+        assert match.paragraph_ref == ref
+        assert match.paragraph_occurrence == 1
+        # Unscoped occurrence=1 is still the second document-wide match (in
+        # P1) — proving the scoped branch switched coordinate systems.
+        unscoped = doc.find_text("committee", occurrence=1)
+        assert unscoped is not None
+        assert unscoped.paragraph_ref != ref
+
+    def test_scoped_misses_text_present_elsewhere(self, multi_para_doc):
+        doc, _ = multi_para_doc
+        ref = doc.list_paragraphs()[0].split("|")[0]
+        assert doc.find_text("item 5", paragraph=ref) is None
+        assert doc.find_text("item 5") is not None  # exists document-wide
+
+    def test_occurrence_beyond_paragraph_matches_returns_none(self, multi_para_doc):
+        """Out-of-range stays None (find_text's lookup contract), never IndexError."""
+        doc, _ = multi_para_doc
+        ref = doc.list_paragraphs()[0].split("|")[0]
+        assert doc.find_text("committee", occurrence=2, paragraph=ref) is None
+
+    def test_negative_occurrence_returns_none_not_wraparound(self, multi_para_doc):
+        """occurrence=-1 must not silently return the paragraph's last match."""
+        doc, _ = multi_para_doc
+        ref = doc.list_paragraphs()[0].split("|")[0]
+        assert doc.find_text("committee", occurrence=-1, paragraph=ref) is None
+
+    def test_stale_hash_raises(self, multi_para_doc):
+        doc, _ = multi_para_doc
+        ref = doc.list_paragraphs()[0].split("|")[0]
+        doc.replace("item 1", "MUTATED", paragraph=ref)
+        with pytest.raises(HashMismatchError):
+            doc.find_text("committee", paragraph=ref)
+
+    def test_malformed_ref_raises_value_error(self, multi_para_doc):
+        doc, _ = multi_para_doc
+        with pytest.raises(ValueError, match="Invalid paragraph reference"):
+            doc.find_text("committee", paragraph="not-a-ref")
+
+    def test_out_of_range_index_raises(self, multi_para_doc):
+        doc, _ = multi_para_doc
+        with pytest.raises(ParagraphIndexError):
+            doc.find_text("committee", paragraph="P999#0000")
+
+    def test_empty_text_raises_value_error_scoped_and_unscoped(self, multi_para_doc):
+        doc, _ = multi_para_doc
+        ref = doc.list_paragraphs()[0].split("|")[0]
+        with pytest.raises(ValueError, match="non-empty"):
+            doc.find_text("")
+        with pytest.raises(ValueError, match="non-empty"):
+            doc.find_text("", paragraph=ref)


### PR DESCRIPTION
## Summary

Completes the error contract for the LLM-facing API (ISSUES.md #42, dogfooding round 2, target 0.6.1):

- **New `DocumentClosedError(DocxEditError)`** with a `path` field, raised by the `_ensure_open()` choke point instead of a bare `ValueError`. The message says how to recover (reopen with `Document.open`). Breaking for callers catching `ValueError` around post-close calls (pre-1.0, per task spec).
- **Structured keyword-only fields, messages unchanged:** `DocumentNotFoundError.path`, `WorkspaceSyncError.workspace_path`/`.source_path`, `CommentError.comment_id`, `RevisionError.revision_id`/`.group_id`. Populated at every raise site that has the value in scope; left `None` where no meaningful value exists. `revision_id` has no populating site today (`accept_revision`/`reject_revision` return `bool`) — it exists for a stable contract.
- **`find_text(text, occurrence=0, paragraph=None)`:** paragraph-scoping parity with `find_all`. `occurrence` counts within the paragraph when scoped, document-wide otherwise; negative occurrence returns `None` instead of wrapping around; empty text raises `ValueError` (same guard both branches).
- **Docs:** SKILL.md error-table rows + scoped-search prose; docs/api.md `find_text` signature, `close()` post-close note, exception entries with field docs.

## Test plan

- `TestDocumentClosedError`: 7 operation kinds post-close raise the typed error with `path` set and recovery hint in the message.
- `TestLifecycleErrorFields`: field assertions for all four extended classes, including None-when-not-applicable cases.
- `TestFindTextScoped`: scoped hit with coordinate-system proof, scoped miss, out-of-range/negative occurrence → `None`, stale hash, malformed ref, out-of-range index, empty text scoped+unscoped.
- 19 existing post-close `pytest.raises(ValueError)` assertions migrated to `DocumentClosedError`.
- Full suite: 1135 passed, 2 skipped. `ruff check` + `ruff format --check` clean; `ty check` diagnostics identical to baseline (7 pre-existing).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added paragraph-scoped text searching with occurrence counting limited to the selected paragraph.
  * Added `DocumentClosedError`, now available from the top-level package.
  * Enhanced errors with structured context such as document paths, revision IDs, comment IDs, and workspace paths.

* **Bug Fixes**
  * Operations after closing a document now consistently report a dedicated error.
  * Improved diagnostics for missing documents, stale workspaces, invalid revisions, and comment replies.

* **Documentation**
  * Updated API and usage guidance for scoped searches, occurrence handling, and structured error recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->