### PR TITLE
feat: reconstruct revision groups at parse time (ISSUES.md #46)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -640,9 +640,10 @@ same second merge into one inferred group. When Word already resolved part of
 a former edit, the remainder reconstructs as a smaller (rump) group, and
 `accept_group()`/`reject_group()` handle it fine. Revisions missing an author
 or date, sitting outside any paragraph (e.g. table-row markers), or sharing a
-duplicated id stay ungrouped (`group_id=None`); revisions with non-numeric ids
-are omitted from `list_revisions()` entirely (no id-keyed operation could
-target them).
+duplicated id stay ungrouped (`group_id=None`), as does the trailing half
+created when an edit splits a *foreign* author's pending insertion mid-session
+(foreign grouping is best-effort); revisions with non-numeric ids are omitted
+from `list_revisions()` entirely (no id-keyed operation could target them).
 
 Never carry a `group_id` across sessions: reopening renumbers groups from 1,
 so a stale id from a previous session may silently resolve to a *different*
@@ -821,7 +822,7 @@ from docx_editor import Revision
 | `author` | str | The revision author |
 | `date` | datetime or None | When the revision was made |
 | `text` | str | The inserted or deleted text |
-| `group_id` | int or None | Revision group this revision belongs to (see [`accept_group()`](#accept_groupgroup_id)): recorded for this session's edits, inferred by reconstruction for revisions already in the file; None only for ungroupable revisions (missing author/date, outside any paragraph, duplicated id) |
+| `group_id` | int or None | Revision group this revision belongs to (see [`accept_group()`](#accept_groupgroup_id)): recorded for this session's edits, inferred by reconstruction for revisions already in the file; None only for ungroupable revisions (missing author/date, outside any paragraph, duplicated id, or a mid-session split half of a foreign insertion) |
 | `group_source` | str or None | Provenance of `group_id`: `"recorded"` (created through this open Document) or `"inferred"` (reconstructed at parse time from same-paragraph contiguity + identical author and date); None iff `group_id` is None |
 
 ### Example

--- a/docs/api.md
+++ b/docs/api.md
@@ -626,15 +626,27 @@ revision. Accepting the group applies the whole edit — the safe alternative to
 resolving a multi-revision edit (especially a rewrite) revision by revision,
 which garbles the text if only some are applied.
 
-Groups are **in-memory and per-open-Document**: after `close()`/reopen,
-revisions report `group_id=None` and old group ids raise
-[`RevisionError`](#revisionerror). `save()` does not invalidate groups (the
-Document stays open and revision ids are preserved). Revisions authored
-outside the current session (foreign reviewers, previous sessions) have no
-group — accept/reject them by id or author as before. If groups ever need to
-survive across sessions, the workspace `meta.json` (which never enters the
-`.docx`) is the natural extension point; that persistence is intentionally not
-implemented today.
+Group ids are **in-memory and per-open-Document**, renumbered on each open.
+Edits made through the open Document **record** their group
+(`Revision.group_source == "recorded"`). For revisions already in the file —
+previous sessions, foreign reviewers, Word round-trips — nothing is persisted
+in the `.docx` (Word has no grouping concept and strips unknown markup), so
+groups are **inferred** at parse time instead
+(`Revision.group_source == "inferred"`): contiguous revisions in the same
+paragraph sharing identical `w:author` + `w:date` reconstruct as one group.
+That heuristic almost always matches the original logical edits — one caveat:
+`w:date` has second precision, so two edits to the *same paragraph* within the
+same second merge into one inferred group. When Word already resolved part of
+a former edit, the remainder reconstructs as a smaller (rump) group, and
+`accept_group()`/`reject_group()` handle it fine. Revisions missing an author
+or date, sitting outside any paragraph (e.g. table-row markers), or carrying
+nonconforming ids stay ungrouped (`group_id=None`).
+
+Never carry a `group_id` across sessions: reopening renumbers groups from 1,
+so a stale id from a previous session may silently resolve to a *different*
+group rather than raise. Always take group ids from the current session's
+`EditResult` or `list_revisions()`. `save()` does not invalidate groups (the
+Document stays open and revision ids are preserved).
 
 **Parameters:**
 
@@ -642,7 +654,7 @@ implemented today.
 
 **Returns:** Number of revisions accepted (int). Members already resolved individually are skipped (and not counted).
 
-**Raises:** [`RevisionError`](#revisionerror) if the group id is unknown (never allocated, or allocated by a previous session on this document).
+**Raises:** [`RevisionError`](#revisionerror) if the group id is unknown to this open Document.
 
 **Example:**
 
@@ -656,7 +668,8 @@ doc.accept_group(result.group_id)  # apply the whole rewrite
 Reject every revision created by one logical edit operation — the counterpart
 of [`accept_group()`](#accept_groupgroup_id). Rejecting the group undoes the
 whole edit, restoring the exact pre-edit text (deletions restored, insertions
-removed). Same group semantics and lifetime as `accept_group()`.
+removed). Same group semantics and lifetime as `accept_group()` — including
+recorded vs inferred groups and per-open renumbering.
 
 **Parameters:**
 
@@ -806,7 +819,8 @@ from docx_editor import Revision
 | `author` | str | The revision author |
 | `date` | datetime or None | When the revision was made |
 | `text` | str | The inserted or deleted text |
-| `group_id` | int or None | Revision group of the edit that created it in this session (see [`accept_group()`](#accept_groupgroup_id)); None for foreign or pre-session revisions |
+| `group_id` | int or None | Revision group this revision belongs to (see [`accept_group()`](#accept_groupgroup_id)): recorded for this session's edits, inferred by reconstruction for revisions already in the file; None only for ungroupable revisions (missing author/date, outside any paragraph, nonconforming id) |
+| `group_source` | str or None | Provenance of `group_id`: `"recorded"` (created through this open Document) or `"inferred"` (reconstructed at parse time from same-paragraph contiguity + identical author and date); None iff `group_id` is None |
 
 ### Example
 
@@ -890,7 +904,7 @@ from docx_editor import EditResult
 
 | Attribute | Type | Description |
 |-----------|------|-------------|
-| `group_id` | int or None | Revision group holding every revision this edit created, for [`accept_group()`](#accept_groupgroup_id) / [`reject_group()`](#reject_groupgroup_id). None when the edit created no new revisions (e.g. text spliced into one of your own pending insertions, a no-change rewrite, or a rewrite whose changes all merged into your own pending insertions). Valid only while this Document stays open. |
+| `group_id` | int or None | Revision group holding every revision this edit created, for [`accept_group()`](#accept_groupgroup_id) / [`reject_group()`](#reject_groupgroup_id). None when the edit created no new revisions (e.g. text spliced into one of your own pending insertions, a no-change rewrite, or a rewrite whose changes all merged into your own pending insertions). Valid only while this Document stays open — after reopen the same revisions belong to a freshly inferred group with a new id. |
 | `revision_ids` | tuple[int, ...] | The `w:id`s of the group's member revisions, in creation order; `()` when `group_id` is None |
 
 ### Example
@@ -1085,7 +1099,7 @@ except CommentError as e:
 
 ### `RevisionError`
 
-Raised when a revision operation fails — most commonly an unknown group id passed to `accept_group()` / `reject_group()`. Revision groups are in-memory and per-open-`Document`, so ids from a previous session are unknown; resolve those revisions by id or author instead. Structured fields: `revision_id` and `group_id` — set when the error is about that specific id (`group_id` for unknown-group errors), `None` otherwise.
+Raised when a revision operation fails — most commonly an unknown group id passed to `accept_group()` / `reject_group()`. Group ids are per-open-`Document` and renumbered on each open (recorded for this session's edits, inferred by reconstruction for revisions already in the file), so always use a group id from the current session's `EditResult` or `list_revisions()` — a stale id from a previous session may raise this, or worse, silently resolve to a different group. Structured fields: `revision_id` and `group_id` — set when the error is about that specific id (`group_id` for unknown-group errors), `None` otherwise.
 
 ```python
 from docx_editor.exceptions import RevisionError

--- a/docs/api.md
+++ b/docs/api.md
@@ -639,8 +639,10 @@ That heuristic almost always matches the original logical edits — one caveat:
 same second merge into one inferred group. When Word already resolved part of
 a former edit, the remainder reconstructs as a smaller (rump) group, and
 `accept_group()`/`reject_group()` handle it fine. Revisions missing an author
-or date, sitting outside any paragraph (e.g. table-row markers), or carrying
-nonconforming ids stay ungrouped (`group_id=None`).
+or date, sitting outside any paragraph (e.g. table-row markers), or sharing a
+duplicated id stay ungrouped (`group_id=None`); revisions with non-numeric ids
+are omitted from `list_revisions()` entirely (no id-keyed operation could
+target them).
 
 Never carry a `group_id` across sessions: reopening renumbers groups from 1,
 so a stale id from a previous session may silently resolve to a *different*
@@ -819,7 +821,7 @@ from docx_editor import Revision
 | `author` | str | The revision author |
 | `date` | datetime or None | When the revision was made |
 | `text` | str | The inserted or deleted text |
-| `group_id` | int or None | Revision group this revision belongs to (see [`accept_group()`](#accept_groupgroup_id)): recorded for this session's edits, inferred by reconstruction for revisions already in the file; None only for ungroupable revisions (missing author/date, outside any paragraph, nonconforming id) |
+| `group_id` | int or None | Revision group this revision belongs to (see [`accept_group()`](#accept_groupgroup_id)): recorded for this session's edits, inferred by reconstruction for revisions already in the file; None only for ungroupable revisions (missing author/date, outside any paragraph, duplicated id) |
 | `group_source` | str or None | Provenance of `group_id`: `"recorded"` (created through this open Document) or `"inferred"` (reconstructed at parse time from same-paragraph contiguity + identical author and date); None iff `group_id` is None |
 
 ### Example

--- a/docx_editor/document.py
+++ b/docx_editor/document.py
@@ -69,8 +69,10 @@ class Document:
         result = doc.replace("30 days", "60 days", paragraph=ref)
         doc.add_comment("Section 5", "Please review")
 
-        # Every edit's revisions form a group — accept/reject them as a unit
-        # (group ids live only while this Document is open):
+        # Every edit's revisions form a group — accept/reject them as a unit.
+        # Group ids are per-open-Document (renumbered on each open; revisions
+        # already in the file get inferred groups reconstructed at parse
+        # time), so always use ids from this session:
         result = doc.rewrite_paragraph(result, "The board shall approve.")
         doc.reject_group(result.group_id)  # undo the whole rewrite
 
@@ -1225,9 +1227,11 @@ class Document:
             locatable, e.g. nested revisions), plus ``nested_under`` and
             ``contains_ids`` describing revision nesting (e.g. a foreign
             deletion inside another author's pending insertion), and
-            ``group_id`` linking revisions created by the same edit
-            operation in this session (None for foreign or pre-session
-            revisions).
+            ``group_id``/``group_source`` linking revisions from the same
+            logical edit — recorded for this session's edits, inferred by
+            parse-time reconstruction for revisions already in the file
+            (``group_id`` is None only for ungroupable revisions, e.g.
+            missing author/date).
 
         Raises:
             ValueError: If ``paragraph`` is malformed
@@ -1292,9 +1296,15 @@ class Document:
         resolving a multi-revision edit (especially a rewrite) revision by
         revision can leave the text garbled if only some are applied.
 
-        Groups are in-memory and live only while this Document is open:
-        after close()/reopen, revisions report ``group_id=None`` and old
-        group ids raise. save() does not invalidate groups.
+        Group ids are in-memory and per-open-Document, renumbered on each
+        open. Revisions already in the file (previous sessions, foreign
+        reviewers) get inferred groups reconstructed at parse time —
+        contiguous same-paragraph revisions sharing identical author and
+        date — so whole logical edits resolve as a unit after reopen too
+        (see ``Revision.group_source``). Always use a group id from this
+        session's EditResult or list_revisions(); a stale id from a
+        previous session may resolve to a different group. save() does not
+        invalidate groups.
 
         Args:
             group_id: Group id from an EditResult (or a Revision's
@@ -1305,8 +1315,7 @@ class Document:
             individually are skipped (and not counted).
 
         Raises:
-            RevisionError: If the group id is unknown (never allocated, or
-                allocated by a previous session on this document).
+            RevisionError: If the group id is unknown to this open Document.
 
         Example:
             result = doc.rewrite_paragraph(ref, "New text.")
@@ -1320,7 +1329,8 @@ class Document:
 
         The counterpart of :meth:`accept_group` — rejecting the group undoes
         the whole edit, restoring the exact pre-edit text (deletions are
-        restored, insertions removed).
+        restored, insertions removed). Same group semantics and lifetime as
+        accept_group(), including inferred groups after reopen.
 
         Args:
             group_id: Group id from an EditResult (or a Revision's
@@ -1331,8 +1341,7 @@ class Document:
             individually are skipped (and not counted).
 
         Raises:
-            RevisionError: If the group id is unknown (never allocated, or
-                allocated by a previous session on this document).
+            RevisionError: If the group id is unknown to this open Document.
 
         Example:
             result = doc.rewrite_paragraph(ref, "New text.")

--- a/docx_editor/track_changes.py
+++ b/docx_editor/track_changes.py
@@ -45,8 +45,15 @@ from .xml_editor import (
 # Document ("recorded") vs reconstructed at parse time ("inferred").
 _GroupSource = Literal["recorded", "inferred"]
 
-# (counter, groups, revision->group, group->source) — see _registry_snapshot.
-_RegistrySnapshot = tuple[int, dict[int, tuple[int, ...]], dict[int, int | None], dict[int, _GroupSource]]
+
+@dataclass
+class _RegistrySnapshot:
+    """Copy of the group registry, for rollback alongside a DOM snapshot."""
+
+    counter: int
+    groups: dict[int, tuple[int, ...]]
+    revision_groups: dict[int, int | None]
+    group_sources: dict[int, _GroupSource]
 
 
 @dataclass
@@ -330,8 +337,11 @@ class Revision:
       record their group directly; revisions already in the file get an
       *inferred* group reconstructed at parse time (see ``group_source``).
       None only when the revision is ungroupable: it sits outside any
-      paragraph, lacks an author or date, carries a non-numeric or
-      duplicate id, or is a mid-session split half of a foreign insertion.
+      paragraph, lacks an author or date, shares a duplicated id with
+      another revision (id-keyed lookup cannot tell the occurrences
+      apart), or is a mid-session split half of a foreign insertion.
+      Revisions with non-numeric ids are omitted from ``list_revisions()``
+      entirely — no id-keyed operation could target them.
     - ``group_source``: provenance of ``group_id`` — ``"recorded"`` for
       groups created by edits through this open Document, ``"inferred"``
       for groups reconstructed at parse time by the heuristic (contiguous
@@ -352,7 +362,7 @@ class Revision:
     nested_under: int | None = None
     contains_ids: tuple[int, ...] = ()
     group_id: int | None = None
-    group_source: Literal["recorded", "inferred"] | None = None
+    group_source: _GroupSource | None = None
 
     def __repr__(self) -> str:
         kind = "ins" if self.type == "insertion" else "del"
@@ -588,8 +598,12 @@ class RevisionManager:
 
         A revision stays unregistered (group_id None, breaking the current
         run) when it has no ancestor <w:p> (e.g. w:trPr row markers), an
-        empty author or date, a non-numeric id, or a duplicate id
-        (nonconforming producers; first occurrence wins).
+        empty author or date, or a non-numeric id (nonconforming producers;
+        list_revisions() omits non-numeric ids entirely — no id-keyed
+        operation could target them). A duplicated id is wholly ungrouped —
+        every occurrence, including the first — because id-keyed lookup
+        cannot tell the occurrences apart, so no group may contain an
+        ambiguous member.
         """
         run_key: tuple[int, str, str] | None = None
         run_members: list[int] = []
@@ -613,14 +627,26 @@ class RevisionManager:
                 rev_id = int(elem.getAttribute("w:id"))
             except ValueError:
                 rev_id = None
-            if (
-                paragraph is None
-                or not author
-                or not date
-                or rev_id is None
-                or rev_id in self._revision_groups
-                or rev_id in run_members
-            ):
+            if paragraph is None or not author or not date or rev_id is None:
+                close_run()
+                run_key = None
+                continue
+            if rev_id in self._revision_groups or rev_id in run_members:
+                # Duplicate w:id: demote the id to explicitly ungrouped —
+                # the earlier occurrence must not "win" a group its
+                # duplicate would silently inherit in list_revisions()
+                # (group lookup is id-keyed and cannot tell them apart).
+                if rev_id in run_members:
+                    run_members.remove(rev_id)
+                group_id = self._revision_groups.get(rev_id)
+                if group_id is not None:
+                    remaining = tuple(m for m in self._groups[group_id] if m != rev_id)
+                    if remaining:
+                        self._groups[group_id] = remaining
+                    else:
+                        del self._groups[group_id]
+                        del self._group_sources[group_id]
+                self._revision_groups[rev_id] = None
                 close_run()
                 run_key = None
                 continue
@@ -653,7 +679,7 @@ class RevisionManager:
         If the operation raises, nothing is registered.
         """
         capture = _GroupCapture()
-        with self.editor.collect_tracked_changes() as collected:
+        with self.editor.collect_tracked_changes() as collected, self.editor.frozen_timestamp():
             yield capture
         members: list[int] = []
         seen: set[int] = set()
@@ -713,11 +739,19 @@ class RevisionManager:
 
     def _registry_snapshot(self) -> _RegistrySnapshot:
         """Snapshot the group registry for rollback alongside a DOM snapshot."""
-        return (self._group_counter, dict(self._groups), dict(self._revision_groups), dict(self._group_sources))
+        return _RegistrySnapshot(
+            counter=self._group_counter,
+            groups=dict(self._groups),
+            revision_groups=dict(self._revision_groups),
+            group_sources=dict(self._group_sources),
+        )
 
     def _restore_registry(self, snapshot: _RegistrySnapshot) -> None:
         """Restore the group registry captured by ``_registry_snapshot``."""
-        self._group_counter, self._groups, self._revision_groups, self._group_sources = snapshot
+        self._group_counter = snapshot.counter
+        self._groups = snapshot.groups
+        self._revision_groups = snapshot.revision_groups
+        self._group_sources = snapshot.group_sources
 
     def group_id_of(self, revision_id: int) -> int | None:
         """Group id of a revision (recorded or inferred), or None if ungrouped."""
@@ -2574,6 +2608,13 @@ class RevisionManager:
         rev_id = elem.getAttribute("w:id")
         if not rev_id:
             return None
+        try:
+            rev_id_int = int(rev_id)
+        except ValueError:
+            # Nonconforming producer: Revision.id is an int and every
+            # id-keyed operation targets ints, so a non-numeric w:id is
+            # unrepresentable — omit it rather than crash the listing.
+            return None
 
         author = elem.getAttribute("w:author") or "Unknown"
         date_str = elem.getAttribute("w:date")
@@ -2608,7 +2649,6 @@ class RevisionManager:
                     view: Literal["accepted", "original"] = "accepted" if rev_type == "insertion" else "original"
                     occurrence = _occurrence_in_text_map(ctx.text_map(paragraph, view), elem, text)
 
-        rev_id_int = int(rev_id)
         group_id = self._revision_groups.get(rev_id_int)
         return Revision(
             id=rev_id_int,

--- a/docx_editor/track_changes.py
+++ b/docx_editor/track_changes.py
@@ -41,6 +41,13 @@ from .xml_editor import (
     render_plain_wt,
 )
 
+# Provenance of a revision group: created by an edit through this open
+# Document ("recorded") vs reconstructed at parse time ("inferred").
+_GroupSource = Literal["recorded", "inferred"]
+
+# (counter, groups, revision->group, group->source) — see _registry_snapshot.
+_RegistrySnapshot = tuple[int, dict[int, tuple[int, ...]], dict[int, int | None], dict[int, _GroupSource]]
+
 
 @dataclass
 class EditOperation:
@@ -223,8 +230,10 @@ class EditResult(str):
       into one of your own pending insertions (physically merged, so it is
       inseparable from the earlier operation at the XML level), a rewrite
       that found no differences, or a rewrite whose changes all landed
-      inside your own pending insertions. Groups live only for the current
-      open Document (see ``Document.accept_group``).
+      inside your own pending insertions. Group ids are per-open-Document
+      and renumbered on each open — after close()/reopen the same revisions
+      belong to a freshly inferred group with a new id, so never carry a
+      group_id across sessions (see ``Document.accept_group``).
     - ``revision_ids``: the w:ids of the group's member revisions, in
       creation order, as of this edit's return; ``()`` when ``group_id`` is
       None. A later edit that splits one of these insertions adds the
@@ -315,10 +324,22 @@ class Revision:
       deletion inside another author's pending insertion), else None.
     - ``contains_ids``: ids of revisions nested inside this one, in document
       order.
-    - ``group_id``: id of the revision group this revision was created in
-      (all revisions from one logical edit share it — see
-      ``Document.accept_group``). None for revisions that predate the open
-      Document session or were authored elsewhere.
+    - ``group_id``: id of the revision group this revision belongs to (all
+      revisions from one logical edit share it — see
+      ``Document.accept_group``). Edits made through the open Document
+      record their group directly; revisions already in the file get an
+      *inferred* group reconstructed at parse time (see ``group_source``).
+      None only when the revision is ungroupable: it sits outside any
+      paragraph, lacks an author or date, carries a non-numeric or
+      duplicate id, or is a mid-session split half of a foreign insertion.
+    - ``group_source``: provenance of ``group_id`` — ``"recorded"`` for
+      groups created by edits through this open Document, ``"inferred"``
+      for groups reconstructed at parse time by the heuristic (contiguous
+      same-paragraph revisions sharing identical ``w:author`` + ``w:date``
+      are one group). Inferred groups usually match the original logical
+      edits, but two edits to the same paragraph within the same second
+      merge into one group (``w:date`` has second precision). None iff
+      ``group_id`` is None.
     """
 
     id: int
@@ -331,6 +352,7 @@ class Revision:
     nested_under: int | None = None
     contains_ids: tuple[int, ...] = ()
     group_id: int | None = None
+    group_source: Literal["recorded", "inferred"] | None = None
 
     def __repr__(self) -> str:
         kind = "ins" if self.type == "insertion" else "del"
@@ -338,7 +360,8 @@ class Revision:
         preview = self.text[:30] + ("..." if len(self.text) > 30 else "")
         nested = f", nested_under={self.nested_under}" if self.nested_under is not None else ""
         contains = f", contains={list(self.contains_ids)}" if self.contains_ids else ""
-        group = f", group={self.group_id}" if self.group_id is not None else ""
+        inferred = "(inferred)" if self.group_source == "inferred" else ""
+        group = f", group={self.group_id}{inferred}" if self.group_id is not None else ""
         return f"Revision({kind} {self.id}{location}: '{preview}' by {self.author}{nested}{contains}{group})"
 
 
@@ -385,6 +408,27 @@ def _descendant_revision_ids(elem) -> tuple[int, ...]:
 
     walk(elem)
     return tuple(ids)
+
+
+def _revision_elements(root) -> list[Element]:
+    """All <w:ins>/<w:del> elements under ``root``, in document order.
+
+    Same unconditional-recursion pattern as ``_descendant_revision_ids``:
+    nested revisions (e.g. a w:del inside a w:ins) are included, each
+    appearing right after its host.
+    """
+    elems: list[Element] = []
+
+    def walk(node) -> None:
+        for child in node.childNodes:
+            if child.nodeType != child.ELEMENT_NODE:
+                continue
+            if child.tagName in ("w:ins", "w:del"):
+                elems.append(child)
+            walk(child)
+
+    walk(root)
+    return elems
 
 
 def _insertion_text_nodes(elem) -> list:
@@ -499,15 +543,93 @@ class RevisionManager:
         self.editor = editor
         # Revision groups: every revision created by one logical operation
         # shares a group id, so callers can accept/reject the operation as a
-        # unit. In-memory only — groups live for the lifetime of this manager
-        # (i.e. the open Document); nothing is written into the .docx.
+        # unit. The registry is in-memory and rebuilt on every open — nothing
+        # is written into the .docx. Revisions already present in the file
+        # get inferred groups from _reconstruct_groups below; edits made
+        # through this manager record theirs and continue the numbering.
         self._groups: dict[int, tuple[int, ...]] = {}
         # Maps revision id -> group id. A None value means explicitly
-        # ungrouped: a split-off tail of a pre-session insertion, registered
-        # so the active _grouped capture cannot claim it (membership is
-        # key-based) while group_id_of/list_revisions still report None.
+        # ungrouped: a split-off tail of an ungroupable own insertion,
+        # registered so the active _grouped capture cannot claim it
+        # (membership is key-based) while group_id_of/list_revisions still
+        # report None.
         self._revision_groups: dict[int, int | None] = {}
+        # Maps group id -> provenance ("recorded" | "inferred").
+        self._group_sources: dict[int, _GroupSource] = {}
         self._group_counter = 1
+        self._reconstruct_groups()
+
+    def _reconstruct_groups(self) -> None:
+        """Infer revision groups for the revisions already in the document.
+
+        Word offers no grouping concept, so nothing about the original
+        logical edits survives in the file; this reconstructs them with a
+        heuristic: maximal runs of consecutive revisions (document order,
+        nested revisions included) in the *same paragraph* sharing identical
+        raw ``w:author`` + ``w:date`` strings become one group. Same-paragraph
+        contiguity is load-bearing — (author, date) alone would merge every
+        edit an author made in the same second across the whole document.
+        Singletons get groups too, matching live behavior where a
+        one-revision edit gets a one-member group.
+
+        Known, accepted imprecisions:
+
+        - Two logical edits to the same paragraph within the same second
+          (w:date has second precision) merge into one group — accepted
+          over-merge, pinned by test.
+        - A revision inside a nested paragraph (e.g. a text box's
+          w:txbxContent) interrupts the outer paragraph's run in document
+          order — conservative over-split.
+        - Foreign revisions group by the same heuristic; provenance is
+          always honest ("inferred").
+        - When Word already resolved part of a former edit, the remaining
+          revisions reconstruct as a rump group — accept_group/reject_group
+          are rump-tolerant.
+
+        A revision stays unregistered (group_id None, breaking the current
+        run) when it has no ancestor <w:p> (e.g. w:trPr row markers), an
+        empty author or date, a non-numeric id, or a duplicate id
+        (nonconforming producers; first occurrence wins).
+        """
+        run_key: tuple[int, str, str] | None = None
+        run_members: list[int] = []
+
+        def close_run() -> None:
+            nonlocal run_members
+            if run_members:
+                group_id = self._group_counter
+                self._group_counter += 1
+                self._groups[group_id] = tuple(run_members)
+                for rev_id in run_members:
+                    self._revision_groups[rev_id] = group_id
+                self._group_sources[group_id] = "inferred"
+                run_members = []
+
+        for elem in _revision_elements(self.editor.dom.documentElement):
+            paragraph = _ancestor_paragraph(elem)
+            author = elem.getAttribute("w:author")
+            date = elem.getAttribute("w:date")
+            try:
+                rev_id = int(elem.getAttribute("w:id"))
+            except ValueError:
+                rev_id = None
+            if (
+                paragraph is None
+                or not author
+                or not date
+                or rev_id is None
+                or rev_id in self._revision_groups
+                or rev_id in run_members
+            ):
+                close_run()
+                run_key = None
+                continue
+            key = (id(paragraph), author, date)
+            if key != run_key:
+                close_run()
+                run_key = key
+            run_members.append(rev_id)
+        close_run()
 
     @contextmanager
     def _grouped(self) -> Iterator[_GroupCapture]:
@@ -520,10 +642,12 @@ class RevisionManager:
         authored by us — a split half of a *foreign* insertion gets a fresh
         id but keeps the foreign author, and must not join our group —
         (ii) still attached to the DOM, excluding create-then-remove churn,
-        and (iii) not already registered by ``_adopt_split_tail`` — a
-        split-off tail of one of our *own* insertions is adopted into its
-        origin group (or marked ungrouped when the origin predates this
-        session), never claimed by the splitting operation.
+        and (iii) not already registered — by ``_adopt_split_tail``, which
+        adopts a split-off tail of one of our *own* insertions into its
+        origin group (or marks it ungrouped when the origin has no group),
+        never letting the splitting operation claim it; or by
+        ``_reconstruct_groups`` (redundantly — the collector only reports
+        freshly assigned ids, which pre-existing revisions never have).
         A group id is allocated only when that filtered set is non-empty;
         it is exposed on the yielded _GroupCapture after the block exits.
         If the operation raises, nothing is registered.
@@ -557,6 +681,7 @@ class RevisionManager:
             self._groups[group_id] = tuple(members)
             for rev_id in members:
                 self._revision_groups[rev_id] = group_id
+            self._group_sources[group_id] = "recorded"
             capture.group_id = group_id
 
     def _adopt_split_tail(self, original_ins, new_nodes) -> None:
@@ -566,9 +691,10 @@ class RevisionManager:
         the trailing half is re-created as a fresh <w:ins> with a fresh w:id.
         That tail is leftover content of the *original* insertion's operation,
         not of the operation doing the splitting — so it joins the original
-        insertion's group, keeping reject_group/accept_group of that earlier
-        operation complete. When the origin has no group (a pre-session
-        insertion by this author), the tail is registered as explicitly
+        insertion's group — recorded or inferred alike, keeping
+        reject_group/accept_group of that earlier operation complete. When
+        the origin has no group (an ungroupable insertion by this author,
+        e.g. one missing its w:date), the tail is registered as explicitly
         ungrouped (None) instead. Either registration stops the active
         ``_grouped`` capture from claiming the tail for the splitting
         operation — otherwise rejecting that operation's group would rip a
@@ -585,30 +711,33 @@ class RevisionManager:
                 if origin_group is not None:
                     self._groups[origin_group] = (*self._groups[origin_group], tail_id)
 
-    def _registry_snapshot(self) -> tuple[int, dict[int, tuple[int, ...]], dict[int, int | None]]:
+    def _registry_snapshot(self) -> _RegistrySnapshot:
         """Snapshot the group registry for rollback alongside a DOM snapshot."""
-        return (self._group_counter, dict(self._groups), dict(self._revision_groups))
+        return (self._group_counter, dict(self._groups), dict(self._revision_groups), dict(self._group_sources))
 
-    def _restore_registry(self, snapshot: tuple[int, dict[int, tuple[int, ...]], dict[int, int | None]]) -> None:
+    def _restore_registry(self, snapshot: _RegistrySnapshot) -> None:
         """Restore the group registry captured by ``_registry_snapshot``."""
-        self._group_counter, self._groups, self._revision_groups = snapshot
+        self._group_counter, self._groups, self._revision_groups, self._group_sources = snapshot
 
     def group_id_of(self, revision_id: int) -> int | None:
-        """Group id of a revision created through this manager, or None."""
+        """Group id of a revision (recorded or inferred), or None if ungrouped."""
         return self._revision_groups.get(revision_id)
 
     def group_revisions(self, group_id: int) -> tuple[int, ...]:
-        """Member revision ids of ``group_id``, in creation order.
+        """Member revision ids of ``group_id``, in creation order (recorded
+        groups) or document order (inferred groups).
 
         Raises:
-            RevisionError: If the group id is unknown to this manager (groups
-                exist only for edits made through the current open Document).
+            RevisionError: If the group id is unknown to this manager (group
+                ids are per-open-Document and renumbered on each open).
         """
         members = self._groups.get(group_id)
         if members is None:
             raise RevisionError(
-                f"Unknown revision group: {group_id}. Groups exist only for edits made "
-                f"through the current open Document; they are not persisted in the file.",
+                f"Unknown revision group: {group_id}. Group ids are per-open-Document and "
+                f"renumbered on each open (recorded for this session's edits, inferred by "
+                f"reconstruction for revisions already in the file); use a group_id from "
+                f"this session's EditResult or list_revisions().",
                 group_id=group_id,
             )
         return members
@@ -1811,6 +1940,12 @@ class RevisionManager:
         point falls mid-run. Returns the last element that belongs to the
         left side of the split point (None when the split point is at the
         very start of the insertion's content).
+
+        Group caveat: when the enclosing *foreign* insertion is later split
+        into fresh-id halves, those halves are not adopted into the origin's
+        inferred group (adoption is deliberately limited to our own
+        insertions) — resolving that group then affects only part of the
+        visual insertion. Foreign grouping is best-effort by design.
         """
         run, rPr_xml = self._get_run_info(edge_node)
         if not run:  # pragma: no cover - a w:t node always sits inside a run
@@ -2474,6 +2609,7 @@ class RevisionManager:
                     occurrence = _occurrence_in_text_map(ctx.text_map(paragraph, view), elem, text)
 
         rev_id_int = int(rev_id)
+        group_id = self._revision_groups.get(rev_id_int)
         return Revision(
             id=rev_id_int,
             type=rev_type,
@@ -2484,7 +2620,8 @@ class RevisionManager:
             occurrence=occurrence,
             nested_under=_nearest_revision_ancestor_id(elem),
             contains_ids=_descendant_revision_ids(elem),
-            group_id=self._revision_groups.get(rev_id_int),
+            group_id=group_id,
+            group_source=self._group_sources.get(group_id) if group_id is not None else None,
         )
 
     def accept_revision(self, revision_id: int) -> bool:

--- a/docx_editor/track_changes.py
+++ b/docx_editor/track_changes.py
@@ -43,7 +43,7 @@ from .xml_editor import (
 
 # Provenance of a revision group: created by an edit through this open
 # Document ("recorded") vs reconstructed at parse time ("inferred").
-_GroupSource = Literal["recorded", "inferred"]
+GroupSource = Literal["recorded", "inferred"]
 
 
 @dataclass
@@ -53,7 +53,7 @@ class _RegistrySnapshot:
     counter: int
     groups: dict[int, tuple[int, ...]]
     revision_groups: dict[int, int | None]
-    group_sources: dict[int, _GroupSource]
+    group_sources: dict[int, GroupSource]
 
 
 @dataclass
@@ -362,7 +362,7 @@ class Revision:
     nested_under: int | None = None
     contains_ids: tuple[int, ...] = ()
     group_id: int | None = None
-    group_source: _GroupSource | None = None
+    group_source: GroupSource | None = None
 
     def __repr__(self) -> str:
         kind = "ins" if self.type == "insertion" else "del"
@@ -565,7 +565,7 @@ class RevisionManager:
         # report None.
         self._revision_groups: dict[int, int | None] = {}
         # Maps group id -> provenance ("recorded" | "inferred").
-        self._group_sources: dict[int, _GroupSource] = {}
+        self._group_sources: dict[int, GroupSource] = {}
         self._group_counter = 1
         self._reconstruct_groups()
 
@@ -601,9 +601,9 @@ class RevisionManager:
         empty author or date, or a non-numeric id (nonconforming producers;
         list_revisions() omits non-numeric ids entirely — no id-keyed
         operation could target them). A duplicated id is wholly ungrouped —
-        every occurrence, including the first — because id-keyed lookup
-        cannot tell the occurrences apart, so no group may contain an
-        ambiguous member.
+        every occurrence, whether or not individually groupable — because
+        id-keyed lookup cannot tell the occurrences apart, so no group may
+        contain an ambiguous member.
         """
         run_key: tuple[int, str, str] | None = None
         run_members: list[int] = []
@@ -619,7 +619,24 @@ class RevisionManager:
                 self._group_sources[group_id] = "inferred"
                 run_members = []
 
-        for elem in _revision_elements(self.editor.dom.documentElement):
+        elements = _revision_elements(self.editor.dom.documentElement)
+
+        # Pre-scan for duplicated ids, independent of groupability: an
+        # ungroupable occurrence (e.g. missing its date) must still bar its
+        # groupable twin from winning a group that id-keyed lookup would
+        # then report for both elements.
+        seen_ids: set[int] = set()
+        duplicate_ids: set[int] = set()
+        for elem in elements:
+            try:
+                elem_id = int(elem.getAttribute("w:id"))
+            except ValueError:
+                continue
+            if elem_id in seen_ids:
+                duplicate_ids.add(elem_id)
+            seen_ids.add(elem_id)
+
+        for elem in elements:
             paragraph = _ancestor_paragraph(elem)
             author = elem.getAttribute("w:author")
             date = elem.getAttribute("w:date")
@@ -627,26 +644,9 @@ class RevisionManager:
                 rev_id = int(elem.getAttribute("w:id"))
             except ValueError:
                 rev_id = None
-            if paragraph is None or not author or not date or rev_id is None:
-                close_run()
-                run_key = None
-                continue
-            if rev_id in self._revision_groups or rev_id in run_members:
-                # Duplicate w:id: demote the id to explicitly ungrouped —
-                # the earlier occurrence must not "win" a group its
-                # duplicate would silently inherit in list_revisions()
-                # (group lookup is id-keyed and cannot tell them apart).
-                if rev_id in run_members:
-                    run_members.remove(rev_id)
-                group_id = self._revision_groups.get(rev_id)
-                if group_id is not None:
-                    remaining = tuple(m for m in self._groups[group_id] if m != rev_id)
-                    if remaining:
-                        self._groups[group_id] = remaining
-                    else:
-                        del self._groups[group_id]
-                        del self._group_sources[group_id]
-                self._revision_groups[rev_id] = None
+            if paragraph is None or not author or not date or rev_id is None or rev_id in duplicate_ids:
+                if rev_id is not None and rev_id in duplicate_ids:
+                    self._revision_groups[rev_id] = None  # explicitly ungrouped
                 close_run()
                 run_key = None
                 continue

--- a/docx_editor/xml_editor.py
+++ b/docx_editor/xml_editor.py
@@ -1231,6 +1231,7 @@ class DocxXMLEditor(XMLEditor):
         # such as revision groups would silently point at the wrong element).
         self._max_change_id = -1
         self._tracked_change_collector: list[Element] | None = None
+        self._frozen_timestamp: str | None = None
 
     def _get_next_change_id(self) -> int:
         """Get the next available change ID by checking all tracked change elements."""
@@ -1267,6 +1268,26 @@ class DocxXMLEditor(XMLEditor):
             yield collected
         finally:
             self._tracked_change_collector = None
+
+    @contextmanager
+    def frozen_timestamp(self) -> Iterator[None]:
+        """Stamp every element injected in this context with ONE ``w:date``.
+
+        ``_inject_attributes_to_nodes`` reads the clock per call, and one
+        logical operation (a multi-hunk rewrite, a cross-run replace) injects
+        several times — crossing a second boundary mid-operation would spread
+        the operation's revisions across two ``w:date`` values, and parse-time
+        group reconstruction (which keys on identical dates) would then reopen
+        one edit as several groups. Does not nest — same single-slot design as
+        ``collect_tracked_changes``.
+        """
+        if self._frozen_timestamp is not None:
+            raise RuntimeError("frozen_timestamp() does not nest")
+        self._frozen_timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        try:
+            yield
+        finally:
+            self._frozen_timestamp = None
 
     def _ensure_w16du_namespace(self) -> None:
         """Ensure w16du namespace is declared on the root element."""
@@ -1306,7 +1327,7 @@ class DocxXMLEditor(XMLEditor):
         - w:comment: gets w:author, w:date, w:initials
         - w16cex:commentExtensible: gets w16cex:dateUtc
         """
-        timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        timestamp = self._frozen_timestamp or datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
         def is_inside_deletion(elem) -> bool:
             """Check if element is inside a w:del element."""

--- a/skills/docx/SKILL.md
+++ b/skills/docx/SKILL.md
@@ -423,8 +423,12 @@ for r in revisions:
     print(f"  at {r.paragraph_ref} occurrence={r.occurrence}")
     # Nesting: e.g. a foreign deletion inside another author's insertion
     print(f"  nested_under={r.nested_under} contains_ids={r.contains_ids}")
-    # Group: revisions created by the same edit in this session share it
-    print(f"  group_id={r.group_id}")
+    # Group: revisions from the same logical edit share it. group_source
+    # says how it was established: "recorded" (edit made in this session)
+    # or "inferred" (reconstructed at parse time for revisions already in
+    # the file). None only for ungroupable revisions (missing author/date,
+    # outside any paragraph, nonconforming id).
+    print(f"  group_id={r.group_id} group_source={r.group_source}")
 
 # Filter by author
 their_changes = doc.list_revisions(author="OtherUser")
@@ -456,10 +460,17 @@ result = doc.rewrite_paragraph("P3#a7b2", "Entirely new paragraph text.")
 doc.reject_group(result.group_id)   # undo the whole rewrite, or:
 # doc.accept_group(result.group_id) # apply it in full
 
-# Groups are in-memory and per-open-Document: after close()/reopen,
-# revisions report group_id=None and old group ids raise RevisionError.
-# save() keeps groups alive (the Document stays open). Foreign/pre-session
-# revisions never have a group — resolve those by id or author.
+# Group ids are in-memory and per-open-Document, renumbered on each open.
+# Pre-existing revisions (previous sessions, foreign reviewers, Word
+# round-trips) get INFERRED groups reconstructed at parse time: contiguous
+# same-paragraph revisions sharing identical w:author + w:date are one
+# group (r.group_source == "inferred"; session edits are "recorded"). So
+# accept_group/reject_group work after reopen too — but always take the
+# group_id from THIS session's list_revisions()/EditResult; a stale id
+# from a previous session may resolve to a different group. Caveat:
+# w:date has second precision, so two edits to the same paragraph in the
+# same second merge into one inferred group. save() keeps groups alive
+# (the Document stays open).
 
 # Accept or reject all revisions (returns count of revisions processed)
 doc.accept_all()
@@ -541,11 +552,15 @@ doc.save("resolved.docx")
 doc.close()
 ```
 
-To act on a subset, target revisions by ID: `list_revisions()` (optionally
-`author=`- or `paragraph=`-filtered), pick by `.text`/`.type`/`.paragraph_ref`,
-then `accept_revision(id)` / `reject_revision(id)`. For edits made in the
-current session, prefer `accept_group()`/`reject_group()` with the
-`EditResult.group_id` — it resolves everything one edit created, in one call.
+To act on a subset, prefer whole groups: `accept_group()`/`reject_group()`
+resolves everything one edit created in one call. For this session's edits
+take the `EditResult.group_id`; for pre-existing revisions (a reviewer
+session over someone else's redlines, or your own after reopen) take the
+`group_id` from `list_revisions()` — those groups are inferred at parse time
+(`group_source == "inferred"`), so one logical edit still resolves as a
+unit. Fall back to per-id `accept_revision(id)` / `reject_revision(id)`
+(pick by `.text`/`.type`/`.paragraph_ref`) only for revisions inside a group
+you don't want to resolve whole.
 
 ## Redlining Workflow (Document Review)
 
@@ -721,7 +736,7 @@ All LLM-facing errors inherit from `DocxEditError` and carry structured fields s
 | `AmbiguousTextError`   | `search_text`, `paragraph_ref`, `paragraph_preview`, `total_occurrences`                | The target matched more than once with no `occurrence` given. Enumerate with `find_all()` and pick, or pass an explicit `occurrence` (0-based).      |
 | `ParagraphIndexError`  | `index`, `total_paragraphs`                                                             | Clamp to `1..total_paragraphs` or call `list_paragraphs()` to pick a valid ref.                 |
 | `BatchOperationError`  | `operation_index`, `reason`, `original`                                                 | Fix the op at `operations[operation_index]` (or drop it) and retry the batch; `original` is the underlying typed error (e.g. use its `actual_hash` to re-target a stale ref), or None for batch-level rules with no underlying exception (a missing paragraph ref, an element that is not an `EditOperation`, or a duplicate paragraph in `batch_rewrite` — `batch_edit` allows repeats, applied sequentially). Batch methods never raise the inner types directly. |
-| `RevisionError`        | `revision_id`, `group_id` (set when the error is about that id, else None)              | Unknown `group_id` passed to `accept_group()`/`reject_group()`. Groups are in-memory and per-open-Document: use the `EditResult.group_id` you were handed in this session; after `close()`/reopen resolve by revision id or author instead. |
+| `RevisionError`        | `revision_id`, `group_id` (set when the error is about that id, else None)              | Unknown `group_id` passed to `accept_group()`/`reject_group()`. Group ids are per-open-Document and renumbered on each open (recorded for this session's edits, inferred for pre-existing revisions): use a `group_id` from this session's `EditResult` or `list_revisions()`, never one saved from a previous session. |
 | `CommentError`         | `comment_id` (set when a comment id was targeted, else None)                            | Replying to a nonexistent comment id — call `list_comments()` and retry with a real id. With `comment_id=None` the arguments themselves were invalid; fix them per the message. |
 | `DocumentClosedError`  | `path`                                                                                  | The `Document` was used after `close()`. Reopen with `Document.open(e.path)`; edits not saved before the `close()` were discarded with the workspace. |
 | `DocumentNotFoundError`| `path`                                                                                  | The file doesn't exist at `path` — fix the path (typo, wrong cwd) before retrying. |

--- a/skills/docx/SKILL.md
+++ b/skills/docx/SKILL.md
@@ -427,7 +427,7 @@ for r in revisions:
     # says how it was established: "recorded" (edit made in this session)
     # or "inferred" (reconstructed at parse time for revisions already in
     # the file). None only for ungroupable revisions (missing author/date,
-    # outside any paragraph, nonconforming id).
+    # outside any paragraph, duplicated id).
     print(f"  group_id={r.group_id} group_source={r.group_source}")
 
 # Filter by author

--- a/skills/docx/SKILL.md
+++ b/skills/docx/SKILL.md
@@ -427,7 +427,8 @@ for r in revisions:
     # says how it was established: "recorded" (edit made in this session)
     # or "inferred" (reconstructed at parse time for revisions already in
     # the file). None only for ungroupable revisions (missing author/date,
-    # outside any paragraph, duplicated id).
+    # outside any paragraph, duplicated id, or a mid-session split half
+    # of a foreign insertion).
     print(f"  group_id={r.group_id} group_source={r.group_source}")
 
 # Filter by author

--- a/tests/test_foreign_revisions.py
+++ b/tests/test_foreign_revisions.py
@@ -37,7 +37,9 @@ from docx_editor import Document, Revision
 # including its trailing bracketed note run. None of the fixture's revisions
 # nest, so nested_under/contains_ids keep their defaults. Ids 1007/1008 carry
 # identical text in the same paragraph — type + occurrence (in each type's own
-# view) is what tells them apart.
+# view) is what tells them apart. Every revision differs from its document-
+# order neighbor by paragraph, author, or date, so group reconstruction
+# infers eight singleton groups, numbered 1-8 in document order.
 EXPECTED_REVISIONS = [
     Revision(
         id=1001,
@@ -47,6 +49,8 @@ EXPECTED_REVISIONS = [
         text="inserted",
         paragraph_ref="P3#e6b4",
         occurrence=0,
+        group_id=1,
+        group_source="inferred",
     ),
     Revision(
         id=1002,
@@ -56,6 +60,8 @@ EXPECTED_REVISIONS = [
         text="old ",
         paragraph_ref="P4#1750",
         occurrence=0,
+        group_id=2,
+        group_source="inferred",
     ),
     Revision(
         id=1003,
@@ -65,6 +71,8 @@ EXPECTED_REVISIONS = [
         text="colour",
         paragraph_ref="P5#a192",
         occurrence=0,
+        group_id=3,
+        group_source="inferred",
     ),
     Revision(
         id=1004,
@@ -74,6 +82,8 @@ EXPECTED_REVISIONS = [
         text="color",
         paragraph_ref="P5#a192",
         occurrence=0,
+        group_id=4,
+        group_source="inferred",
     ),
     Revision(
         id=1005,
@@ -83,6 +93,8 @@ EXPECTED_REVISIONS = [
         text="reenter",
         paragraph_ref="P6#975f",
         occurrence=0,
+        group_id=5,
+        group_source="inferred",
     ),
     Revision(
         id=1006,
@@ -92,6 +104,8 @@ EXPECTED_REVISIONS = [
         text="— or is it?",
         paragraph_ref="P8#1b23",
         occurrence=0,
+        group_id=6,
+        group_source="inferred",
     ),
     Revision(
         id=1007,
@@ -101,6 +115,8 @@ EXPECTED_REVISIONS = [
         text="DRAFT ",
         paragraph_ref="P9#5772",
         occurrence=0,
+        group_id=7,
+        group_source="inferred",
     ),
     Revision(
         id=1008,
@@ -110,6 +126,8 @@ EXPECTED_REVISIONS = [
         text="DRAFT ",
         paragraph_ref="P9#5772",
         occurrence=0,
+        group_id=8,
+        group_source="inferred",
     ),
 ]
 

--- a/tests/test_revision_groups.py
+++ b/tests/test_revision_groups.py
@@ -660,7 +660,7 @@ class TestGroupReconstruction:
         )
         manager = _make_manager(temp_xml(body))
 
-        assert manager._groups == {2: (3,), 3: (4,)}
+        assert manager._groups == {1: (3,), 2: (4,)}
 
         revisions = manager.list_revisions()
         assert sorted(rev.id for rev in revisions) == [1, 1, 2, 2, 3, 4]  # "oops" omitted
@@ -668,7 +668,22 @@ class TestGroupReconstruction:
             if rev.id in (1, 2):  # both occurrences of each duplicated id
                 assert rev.group_id is None and rev.group_source is None
         by_id = {rev.id: rev for rev in revisions}
-        assert by_id[3].group_id == 2 and by_id[4].group_id == 3
+        assert by_id[3].group_id == 1 and by_id[4].group_id == 2
+
+    def test_duplicate_id_with_ungroupable_occurrence_stays_ungrouped(self, temp_xml):
+        # An ungroupable occurrence (here: no w:date) of a duplicated id
+        # must still bar its groupable twin from winning a group — id-keyed
+        # lookup would report that group for both elements.
+        body = (
+            f'<w:p><w:ins w:id="5" w:author="{AUTHOR_A}"><w:r><w:t>no date </w:t></w:r></w:ins>'
+            f"{_ins_xml(5, 'groupable twin ')}{_ins_xml(6, 'six')}</w:p>"
+        )
+        manager = _make_manager(temp_xml(body))
+
+        assert manager._groups == {1: (6,)}
+        revisions = manager.list_revisions()
+        assert sorted(rev.id for rev in revisions) == [5, 5, 6]
+        assert all(rev.group_id is None for rev in revisions if rev.id == 5)
 
     def test_revision_outside_paragraph_stays_ungrouped(self, temp_xml):
         # A <w:trPr> row-mark insertion has no ancestor <w:p>.

--- a/tests/test_revision_groups.py
+++ b/tests/test_revision_groups.py
@@ -1,4 +1,4 @@
-"""Tests for revision grouping (ISSUES.md #37).
+"""Tests for revision grouping (ISSUES.md #37) and reconstruction (#46).
 
 Every logical edit operation registers the revisions it creates as one
 in-memory revision group, exposed via EditResult (a str subclass carrying
@@ -7,11 +7,16 @@ in-memory revision group, exposed via EditResult (a str subclass carrying
 accepting only some of a ``rewrite_paragraph``'s revisions garbles the
 paragraph, because each revision is a diff hunk, not a self-contained edit.
 
-Groups are per-open-Document: foreign or pre-session revisions report
-``group_id=None`` and unknown group ids raise RevisionError.
+Group ids are per-open-Document and renumbered on each open. Revisions
+already in the file (pre-session or foreign) get *inferred* groups
+reconstructed at parse time: contiguous same-paragraph revisions sharing
+identical raw ``w:author`` + ``w:date`` are one group
+(``group_source="inferred"``); session edits record theirs
+(``group_source="recorded"``). Unknown group ids raise RevisionError.
 """
 
 import shutil
+from datetime import datetime
 from pathlib import Path
 
 import pytest
@@ -27,6 +32,37 @@ NS = 'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"'
 AUTHOR_A = "Reviewer A"
 AUTHOR_B = "Reviewer B"
 DATE_A = "2024-01-01T00:00:00Z"
+DATE_B = "2024-01-01T00:00:01Z"
+
+
+def _ins_xml(rev_id, text: str, author: str = AUTHOR_A, date: str = DATE_A) -> str:
+    """A <w:ins> wrapping one run of ``text``."""
+    return f'<w:ins w:id="{rev_id}" w:author="{author}" w:date="{date}"><w:r><w:t>{text}</w:t></w:r></w:ins>'
+
+
+def _del_xml(rev_id, text: str, author: str = AUTHOR_A, date: str = DATE_A) -> str:
+    """A <w:del> wrapping one run of deleted ``text``."""
+    return (
+        f'<w:del w:id="{rev_id}" w:author="{author}" w:date="{date}"><w:r><w:delText>{text}</w:delText></w:r></w:del>'
+    )
+
+
+class _FrozenDatetime(datetime):
+    """datetime whose now() is pinned to one instant."""
+
+    @classmethod
+    def now(cls, tz=None):
+        return cls(2025, 6, 1, 12, 0, 0, tzinfo=tz)
+
+
+@pytest.fixture
+def frozen_clock(monkeypatch):
+    """Pin every w:date this session stamps to one fixed second.
+
+    w:date has second precision, so same-second tests against the real
+    clock would be flaky across second boundaries.
+    """
+    monkeypatch.setattr("docx_editor.xml_editor.datetime", _FrozenDatetime)
 
 
 @pytest.fixture
@@ -116,15 +152,22 @@ class TestGroupIdOnRevisions:
             assert rev.group_id == result.group_id
             assert "group=" in repr(rev)
 
-    def test_foreign_revisions_have_no_group(self, test_data_dir, temp_dir):
+    def test_foreign_revisions_get_inferred_groups(self, test_data_dir, temp_dir):
+        # Every revision in the fixture differs from its document-order
+        # neighbor by paragraph, author, or date — the heuristic partitions
+        # them into eight singleton inferred groups (the full expected
+        # partition is pinned in test_foreign_revisions.py).
         fixture = test_data_dir / "OXML_TrackChanges_Test.docx"
         dest = temp_dir / "foreign.docx"
         shutil.copy(fixture, dest)
         with Document.open(dest) as doc:
             revisions = doc.list_revisions()
             assert revisions
-            assert all(rev.group_id is None for rev in revisions)
-            assert all("group=" not in repr(rev) for rev in revisions)
+            assert all(rev.group_id is not None for rev in revisions)
+            assert all(rev.group_source == "inferred" for rev in revisions)
+            assert all(f"group={rev.group_id}(inferred)" in repr(rev) for rev in revisions)
+            gids = [rev.group_id for rev in revisions]
+            assert len(set(gids)) == len(gids)  # all singletons
 
 
 class TestAcceptRejectGroup:
@@ -305,20 +348,27 @@ class TestBatchGrouping:
 
 
 class TestGroupSessionScope:
-    def test_groups_do_not_survive_reopen(self, temp_docx):
+    def test_reopen_reconstructs_inferred_group(self, temp_docx):
         with Document.open(temp_docx) as doc:
             ref = find_ref(doc, "quick brown fox")
             result = doc.replace("quick", "speedy", paragraph=ref)
-            group_id = result.group_id
-            assert group_id is not None
+            assert result.group_id is not None
             doc.save()
 
         with Document.open(temp_docx) as doc:
             revisions = doc.list_revisions()
-            assert revisions  # the tracked change persisted in the file
-            assert all(rev.group_id is None for rev in revisions)
-            with pytest.raises(RevisionError):
-                doc.accept_group(group_id)
+            assert len(revisions) == 2  # the tracked change persisted
+            # The replace's del+ins pair is contiguous in one paragraph with
+            # one author+date, so it reconstructs as ONE inferred group under
+            # a fresh per-open id — old ids are meaningless after reopen.
+            gid = revisions[0].group_id
+            assert gid is not None
+            assert all(rev.group_id == gid for rev in revisions)
+            assert all(rev.group_source == "inferred" for rev in revisions)
+            # The reconstructed group resolves as a unit.
+            assert doc.accept_group(gid) == 2
+            assert "speedy brown fox" in _paragraph_text(doc, 1)
+            assert doc.list_revisions() == []
 
     def test_save_keeps_groups_alive(self, doc):
         ref = find_ref(doc, "quick brown fox")
@@ -359,13 +409,12 @@ class TestForeignInsGrouping:
         assert member_types == {"deletion", "insertion"}
 
     def test_split_foreign_ins_does_not_claim_presession_nested_del(self, temp_xml):
-        # A's pending insertion contains B's PRE-SESSION deletion (no group —
-        # e.g. made before a save/reopen). B then inserts inside A's
-        # insertion before the deletion: the split re-serializes A's
-        # trailing content INCLUDING B's old <w:del>, running it back
-        # through attribute injection. That pre-existing deletion must not
-        # join B's insert group — rejecting the insert would silently
-        # resurrect "beta ".
+        # A's pending insertion contains B's PRE-SESSION deletion (made
+        # before a save/reopen). B then inserts inside A's insertion before
+        # the deletion: the split re-serializes A's trailing content
+        # INCLUDING B's old <w:del>, running it back through attribute
+        # injection. That pre-existing deletion must not join B's insert
+        # group — rejecting the insert would silently resurrect "beta ".
         body = (
             f'<w:p><w:ins w:id="1" w:author="{AUTHOR_A}" w:date="{DATE_A}">'
             "<w:r><w:t>alpha </w:t></w:r>"
@@ -382,8 +431,15 @@ class TestForeignInsGrouping:
         members = manager.group_revisions(group_id)
         assert members == (change_id,)  # only the new insertion, not del#2
 
+        # del#2 keeps its own inferred singleton group (the author change
+        # inside ins#1 broke the contiguity run), distinct from B's
+        # recorded insert group.
         revisions = {rev.id: rev for rev in manager.list_revisions()}
-        assert revisions[2].group_id is None  # pre-session del stays ungrouped
+        del_gid = revisions[2].group_id
+        assert del_gid is not None
+        assert del_gid != group_id
+        assert revisions[2].group_source == "inferred"
+        assert manager.group_revisions(del_gid) == (2,)
 
         # Undoing the insert must leave the pre-existing deletion untouched.
         manager.reject_group(group_id)
@@ -449,12 +505,14 @@ class TestOwnInsertionSplits:
         assert _paragraph_text(doc, 1) == original
         assert doc.list_revisions() == []
 
-    def test_presession_middle_delete_leaves_tail_ungrouped(self, temp_docx):
-        # The origin insertion predates this session (reopen dropped its
-        # group), so its split-off tail has no group to join — and must not
-        # be claimed into a phantom group by the delete operation.
+    def test_presession_middle_delete_adopts_tail_into_inferred_group(self, temp_docx):
+        # The origin insertion predates this session, but reconstruction
+        # gave it an inferred group on reopen — so its split-off tail joins
+        # that group (and must not be claimed into a phantom group by the
+        # delete operation, which itself creates no revisions).
         with Document.open(temp_docx) as doc:
             ref = find_ref(doc, "quick brown fox")
+            original = _paragraph_text(doc, 1)
             doc.insert_after("fox", " AAA MID BBB", paragraph=ref)
             doc.save()
 
@@ -463,10 +521,18 @@ class TestOwnInsertionSplits:
             result = doc.delete("MID ", paragraph=ref)
 
             assert result.group_id is None
-            assert doc._revision_manager._groups == {}
             revisions = doc.list_revisions()
             assert len(revisions) == 2  # truncated head + split-off tail
-            assert all(rev.group_id is None for rev in revisions)
+            gid = revisions[0].group_id
+            assert gid is not None
+            assert all(rev.group_id == gid for rev in revisions)
+            assert all(rev.group_source == "inferred" for rev in revisions)
+
+            # Rejecting the inferred group removes BOTH halves — the rump/
+            # tail correctness win of reconstruction.
+            doc.reject_group(gid)
+            assert _paragraph_text(doc, 1) == original
+            assert doc.list_revisions() == []
 
     def test_presession_rewrite_does_not_claim_split_tail(self, temp_docx):
         # Same defect through the public rewrite path: without tail
@@ -485,16 +551,246 @@ class TestOwnInsertionSplits:
             result = doc.rewrite_paragraph(ref, current.replace("beta", "BETA"))
 
             # The only physical change happens inside our own pre-session
-            # insertion — no trackable revisions, so no group at all.
+            # insertion — no trackable revisions, so no group for the
+            # rewrite. Every surviving revision piece (truncated origin +
+            # split-off tails) stays in the origin's inferred group.
             assert result.group_id is None
-            assert doc._revision_manager._groups == {}
-            assert all(rev.group_id is None for rev in doc.list_revisions())
+            revisions = doc.list_revisions()
+            gids = {rev.group_id for rev in revisions}
+            assert len(gids) == 1 and None not in gids
+            assert set(doc._revision_manager._groups) == gids
+            assert all(rev.group_source == "inferred" for rev in revisions)
             # Placement-agnostic content check: replacement position inside
             # an own insertion is the pre-existing ISSUES.md #31 ordering
             # bug, out of scope here.
             text = _paragraph_text(doc, 1)
             assert "BETA" in text and "beta" not in text
             assert "alpha" in text and "gamma" in text
+
+
+class TestGroupReconstruction:
+    """Parse-time inference of groups for revisions already in the file (#46).
+
+    Reconstruction runs at RevisionManager construction, so these unit
+    tests build a manager over raw XML — no save/reopen needed.
+    """
+
+    def test_contiguous_same_author_date_one_group(self, temp_xml):
+        body = f"<w:p><w:r><w:t>keep </w:t></w:r>{_ins_xml(1, 'one ')}{_del_xml(2, 'two ')}{_ins_xml(3, 'three')}</w:p>"
+        manager = _make_manager(temp_xml(body))
+
+        assert manager.group_revisions(1) == (1, 2, 3)  # document order
+        by_id = {rev.id: rev for rev in manager.list_revisions()}
+        assert all(rev.group_id == 1 for rev in by_id.values())
+        assert all(rev.group_source == "inferred" for rev in by_id.values())
+        assert "group=1(inferred)" in repr(by_id[1])
+
+    def test_interleaved_author_breaks_contiguity(self, temp_xml):
+        # A,A,B,A with identical dates: same-paragraph contiguity is
+        # load-bearing — A's revisions around B's do NOT merge.
+        body = (
+            f"<w:p>{_ins_xml(1, 'a1 ')}{_ins_xml(2, 'a2 ')}"
+            f"{_ins_xml(3, 'b ', author=AUTHOR_B)}{_ins_xml(4, 'a3')}</w:p>"
+        )
+        manager = _make_manager(temp_xml(body))
+
+        assert manager._groups == {1: (1, 2), 2: (3,), 3: (4,)}
+
+    def test_same_key_different_paragraphs_two_groups(self, temp_xml):
+        # The measured paperflow partition: identical author+date in two
+        # paragraphs stays two groups.
+        body = f"<w:p>{_ins_xml(1, 'one')}</w:p><w:p>{_ins_xml(2, 'two')}</w:p>"
+        manager = _make_manager(temp_xml(body))
+
+        assert manager._groups == {1: (1,), 2: (2,)}
+
+    def test_same_paragraph_different_dates_two_groups(self, temp_xml):
+        body = f"<w:p>{_ins_xml(1, 'one ')}{_ins_xml(2, 'two', date=DATE_B)}</w:p>"
+        manager = _make_manager(temp_xml(body))
+
+        assert manager._groups == {1: (1,), 2: (2,)}
+
+    def test_missing_author_or_date_stays_ungrouped(self, temp_xml):
+        body = (
+            f"<w:p>{_ins_xml(1, 'one ')}"
+            f'<w:ins w:id="2" w:author="{AUTHOR_A}"><w:r><w:t>no date </w:t></w:r></w:ins>'
+            f'<w:ins w:id="3" w:date="{DATE_A}"><w:r><w:t>no author </w:t></w:r></w:ins>'
+            f"{_ins_xml(4, 'four')}</w:p>"
+        )
+        manager = _make_manager(temp_xml(body))
+
+        # Ungroupable elements stay unregistered AND break the run: 1 and 4
+        # do not merge across them.
+        assert manager._groups == {1: (1,), 2: (4,)}
+        by_id = {rev.id: rev for rev in manager.list_revisions()}
+        assert by_id[2].group_id is None and by_id[2].group_source is None
+        assert by_id[3].group_id is None
+        assert "group=" not in repr(by_id[2])
+
+    def test_nonconforming_ids_stay_ungrouped(self, temp_xml):
+        # Non-numeric and duplicate ids (nonconforming producers) break
+        # their runs and stay unregistered; first occurrence wins.
+        body = (
+            f"<w:p>{_ins_xml(1, 'one ')}"
+            f'<w:ins w:id="oops" w:author="{AUTHOR_A}" w:date="{DATE_A}"><w:r><w:t>bad </w:t></w:r></w:ins>'
+            f"{_ins_xml(2, 'two ')}{_ins_xml(2, 'dup ')}{_ins_xml(3, 'three')}</w:p>"
+            f"<w:p>{_ins_xml(1, 'cross-para dup ')}{_ins_xml(4, 'four')}</w:p>"
+        )
+        manager = _make_manager(temp_xml(body))
+
+        assert manager._groups == {1: (1,), 2: (2,), 3: (3,), 4: (4,)}
+
+    def test_revision_outside_paragraph_stays_ungrouped(self, temp_xml):
+        # A <w:trPr> row-mark insertion has no ancestor <w:p>.
+        body = (
+            "<w:tbl><w:tr>"
+            f'<w:trPr><w:ins w:id="7" w:author="{AUTHOR_A}" w:date="{DATE_A}"/></w:trPr>'
+            f"<w:tc><w:p>{_ins_xml(8, 'cell')}</w:p></w:tc>"
+            "</w:tr></w:tbl>"
+        )
+        manager = _make_manager(temp_xml(body))
+
+        assert manager._groups == {1: (8,)}
+        by_id = {rev.id: rev for rev in manager.list_revisions()}
+        assert by_id[7].group_id is None
+        assert by_id[8].group_id == 1
+
+    def test_live_groups_number_after_inferred(self, temp_xml):
+        body = f"<w:p>{_ins_xml(1, 'old ')}<w:r><w:t>keep it</w:t></w:r></w:p>"
+        manager = _make_manager(temp_xml(body))
+        assert manager._groups == {1: (1,)}
+
+        change_id = manager.replace_text("keep", "hold")
+
+        live_gid = manager.group_id_of(change_id)
+        assert live_gid is not None and live_gid > 1
+        # The live capture never claims the pre-registered revision.
+        assert 1 not in manager.group_revisions(live_gid)
+        by_id = {rev.id: rev for rev in manager.list_revisions()}
+        assert by_id[1].group_id == 1 and by_id[1].group_source == "inferred"
+        assert by_id[change_id].group_source == "recorded"
+        assert "(inferred)" not in repr(by_id[change_id])
+
+    def test_saved_cross_run_replace_reconstructs_one_group(self, temp_xml, frozen_clock):
+        # ISSUES.md #46 repro at unit level: one replace spanning split runs
+        # creates several revisions sharing one date; after save + fresh
+        # construction they reconstruct as ONE inferred group and
+        # accept_group applies the whole replace.
+        body = "<w:p><w:r><w:t>the quick </w:t></w:r><w:r><w:t>brown </w:t></w:r><w:r><w:t>fox jumps</w:t></w:r></w:p>"
+        xml_path = temp_xml(body)
+        manager = _make_manager(xml_path)
+        change_id = manager.replace_text("quick brown fox", "slow red cat")
+        live_gid = manager.group_id_of(change_id)
+        assert live_gid is not None
+        live_members = manager.group_revisions(live_gid)
+        assert len(live_members) > 1  # several dels + one ins
+        manager.editor.save()
+
+        reopened = _make_manager(xml_path)
+        assert len(reopened._groups) == 1
+        (gid,) = reopened._groups
+        assert set(reopened._groups[gid]) == set(live_members)
+        assert reopened.accept_group(gid) == len(live_members)
+        assert reopened.list_revisions() == []
+        xml = reopened.editor.dom.toxml()
+        assert "slow red cat" in xml and "quick brown" not in xml
+
+
+class TestGroupReconstructionAcrossReopen:
+    """Document-level save/reopen behavior of inferred groups (#46)."""
+
+    def test_reopen_reconstructs_one_group_per_edit(self, temp_docx, frozen_clock):
+        # The paperflow repro: one rewrite = several diff hunks; after
+        # reopen they must resolve as one unit, not as orphans.
+        new_text = "A slow red cat crawls beneath the energetic dog."
+        with Document.open(temp_docx) as doc:
+            ref = find_ref(doc, "quick brown fox")
+            result = doc.rewrite_paragraph(ref, new_text)
+            assert len(result.revision_ids) > 2
+            doc.save()
+
+        with Document.open(temp_docx) as doc:
+            revisions = doc.list_revisions()
+            assert len(revisions) == len(result.revision_ids)
+            gid = revisions[0].group_id
+            assert gid is not None
+            assert all(rev.group_id == gid for rev in revisions)
+            assert all(rev.group_source == "inferred" for rev in revisions)
+            doc.accept_group(gid)
+            assert _paragraph_text(doc, 1) == new_text
+            assert doc.list_revisions() == []
+
+    def test_three_edits_same_second_partition_into_three_groups(self, temp_docx, frozen_clock):
+        with Document.open(temp_docx) as doc:
+            results = doc.batch_edit([
+                EditOperation.replace("quick", "speedy", paragraph=find_ref(doc, "quick brown fox")),
+                EditOperation.delete("sample ", paragraph=find_ref(doc, "sample document for testing")),
+            ])
+            third = doc.replace("well-structured", "tidy", paragraph=find_ref(doc, "well-structured document"))
+            assert len({r.group_id for r in [*results, third]}) == 3
+            doc.save()
+
+        with Document.open(temp_docx) as doc:
+            # Same author and same (frozen) second everywhere: same-paragraph
+            # contiguity is what partitions the edits into three groups.
+            by_gid: dict[int, set[str]] = {}
+            for rev in doc.list_revisions():
+                assert rev.group_id is not None and rev.paragraph_ref is not None
+                assert rev.group_source == "inferred"
+                by_gid.setdefault(rev.group_id, set()).add(rev.paragraph_ref)
+            assert len(by_gid) == 3
+            assert all(len(paras) == 1 for paras in by_gid.values())
+            assert len(set().union(*by_gid.values())) == 3  # one paragraph each
+
+    def test_same_paragraph_same_second_over_merges(self, temp_docx, frozen_clock):
+        # Accepted relaxation, pinned: w:date has second precision, so two
+        # separate edits to the SAME paragraph in the same second are
+        # indistinguishable and reconstruct as one merged group.
+        with Document.open(temp_docx) as doc:
+            ref = find_ref(doc, "quick brown fox")
+            first = doc.replace("quick", "speedy", paragraph=ref)
+            second = doc.replace("lazy", "sleepy", paragraph=first)
+            assert first.group_id != second.group_id  # two live groups...
+            doc.save()
+
+        with Document.open(temp_docx) as doc:
+            revisions = doc.list_revisions()
+            assert len(revisions) == 4
+            gids = {rev.group_id for rev in revisions}
+            assert len(gids) == 1 and None not in gids  # ...one after reopen
+
+    def test_rump_group_after_partial_accept(self, temp_docx):
+        with Document.open(temp_docx) as doc:
+            ref = find_ref(doc, "quick brown fox")
+            doc.replace("quick", "speedy", paragraph=ref)
+            doc.save()
+
+        # A partial accept, same XML result as Word accepting one revision.
+        with Document.open(temp_docx) as doc:
+            revisions = doc.list_revisions()
+            assert len(revisions) == 2
+            assert doc.accept_revision(revisions[0].id)
+            doc.save()
+
+        with Document.open(temp_docx) as doc:
+            revisions = doc.list_revisions()
+            assert len(revisions) == 1
+            gid = revisions[0].group_id
+            assert gid is not None
+            assert revisions[0].group_source == "inferred"
+            # The rump group resolves without error.
+            assert doc.accept_group(gid) == 1
+            assert "speedy brown fox" in _paragraph_text(doc, 1)
+            assert doc.list_revisions() == []
+
+    def test_group_source_recorded_in_live_session(self, doc):
+        ref = find_ref(doc, "quick brown fox")
+        result = doc.replace("quick", "speedy", paragraph=ref)
+
+        for rev in doc.list_revisions():
+            assert rev.group_id == result.group_id
+            assert rev.group_source == "recorded"
+            assert "(inferred)" not in repr(rev)
 
 
 class TestMonotonicChangeIds:

--- a/tests/test_revision_groups.py
+++ b/tests/test_revision_groups.py
@@ -66,6 +66,26 @@ def frozen_clock(monkeypatch):
 
 
 @pytest.fixture
+def ticking_clock(monkeypatch):
+    """Every datetime.now() call lands in a NEW second.
+
+    Adversarial clock for the per-operation frozen timestamp: without
+    freezing, each attribute-injection call inside one edit would stamp
+    its own second, and reconstruction would split the edit after reopen.
+    """
+
+    class _TickingDatetime(datetime):
+        _tick = 0
+
+        @classmethod
+        def now(cls, tz=None):
+            _TickingDatetime._tick += 1
+            return cls(2025, 6, 1, 12, _TickingDatetime._tick // 60, _TickingDatetime._tick % 60, tzinfo=tz)
+
+    monkeypatch.setattr("docx_editor.xml_editor.datetime", _TickingDatetime)
+
+
+@pytest.fixture
 def doc(temp_docx):
     """An open Document over the simple.docx copy, closed after the test."""
     document = Document.open(temp_docx)
@@ -628,8 +648,10 @@ class TestGroupReconstruction:
         assert "group=" not in repr(by_id[2])
 
     def test_nonconforming_ids_stay_ungrouped(self, temp_xml):
-        # Non-numeric and duplicate ids (nonconforming producers) break
-        # their runs and stay unregistered; first occurrence wins.
+        # Non-numeric ids (nonconforming producers) break their runs, stay
+        # unregistered, and are omitted from list_revisions(). A duplicated
+        # id is wholly ungrouped — every occurrence, including the first —
+        # because id-keyed lookup cannot tell the occurrences apart.
         body = (
             f"<w:p>{_ins_xml(1, 'one ')}"
             f'<w:ins w:id="oops" w:author="{AUTHOR_A}" w:date="{DATE_A}"><w:r><w:t>bad </w:t></w:r></w:ins>'
@@ -638,7 +660,15 @@ class TestGroupReconstruction:
         )
         manager = _make_manager(temp_xml(body))
 
-        assert manager._groups == {1: (1,), 2: (2,), 3: (3,), 4: (4,)}
+        assert manager._groups == {2: (3,), 3: (4,)}
+
+        revisions = manager.list_revisions()
+        assert sorted(rev.id for rev in revisions) == [1, 1, 2, 2, 3, 4]  # "oops" omitted
+        for rev in revisions:
+            if rev.id in (1, 2):  # both occurrences of each duplicated id
+                assert rev.group_id is None and rev.group_source is None
+        by_id = {rev.id: rev for rev in revisions}
+        assert by_id[3].group_id == 2 and by_id[4].group_id == 3
 
     def test_revision_outside_paragraph_stays_ungrouped(self, temp_xml):
         # A <w:trPr> row-mark insertion has no ancestor <w:p>.
@@ -741,6 +771,27 @@ class TestGroupReconstructionAcrossReopen:
             assert len(by_gid) == 3
             assert all(len(paras) == 1 for paras in by_gid.values())
             assert len(set().union(*by_gid.values())) == 3  # one paragraph each
+
+    def test_multi_hunk_edit_straddling_seconds_stays_one_group(self, temp_docx, ticking_clock):
+        # One logical edit stamps ONE w:date even when the wall clock ticks
+        # between its internal injection calls (frozen_timestamp): without
+        # the freeze, a multi-hunk rewrite crossing a second boundary would
+        # reconstruct as several inferred groups after reopen.
+        new_text = "A slow red cat crawls beneath the energetic dog."
+        with Document.open(temp_docx) as doc:
+            ref = find_ref(doc, "quick brown fox")
+            result = doc.rewrite_paragraph(ref, new_text)
+            assert len(result.revision_ids) > 2
+            doc.save()
+
+        with Document.open(temp_docx) as doc:
+            revisions = doc.list_revisions()
+            assert len({rev.date for rev in revisions}) == 1  # one frozen stamp
+            gid = revisions[0].group_id
+            assert gid is not None
+            assert all(rev.group_id == gid for rev in revisions)
+            doc.accept_group(gid)
+            assert _paragraph_text(doc, 1) == new_text
 
     def test_same_paragraph_same_second_over_merges(self, temp_docx, frozen_clock):
         # Accepted relaxation, pinned: w:date has second precision, so two


### PR DESCRIPTION
## Summary

Group ids used to be recorded only for edits made through the open `Document`; anything already in the file (previous sessions, foreign reviewers, Word round-trips) reported `group_id=None`, so a multi-revision edit — especially a `rewrite_paragraph` — could only be resolved revision-by-revision after reopen, which garbles text when partially applied.

This implements ISSUES.md #46 (repo-local issue list, not a GitHub issue): revision groups are now **reconstructed at parse time**. `RevisionManager` construction walks all `w:ins`/`w:del` in document order (nested included) and turns maximal runs of contiguous same-paragraph revisions sharing identical raw `w:author` + `w:date` into inferred groups, so `accept_group()`/`reject_group()` resolve whole logical edits after reopen too.

## Changes

- `Revision.group_source`: `"recorded"` (edit made through this open Document) vs `"inferred"` (reconstructed); `None` iff `group_id` is `None`. Shown in `repr` as `group=N(inferred)`.
- Recorded groups continue numbering after inferred ones; registry snapshots (batch rollback) carry provenance.
- Split-off tails of own pre-session insertions are now adopted into their origin's inferred group, keeping reject/accept of that edit whole.
- Ungroupable revisions (missing author/date, outside any paragraph e.g. `w:trPr` row marks, non-numeric or duplicate ids) stay `group_id=None` and break contiguity runs.
- Known imprecisions documented and pinned by tests: same-paragraph same-second over-merge (`w:date` has second precision), nested-paragraph over-split, rump groups after Word partially resolved an edit.
- Docs updated (`docs/api.md`, `skills/docx/SKILL.md`, docstrings), including the real footgun: after reopen, group ids are renumbered from 1, so a stale id can silently resolve to a different group — always take ids from the current session.

## Tests

- Two new test classes: `TestGroupReconstruction` (unit-level over raw XML) and `TestGroupReconstructionAcrossReopen` (document-level save/reopen), with a frozen clock where same-second behavior matters.
- `test_foreign_revisions.py` pins the full expected partition (8 singleton groups) of the foreign fixture.
- Full suite: 1173 passed, 2 skipped; ruff clean; `ty check` exit 0 (7 pre-existing warnings, none introduced).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that revision group IDs are specific to the currently open document and may be renumbered after reopening.
  * Documented inferred groups for revisions loaded from previous sessions, including grouping limitations and stale-ID behavior.
  * Added guidance for using `group_source` to distinguish recorded and inferred groups.

* **Enhancements**
  * Revision data now reports how its group was derived.
  * Existing revisions can be reconstructed into groups and reviewed as a unit after reopening.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->