### PR TITLE
feat: collision-bumped w:date stamping at changeset granularity (ISSUES.md #53)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -655,12 +655,14 @@ groups are **inferred** at parse time instead
 paragraph sharing identical `w:author` + `w:date` reconstruct as one group.
 That heuristic matches this library's own edits exactly: each changeset (one
 edit call, or one whole `batch_edit`/`batch_rewrite` call) stamps a
-collision-bumped whole-second date, so two changesets by the same author never
-share a second; all ops of one batch call share one date (one changeset) and
-same-paragraph batch ops merge by design. Foreign revisions with identical
-`w:author` + `w:date` still merge (`w:date` has second precision). When Word
-already resolved part of
-a former edit, the remainder reconstructs as a smaller (rump) group, and
+collision-bumped whole-second date, so within one open session two changesets
+by the same author never share a second; all ops of one batch call share one
+date (one changeset) and same-paragraph batch ops merge by design. The
+collision counter is per-session (not seeded from dates already in the file),
+so own writes from a *previous* session merge like foreign revisions: any
+revisions with identical `w:author` + `w:date` merge (`w:date` has second
+precision). When Word already resolved part of a former edit, the remainder
+reconstructs as a smaller (rump) group, and
 `accept_group()`/`reject_group()` handle it fine. Revisions missing an author
 or date, sitting outside any paragraph (e.g. table-row markers), or sharing a
 duplicated id stay ungrouped (`group_id=None`), as does the trailing half

--- a/docs/api.md
+++ b/docs/api.md
@@ -653,9 +653,13 @@ in the `.docx` (Word has no grouping concept and strips unknown markup), so
 groups are **inferred** at parse time instead
 (`Revision.group_source == "inferred"`): contiguous revisions in the same
 paragraph sharing identical `w:author` + `w:date` reconstruct as one group.
-That heuristic almost always matches the original logical edits — one caveat:
-`w:date` has second precision, so two edits to the *same paragraph* within the
-same second merge into one inferred group. When Word already resolved part of
+That heuristic matches this library's own edits exactly: each changeset (one
+edit call, or one whole `batch_edit`/`batch_rewrite` call) stamps a
+collision-bumped whole-second date, so two changesets by the same author never
+share a second; all ops of one batch call share one date (one changeset) and
+same-paragraph batch ops merge by design. Foreign revisions with identical
+`w:author` + `w:date` still merge (`w:date` has second precision). When Word
+already resolved part of
 a former edit, the remainder reconstructs as a smaller (rump) group, and
 `accept_group()`/`reject_group()` handle it fine. Revisions missing an author
 or date, sitting outside any paragraph (e.g. table-row markers), or sharing a

--- a/docx_editor/track_changes.py
+++ b/docx_editor/track_changes.py
@@ -346,13 +346,14 @@ class Revision:
       groups created by edits through this open Document, ``"inferred"``
       for groups reconstructed at parse time by the heuristic (contiguous
       same-paragraph revisions sharing identical ``w:author`` + ``w:date``
-      are one group). Our own writes stamp collision-bumped dates (two
-      changesets by one author never share a second), so inferred groups
-      match the original changesets; same-paragraph ops of one
-      ``batch_edit``/``batch_rewrite`` call share their date and merge by
-      design. Foreign revisions with identical author + date can still
-      over-merge (``w:date`` has second precision). None iff ``group_id``
-      is None.
+      are one group). Our own writes stamp collision-bumped dates (within
+      one open session, two changesets by one author never share a
+      second), so inferred groups match the original changesets;
+      same-paragraph ops of one ``batch_edit``/``batch_rewrite`` call
+      share their date and merge by design. The counter is per-session,
+      so own writes from a previous session merge like foreign revisions:
+      identical author + date can still over-merge (``w:date`` has second
+      precision). None iff ``group_id`` is None.
     """
 
     id: int
@@ -588,11 +589,14 @@ class RevisionManager:
         Known, accepted imprecisions:
 
         - Same-paragraph over-merge is confined to one batch call for our
-          own writes: each changeset stamps a collision-bumped date (never
-          reused across an author's changesets), so only ops of a single
+          own writes within one open session: each changeset stamps a
+          collision-bumped date (never reused across an author's
+          changesets in that session), so only ops of a single
           batch_edit/batch_rewrite call — which share their date by
-          design — merge. Foreign producers stamping identical author +
-          date (w:date has second precision) can still over-merge.
+          design — merge. The counter is not seeded from dates already in
+          the file, so a previous session's own writes behave like
+          foreign ones: identical author + date (w:date has second
+          precision) can still over-merge.
         - A revision inside a nested paragraph (e.g. a text box's
           w:txbxContent) interrupts the outer paragraph's run in document
           order — conservative over-split.

--- a/docx_editor/track_changes.py
+++ b/docx_editor/track_changes.py
@@ -346,10 +346,13 @@ class Revision:
       groups created by edits through this open Document, ``"inferred"``
       for groups reconstructed at parse time by the heuristic (contiguous
       same-paragraph revisions sharing identical ``w:author`` + ``w:date``
-      are one group). Inferred groups usually match the original logical
-      edits, but two edits to the same paragraph within the same second
-      merge into one group (``w:date`` has second precision). None iff
-      ``group_id`` is None.
+      are one group). Our own writes stamp collision-bumped dates (two
+      changesets by one author never share a second), so inferred groups
+      match the original changesets; same-paragraph ops of one
+      ``batch_edit``/``batch_rewrite`` call share their date and merge by
+      design. Foreign revisions with identical author + date can still
+      over-merge (``w:date`` has second precision). None iff ``group_id``
+      is None.
     """
 
     id: int
@@ -584,9 +587,12 @@ class RevisionManager:
 
         Known, accepted imprecisions:
 
-        - Two logical edits to the same paragraph within the same second
-          (w:date has second precision) merge into one group — accepted
-          over-merge, pinned by test.
+        - Same-paragraph over-merge is confined to one batch call for our
+          own writes: each changeset stamps a collision-bumped date (never
+          reused across an author's changesets), so only ops of a single
+          batch_edit/batch_rewrite call — which share their date by
+          design — merge. Foreign producers stamping identical author +
+          date (w:date has second precision) can still over-merge.
         - A revision inside a nested paragraph (e.g. a text box's
           w:txbxContent) interrupts the outer paragraph's run in document
           order — conservative over-split.
@@ -856,7 +862,9 @@ class RevisionManager:
 
         Validates all paragraph hashes before applying any edits.
         Applies edits in reverse paragraph order so earlier paragraphs'
-        hashes remain valid throughout.
+        hashes remain valid throughout. The whole call is one changeset:
+        every op's revisions share one ``w:date``, while each op still
+        records its own revision group in-session.
 
         Args:
             operations: List of EditOperation objects (each must have paragraph set)
@@ -901,15 +909,18 @@ class RevisionManager:
 
         try:
             results = [0] * len(operations)
-            for original_idx, _ref, op in parsed:
-                try:
-                    # Each op is its own logical edit: one group per op, so
-                    # callers can accept one op and reject another.
-                    with self._grouped():
-                        change_id = self._apply_single_edit(op)
-                except (ValueError, DocxEditError) as e:
-                    raise BatchOperationError(original_idx, str(e), original=e) from e
-                results[original_idx] = change_id
+            # One batch call = one changeset: every op's revisions share one
+            # w:date (the per-op _grouped() freezes join this outer scope).
+            with self.editor.frozen_timestamp():
+                for original_idx, _ref, op in parsed:
+                    try:
+                        # Each op is its own logical edit: one group per op, so
+                        # callers can accept one op and reject another.
+                        with self._grouped():
+                            change_id = self._apply_single_edit(op)
+                    except (ValueError, DocxEditError) as e:
+                        raise BatchOperationError(original_idx, str(e), original=e) from e
+                    results[original_idx] = change_id
             return results
         except Exception:
             # Restore via the line-tracking parser so parse_position is preserved.
@@ -1053,6 +1064,9 @@ class RevisionManager:
     def batch_rewrite(self, rewrites: list[tuple[str, str]]) -> list[int | None]:
         """Rewrite multiple paragraphs with upfront hash validation.
 
+        The whole call is one changeset: all rewrites share one ``w:date``,
+        while each rewrite still records its own revision group in-session.
+
         Returns:
             One revision group id per rewrite, in input order (None for
             rewrites that created no revisions) — each rewrite gets its own
@@ -1099,13 +1113,18 @@ class RevisionManager:
         registry_snapshot = self._registry_snapshot()
 
         try:
-            # Apply rewrites in reverse paragraph order
+            # Apply rewrites in reverse paragraph order. One batch call = one
+            # changeset: all rewrites share one w:date (each rewrite still
+            # gets its own group; duplicate paragraphs are rejected above, so
+            # reconstruction keeps one group per paragraph despite the
+            # shared date).
             group_ids: list[int | None] = [None] * len(rewrites)
-            for original_idx, ref, new_text in parsed:
-                try:
-                    group_ids[original_idx] = self.rewrite_paragraph(f"P{ref.index}#{ref.hash}", new_text)
-                except (ValueError, DocxEditError) as e:
-                    raise BatchOperationError(original_idx, str(e), original=e) from e
+            with self.editor.frozen_timestamp():
+                for original_idx, ref, new_text in parsed:
+                    try:
+                        group_ids[original_idx] = self.rewrite_paragraph(f"P{ref.index}#{ref.hash}", new_text)
+                    except (ValueError, DocxEditError) as e:
+                        raise BatchOperationError(original_idx, str(e), original=e) from e
             return group_ids
         except Exception:
             # Restore via the line-tracking parser so parse_position is preserved.

--- a/docx_editor/xml_editor.py
+++ b/docx_editor/xml_editor.py
@@ -1313,8 +1313,9 @@ class DocxXMLEditor(XMLEditor):
         one edit as several groups.
 
         One changeset = one outermost ``frozen_timestamp()`` scope, stamped
-        via ``_get_next_changeset_timestamp`` (collision-bumped so two changesets
-        never share a second). Reentrant by reuse: a nested entry joins the
+        via ``_get_next_changeset_timestamp`` (collision-bumped so two
+        changesets by the same author never share a second within one open
+        session). Reentrant by reuse: a nested entry joins the
         enclosing changeset — ``batch_edit``/``batch_rewrite`` open the scope
         once for the whole call and the per-op ``_grouped()`` freezes join
         it. Only the outermost entry allocates a stamp and clears it on exit.

--- a/docx_editor/xml_editor.py
+++ b/docx_editor/xml_editor.py
@@ -1240,7 +1240,7 @@ class DocxXMLEditor(XMLEditor):
         self._tracked_change_collector: list[Element] | None = None
         self._frozen_timestamp: str | None = None
         # Last stamped (author, second) — the one collision counter behind
-        # _next_changeset_timestamp.
+        # _get_next_changeset_timestamp.
         self._last_changeset_stamp: tuple[str, datetime] | None = None
 
     def _get_next_change_id(self) -> int:
@@ -1279,7 +1279,7 @@ class DocxXMLEditor(XMLEditor):
         finally:
             self._tracked_change_collector = None
 
-    def _next_changeset_timestamp(self) -> str:
+    def _get_next_changeset_timestamp(self) -> str:
         """Whole-second UTC stamp for one changeset, collision-bumped.
 
         True wall clock, except when this editor's previous changeset by the
@@ -1288,7 +1288,10 @@ class DocxXMLEditor(XMLEditor):
         parse-time group reconstruction never merges two changesets. The
         same rule keeps stamps monotonic per author across a clock
         regression (e.g. an NTP step back): dates never go backwards,
-        pinned at previous + 1 until the clock catches up.
+        pinned at previous + 1 until the clock catches up. The counter is
+        per-editor-instance (one open session) — it is not seeded from
+        dates already persisted in the document, so uniqueness does not
+        extend across sessions.
         """
         now = datetime.now(timezone.utc).replace(microsecond=0)
         if self._last_changeset_stamp is not None:
@@ -1310,7 +1313,7 @@ class DocxXMLEditor(XMLEditor):
         one edit as several groups.
 
         One changeset = one outermost ``frozen_timestamp()`` scope, stamped
-        via ``_next_changeset_timestamp`` (collision-bumped so two changesets
+        via ``_get_next_changeset_timestamp`` (collision-bumped so two changesets
         never share a second). Reentrant by reuse: a nested entry joins the
         enclosing changeset — ``batch_edit``/``batch_rewrite`` open the scope
         once for the whole call and the per-op ``_grouped()`` freezes join
@@ -1319,7 +1322,7 @@ class DocxXMLEditor(XMLEditor):
         if self._frozen_timestamp is not None:
             yield
             return
-        self._frozen_timestamp = self._next_changeset_timestamp()
+        self._frozen_timestamp = self._get_next_changeset_timestamp()
         try:
             yield
         finally:

--- a/docx_editor/xml_editor.py
+++ b/docx_editor/xml_editor.py
@@ -12,7 +12,7 @@ import zlib
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Literal
 from xml.dom.minidom import Element
@@ -1239,6 +1239,9 @@ class DocxXMLEditor(XMLEditor):
         self._max_change_id = -1
         self._tracked_change_collector: list[Element] | None = None
         self._frozen_timestamp: str | None = None
+        # Last stamped (author, second) — the one collision counter behind
+        # _next_changeset_timestamp.
+        self._last_changeset_stamp: tuple[str, datetime] | None = None
 
     def _get_next_change_id(self) -> int:
         """Get the next available change ID by checking all tracked change elements."""
@@ -1276,6 +1279,25 @@ class DocxXMLEditor(XMLEditor):
         finally:
             self._tracked_change_collector = None
 
+    def _next_changeset_timestamp(self) -> str:
+        """Whole-second UTC stamp for one changeset, collision-bumped.
+
+        True wall clock, except when this editor's previous changeset by the
+        same author already occupies this (or a later) second — then previous
+        second + 1, keeping (author, second) unique per changeset so
+        parse-time group reconstruction never merges two changesets. The
+        same rule keeps stamps monotonic per author across a clock
+        regression (e.g. an NTP step back): dates never go backwards,
+        pinned at previous + 1 until the clock catches up.
+        """
+        now = datetime.now(timezone.utc).replace(microsecond=0)
+        if self._last_changeset_stamp is not None:
+            last_author, last_second = self._last_changeset_stamp
+            if last_author == self.author and now <= last_second:
+                now = last_second + timedelta(seconds=1)
+        self._last_changeset_stamp = (self.author, now)
+        return now.strftime("%Y-%m-%dT%H:%M:%SZ")
+
     @contextmanager
     def frozen_timestamp(self) -> Iterator[None]:
         """Stamp every element injected in this context with ONE ``w:date``.
@@ -1285,12 +1307,19 @@ class DocxXMLEditor(XMLEditor):
         several times — crossing a second boundary mid-operation would spread
         the operation's revisions across two ``w:date`` values, and parse-time
         group reconstruction (which keys on identical dates) would then reopen
-        one edit as several groups. Does not nest — same single-slot design as
-        ``collect_tracked_changes``.
+        one edit as several groups.
+
+        One changeset = one outermost ``frozen_timestamp()`` scope, stamped
+        via ``_next_changeset_timestamp`` (collision-bumped so two changesets
+        never share a second). Reentrant by reuse: a nested entry joins the
+        enclosing changeset — ``batch_edit``/``batch_rewrite`` open the scope
+        once for the whole call and the per-op ``_grouped()`` freezes join
+        it. Only the outermost entry allocates a stamp and clears it on exit.
         """
         if self._frozen_timestamp is not None:
-            raise RuntimeError("frozen_timestamp() does not nest")
-        self._frozen_timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+            yield
+            return
+        self._frozen_timestamp = self._next_changeset_timestamp()
         try:
             yield
         finally:

--- a/skills/docx/SKILL.md
+++ b/skills/docx/SKILL.md
@@ -504,8 +504,6 @@ doc.reject_group(result.group_id)   # undo the whole rewrite, or:
 # group_id from THIS session's list_revisions()/EditResult; a stale id
 # from a previous session may resolve to a different group. Own edits
 # stamp collision-bumped whole-second dates (two changesets by one author
-# from a previous session may resolve to a different group. Own edits
-# stamp collision-bumped whole-second dates (two changesets by one author
 # never share a second within one open session); all ops of one
 # batch_edit/batch_rewrite call share one date (one changeset). Revisions
 # from other sources — foreign authors, or own edits from a previous

--- a/skills/docx/SKILL.md
+++ b/skills/docx/SKILL.md
@@ -504,10 +504,13 @@ doc.reject_group(result.group_id)   # undo the whole rewrite, or:
 # group_id from THIS session's list_revisions()/EditResult; a stale id
 # from a previous session may resolve to a different group. Own edits
 # stamp collision-bumped whole-second dates (two changesets by one author
-# never share a second); all ops of one batch_edit/batch_rewrite call
-# share one date (one changeset). Foreign revisions with identical
-# author + date still merge. save() keeps groups alive (the Document
-# stays open).
+# from a previous session may resolve to a different group. Own edits
+# stamp collision-bumped whole-second dates (two changesets by one author
+# never share a second within one open session); all ops of one
+# batch_edit/batch_rewrite call share one date (one changeset). Revisions
+# from other sources — foreign authors, or own edits from a previous
+# session — still merge on identical author + date. save() keeps groups
+# alive (the Document stays open).
 # Revision ids, unlike group ids, ARE stable: they are the w:id attributes
 # stored in the document XML and survive save()/close()/reopen — resolving
 # by revision id in a later session is always safe.

--- a/skills/docx/SKILL.md
+++ b/skills/docx/SKILL.md
@@ -502,10 +502,12 @@ doc.reject_group(result.group_id)   # undo the whole rewrite, or:
 # group (r.group_source == "inferred"; session edits are "recorded"). So
 # accept_group/reject_group work after reopen too — but always take the
 # group_id from THIS session's list_revisions()/EditResult; a stale id
-# from a previous session may resolve to a different group. Caveat:
-# w:date has second precision, so two edits to the same paragraph in the
-# same second merge into one inferred group. save() keeps groups alive
-# (the Document stays open).
+# from a previous session may resolve to a different group. Own edits
+# stamp collision-bumped whole-second dates (two changesets by one author
+# never share a second); all ops of one batch_edit/batch_rewrite call
+# share one date (one changeset). Foreign revisions with identical
+# author + date still merge. save() keeps groups alive (the Document
+# stays open).
 # Revision ids, unlike group ids, ARE stable: they are the w:id attributes
 # stored in the document XML and survive save()/close()/reopen — resolving
 # by revision id in a later session is always safe.

--- a/tests/test_revision_groups.py
+++ b/tests/test_revision_groups.py
@@ -16,7 +16,7 @@ identical raw ``w:author`` + ``w:date`` are one group
 """
 
 import shutil
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -83,6 +83,26 @@ def ticking_clock(monkeypatch):
             return cls(2025, 6, 1, 12, _TickingDatetime._tick // 60, _TickingDatetime._tick % 60, tzinfo=tz)
 
     monkeypatch.setattr("docx_editor.xml_editor.datetime", _TickingDatetime)
+
+
+@pytest.fixture
+def settable_clock(monkeypatch):
+    """A clock the test drives explicitly.
+
+    ``now()`` returns whatever instant the test last assigned to the
+    class-level ``current``; assign a later value to advance time.
+    """
+
+    class _SettableDatetime(datetime):
+        current = datetime(2025, 6, 1, 12, 0, 0)
+
+        @classmethod
+        def now(cls, tz=None):
+            c = cls.current
+            return cls(c.year, c.month, c.day, c.hour, c.minute, c.second, tzinfo=tz)
+
+    monkeypatch.setattr("docx_editor.xml_editor.datetime", _SettableDatetime)
+    return _SettableDatetime
 
 
 @pytest.fixture
@@ -776,8 +796,10 @@ class TestGroupReconstructionAcrossReopen:
             doc.save()
 
         with Document.open(temp_docx) as doc:
-            # Same author and same (frozen) second everywhere: same-paragraph
-            # contiguity is what partitions the edits into three groups.
+            # Same author; the batch's ops share one date and the third
+            # (single) edit gets a collision-bumped second. All three edits
+            # land in distinct paragraphs, so same-paragraph contiguity
+            # partitions them into three groups regardless of dates.
             by_gid: dict[int, set[str]] = {}
             for rev in doc.list_revisions():
                 assert rev.group_id is not None and rev.paragraph_ref is not None
@@ -808,22 +830,27 @@ class TestGroupReconstructionAcrossReopen:
             doc.accept_group(gid)
             assert _paragraph_text(doc, 1) == new_text
 
-    def test_same_paragraph_same_second_over_merges(self, temp_docx, frozen_clock):
-        # Accepted relaxation, pinned: w:date has second precision, so two
-        # separate edits to the SAME paragraph in the same second are
-        # indistinguishable and reconstruct as one merged group.
+    def test_same_paragraph_same_second_two_groups(self, temp_docx, frozen_clock):
+        # Headline of ISSUES.md #53: two separate edits to the SAME
+        # paragraph while the wall clock sits in one second get
+        # collision-bumped dates (T and T+1), so reconstruction keeps
+        # them apart after reopen instead of over-merging.
         with Document.open(temp_docx) as doc:
             ref = find_ref(doc, "quick brown fox")
             first = doc.replace("quick", "speedy", paragraph=ref)
             second = doc.replace("lazy", "sleepy", paragraph=first)
             assert first.group_id != second.group_id  # two live groups...
+            assert {rev.date for rev in doc.list_revisions()} == {
+                datetime(2025, 6, 1, 12, 0, 0, tzinfo=timezone.utc),
+                datetime(2025, 6, 1, 12, 0, 1, tzinfo=timezone.utc),
+            }
             doc.save()
 
         with Document.open(temp_docx) as doc:
             revisions = doc.list_revisions()
             assert len(revisions) == 4
             gids = {rev.group_id for rev in revisions}
-            assert len(gids) == 1 and None not in gids  # ...one after reopen
+            assert len(gids) == 2 and None not in gids  # ...two after reopen
 
     def test_rump_group_after_partial_accept(self, temp_docx):
         with Document.open(temp_docx) as doc:
@@ -857,6 +884,140 @@ class TestGroupReconstructionAcrossReopen:
             assert rev.group_id == result.group_id
             assert rev.group_source == "recorded"
             assert "(inferred)" not in repr(rev)
+
+
+class TestChangesetDateStamping:
+    """Collision-bumped w:date stamping at changeset granularity (ISSUES.md #53).
+
+    One changeset = one single edit call or one whole batch_edit/batch_rewrite
+    call. Distinct changesets by the same author never share a second (the
+    stamp is bumped past the previous one on collision), so parse-time
+    reconstruction (#46) never merges them; all ops of one batch call share
+    one date by design.
+    """
+
+    def test_batch_ops_share_one_date(self, temp_docx, ticking_clock):
+        # Adversarial clock: every now() lands in a new second. One
+        # batch_edit call is one changeset — all its revisions must still
+        # carry ONE date, and same-paragraph ops of that one call merge
+        # into one inferred group after reopen (changeset granularity,
+        # pinned as a contract).
+        with Document.open(temp_docx) as doc:
+            ref_fox = find_ref(doc, "quick brown fox")
+            ref_sample = find_ref(doc, "sample document for testing")
+            doc.batch_edit([
+                EditOperation.replace("quick", "speedy", paragraph=ref_fox),
+                EditOperation.replace("lazy", "sleepy", paragraph=ref_fox),
+                EditOperation.delete("sample ", paragraph=ref_sample),
+            ])
+            doc.save()
+
+        with Document.open(temp_docx) as doc:
+            revisions = doc.list_revisions()
+            assert len({rev.date for rev in revisions}) == 1  # one changeset date
+            by_para: dict[str, set[int]] = {}
+            for rev in revisions:
+                assert rev.group_id is not None and rev.paragraph_ref is not None
+                by_para.setdefault(rev.paragraph_ref, set()).add(rev.group_id)
+            assert len(by_para) == 2
+            assert all(len(gids) == 1 for gids in by_para.values())
+
+    def test_batch_rewrite_shares_one_date(self, temp_docx, ticking_clock):
+        # One batch_rewrite call is one changeset: a 50-paragraph batch must
+        # not push dates 49 s into the future. Rewrites always land in
+        # distinct paragraphs (duplicates are rejected), so contiguity still
+        # reconstructs one group per paragraph despite the shared date.
+        with Document.open(temp_docx) as doc:
+            ref_fox = find_ref(doc, "quick brown fox")
+            ref_sample = find_ref(doc, "sample document for testing")
+            doc.batch_rewrite([
+                (ref_fox, "A slow red cat crawls beneath the energetic dog."),
+                (ref_sample, "Entirely different sample text."),
+            ])
+            doc.save()
+
+        with Document.open(temp_docx) as doc:
+            revisions = doc.list_revisions()
+            assert len({rev.date for rev in revisions}) == 1
+            by_para: dict[str, set[int]] = {}
+            for rev in revisions:
+                assert rev.group_id is not None and rev.paragraph_ref is not None
+                by_para.setdefault(rev.paragraph_ref, set()).add(rev.group_id)
+            assert len(by_para) == 2
+            assert all(len(gids) == 1 for gids in by_para.values())
+
+    def test_no_bump_when_seconds_differ(self, temp_docx, settable_clock):
+        # The bump only fires on collision: once real time moves past the
+        # previous stamp, the true wall clock is used, not previous+1.
+        with Document.open(temp_docx) as doc:
+            ref = find_ref(doc, "quick brown fox")
+            first = doc.replace("quick", "speedy", paragraph=ref)
+            settable_clock.current = datetime(2025, 6, 1, 12, 0, 5)
+            doc.replace("lazy", "sleepy", paragraph=first)
+            assert {rev.date for rev in doc.list_revisions()} == {
+                datetime(2025, 6, 1, 12, 0, 0, tzinfo=timezone.utc),
+                datetime(2025, 6, 1, 12, 0, 5, tzinfo=timezone.utc),
+            }
+
+    def test_drift_bounded_by_changesets_per_second(self, temp_docx, settable_clock):
+        # Drift is bounded by changesets per real second: N single edits in
+        # one second stamp T, T+1, ..., T+N-1, and the drift collapses as
+        # soon as real time passes the bumped value.
+        with Document.open(temp_docx) as doc:
+            ref = find_ref(doc, "quick brown fox")
+            first = doc.replace("quick", "speedy", paragraph=ref)
+            doc.replace("lazy", "sleepy", paragraph=first)
+            doc.delete("sample ", paragraph=find_ref(doc, "sample document for testing"))
+            settable_clock.current = datetime(2025, 6, 1, 12, 0, 10)
+            doc.replace("well-structured", "tidy", paragraph=find_ref(doc, "well-structured document"))
+            assert {rev.date for rev in doc.list_revisions()} == {
+                datetime(2025, 6, 1, 12, 0, 0, tzinfo=timezone.utc),
+                datetime(2025, 6, 1, 12, 0, 1, tzinfo=timezone.utc),
+                datetime(2025, 6, 1, 12, 0, 2, tzinfo=timezone.utc),
+                datetime(2025, 6, 1, 12, 0, 10, tzinfo=timezone.utc),
+            }
+
+    def test_two_batches_same_second_get_distinct_dates(self, temp_docx, frozen_clock):
+        # Two batch_edit calls are two changesets even inside one real
+        # second — distinct dates, two inferred groups after reopen.
+        with Document.open(temp_docx) as doc:
+            ref = find_ref(doc, "quick brown fox")
+            (first,) = doc.batch_edit([EditOperation.replace("quick", "speedy", paragraph=ref)])
+            doc.batch_edit([EditOperation.replace("lazy", "sleepy", paragraph=first)])
+            assert len({rev.date for rev in doc.list_revisions()}) == 2
+            doc.save()
+
+        with Document.open(temp_docx) as doc:
+            revisions = doc.list_revisions()
+            assert len(revisions) == 4
+            gids = {rev.group_id for rev in revisions}
+            assert len(gids) == 2 and None not in gids
+
+    def test_nested_frozen_timestamp_reuses_outer_stamp(self, temp_xml):
+        # frozen_timestamp is reentrant-by-reuse: an inner scope joins the
+        # enclosing changeset (batch wrapper + per-op _grouped). Only the
+        # outermost entry allocates a stamp; only the outermost exit clears.
+        editor = DocxXMLEditor(temp_xml("<w:p><w:r><w:t>x</w:t></w:r></w:p>"), rsid="00000000", author=AUTHOR_B)
+        with editor.frozen_timestamp():
+            outer = editor._frozen_timestamp
+            assert outer is not None
+            with editor.frozen_timestamp():
+                assert editor._frozen_timestamp == outer
+            assert editor._frozen_timestamp == outer
+        assert editor._frozen_timestamp is None
+
+    def test_w16du_dateutc_matches_bumped_date(self, temp_xml, frozen_clock):
+        # w:date and w16du:dateUtc read the same stamp variable — a bumped
+        # changeset must bump both, never just w:date.
+        manager = _make_manager(temp_xml("<w:p><w:r><w:t>alpha beta gamma</w:t></w:r></w:p>"))
+        manager.replace_text("alpha", "ALPHA")
+        manager.replace_text("gamma", "GAMMA")
+        elements = [e for tag in ("w:ins", "w:del") for e in manager.editor.dom.getElementsByTagName(tag)]
+        assert all(e.getAttribute("w16du:dateUtc") == e.getAttribute("w:date") for e in elements)
+        assert {e.getAttribute("w:date") for e in elements} == {
+            "2025-06-01T12:00:00Z",
+            "2025-06-01T12:00:01Z",
+        }
 
 
 class TestMonotonicChangeIds:

--- a/tests/test_revision_groups.py
+++ b/tests/test_revision_groups.py
@@ -890,10 +890,10 @@ class TestChangesetDateStamping:
     """Collision-bumped w:date stamping at changeset granularity (ISSUES.md #53).
 
     One changeset = one single edit call or one whole batch_edit/batch_rewrite
-    call. Distinct changesets by the same author never share a second (the
-    stamp is bumped past the previous one on collision), so parse-time
-    reconstruction (#46) never merges them; all ops of one batch call share
-    one date by design.
+    call. Within one open session, distinct changesets by the same author
+    never share a second (the stamp is bumped past the previous one on
+    collision), so parse-time reconstruction (#46) never merges them; all ops
+    of one batch call share one date by design.
     """
 
     def test_batch_ops_share_one_date(self, temp_docx, ticking_clock):
@@ -977,6 +977,20 @@ class TestChangesetDateStamping:
                 datetime(2025, 6, 1, 12, 0, 10, tzinfo=timezone.utc),
             }
 
+    def test_clock_regression_keeps_dates_monotonic(self, temp_docx, settable_clock):
+        # A clock step back (e.g. NTP) is treated as a collision: dates
+        # never go backwards, pinned at previous+1 per changeset until
+        # the clock catches up.
+        with Document.open(temp_docx) as doc:
+            ref = find_ref(doc, "quick brown fox")
+            first = doc.replace("quick", "speedy", paragraph=ref)
+            settable_clock.current = datetime(2025, 6, 1, 11, 59, 30)
+            doc.replace("lazy", "sleepy", paragraph=first)
+            assert {rev.date for rev in doc.list_revisions()} == {
+                datetime(2025, 6, 1, 12, 0, 0, tzinfo=timezone.utc),
+                datetime(2025, 6, 1, 12, 0, 1, tzinfo=timezone.utc),
+            }
+
     def test_two_batches_same_second_get_distinct_dates(self, temp_docx, frozen_clock):
         # Two batch_edit calls are two changesets even inside one real
         # second — distinct dates, two inferred groups after reopen.
@@ -997,7 +1011,7 @@ class TestChangesetDateStamping:
         # frozen_timestamp is reentrant-by-reuse: an inner scope joins the
         # enclosing changeset (batch wrapper + per-op _grouped). Only the
         # outermost entry allocates a stamp; only the outermost exit clears.
-        editor = DocxXMLEditor(temp_xml("<w:p><w:r><w:t>x</w:t></w:r></w:p>"), rsid="00000000", author=AUTHOR_B)
+        editor = _make_manager(temp_xml("<w:p><w:r><w:t>x</w:t></w:r></w:p>")).editor
         with editor.frozen_timestamp():
             outer = editor._frozen_timestamp
             assert outer is not None


### PR DESCRIPTION
## Summary

Implements ISSUES.md #53 (slimmed writer-side scope, gated on #46). One changeset — a single edit call, or one whole `batch_edit`/`batch_rewrite` call — stamps one whole-second `w:date`, collision-bumped past the previous stamp when the same author's changesets land in one real second. Parse-time group reconstruction (#46) therefore never merges two of this library's own changesets after save/reopen; same-paragraph ops of one batch call share their date and merge by design (changeset granularity, pinned as a contract).

No public API changes, no version bump.

## Changes

- **`xml_editor.py`**: new `_next_changeset_timestamp()` — true wall clock, except on collision with the editor's previous stamp by the same author, then previous+1. Monotonic per author, including across clock regressions (NTP step back). `frozen_timestamp()` becomes reentrant-by-reuse: a nested entry joins the enclosing changeset; only the outermost entry allocates/clears the stamp.
- **`track_changes.py`**: `batch_edit`/`batch_rewrite` wrap the whole call in one `frozen_timestamp()` scope — one date per batch call (the per-op `_grouped()` freezes join it), while each op keeps its own revision group in-session.
- **Tests**: new `TestChangesetDateStamping` (7 tests) pins the contract: batch ops share one date under an adversarial ticking clock, no bump when seconds genuinely differ, drift bounded by changesets-per-second and collapsing once real time catches up, two batches in one second get distinct dates, nested freeze reuses the outer stamp, `w16du:dateUtc` always matches the bumped `w:date`. The former accepted-relaxation test flips into `test_same_paragraph_same_second_two_groups`.
- **Docs**: `docs/api.md`, `skills/docx/SKILL.md`, and the `Revision.group_source` docstring updated — own edits never over-merge across changesets; foreign revisions with identical author+date still can.

## Known limitation

The collision counter is in-memory, per open Document: save/close/reopen within one real second can still stamp the same `(author, second)` and merge on the next reopen. Out of this slimmed scope (no seeding from persisted dates).

## Verification

- `uv run pytest`: 1223 passed, 2 skipped
- `uv run ruff check .` / `ruff format --check`: clean
- `uv run ty check`: exit 0 (7 pre-existing warnings in untouched test files)