### PR TITLE
perf: constant-cost batch_edit apply — seeded change ids + per-batch w:p snapshot (ISSUES.md #51)

### DIFF
--- a/benchmarks/batch_edit_scaling.py
+++ b/benchmarks/batch_edit_scaling.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Benchmark: batch_edit scaling with operation count (ISSUES.md #51).
+
+Builds a ~600-paragraph document (multi-run paragraphs, ~400 chars each) and
+measures batch_edit at increasing operation counts, apply and dry_run. Before
+the per-batch <w:p> snapshot + seeded change-id fixes, per-op cost was
+O(document size) and flat in the op count (~26 ms/op apply, ~3.5 ms/op
+dry_run at this size); after, ~1.3 ms/op apply and ~0.3 ms/op dry_run,
+falling further as the per-batch fixed cost amortizes over more ops.
+
+Usage:
+    uv run python benchmarks/batch_edit_scaling.py [--ops 1000]
+
+Timing output is informational. The script exits non-zero only on a
+correctness assertion failure (every returned ref must be valid against a
+fresh list_paragraphs() after the batch).
+"""
+
+import argparse
+import shutil
+import tempfile
+import time
+from pathlib import Path
+
+from docx_editor import Document, EditOperation
+
+TEST_DATA = Path(__file__).parent.parent / "tests" / "test_data" / "simple.docx"
+
+N_PARAGRAPHS = 600
+
+FILLER = (
+    "The committee shall review the quarterly compliance report and "
+    "record all findings in the shared register for later audit. "
+)
+
+
+def build_large_doc(n_paragraphs: int = N_PARAGRAPHS) -> tuple[Path, Path]:
+    """Build a document with many multi-run paragraphs via direct XML injection.
+
+    Each paragraph has a unique marker run plus three filler runs (~400 chars
+    total, 'committee' appears three times). Returns (docx_path, tmp_dir);
+    the caller removes tmp_dir.
+    """
+    tmp = tempfile.mkdtemp(prefix="bench_scale_")
+    dest = Path(tmp) / "bench.docx"
+    shutil.copy(TEST_DATA, dest)
+
+    doc = Document.open(dest)
+    doc.accept_all()
+    doc.save()
+    doc.close()
+
+    doc = Document.open(dest, force_recreate=True)
+    editor = doc._document_editor
+    body = editor.dom.getElementsByTagName("w:body")[0]
+
+    for p in list(editor.dom.getElementsByTagName("w:p")):
+        if p.parentNode == body:
+            body.removeChild(p)
+
+    sect_pr = editor.dom.getElementsByTagName("w:sectPr")
+    insert_before = sect_pr[0] if sect_pr else None
+
+    filler_runs = f'<w:r><w:t xml:space="preserve">{FILLER}</w:t></w:r>' * 3
+    for i in range(1, n_paragraphs + 1):
+        p_xml = f'<w:p><w:r><w:t xml:space="preserve">[P{i:04d}] </w:t></w:r>{filler_runs}</w:p>'
+        for node in editor._parse_fragment(p_xml):
+            if insert_before:
+                body.insertBefore(node, insert_before)
+            else:
+                body.appendChild(node)
+
+    editor.save()
+    save_path = doc.save()
+    doc.close()
+    return save_path, Path(tmp)
+
+
+def run_batch(persist_path: Path, n_ops: int, *, dry_run: bool) -> float:
+    """Time one batch_edit of n_ops on a fresh copy; return elapsed seconds."""
+    tmp = tempfile.mkdtemp(prefix="bench_scale_run_")
+    dest = Path(tmp) / "b.docx"
+    shutil.copy(persist_path, dest)
+    doc = Document.open(dest, force_recreate=True)
+    try:
+        refs = doc.list_paragraphs(limit=None)
+        n_paras = len(refs)
+        # Coprime stride spreads targets across the document; beyond n_paras
+        # ops it revisits paragraphs (valid: hashes are validated upfront
+        # against the pre-batch state, and each paragraph holds three
+        # 'committee' occurrences).
+        assert n_ops <= 2 * n_paras, f"at most {2 * n_paras} ops supported"
+        ops = [
+            EditOperation.replace(
+                "committee",
+                f"BOARD_{i}",
+                paragraph=refs[(i * 397) % n_paras].split("|")[0],
+                occurrence=0,
+            )
+            for i in range(n_ops)
+        ]
+
+        start = time.perf_counter()
+        if dry_run:
+            results = doc.batch_edit(ops, dry_run=True)
+            elapsed = time.perf_counter() - start
+            invalid = [r for r in results if not r.valid]
+            assert not invalid, f"dry_run flagged {len(invalid)} valid op(s) as invalid: {invalid[0].error}"
+        else:
+            results = doc.batch_edit(ops)
+            elapsed = time.perf_counter() - start
+            fresh = {entry.split("|")[0] for entry in doc.list_paragraphs(limit=None)}
+            stale = [r for r in results if str(r) not in fresh]
+            assert not stale, f"{len(stale)} returned ref(s) invalid after batch, e.g. {stale[0]}"
+        return elapsed
+    finally:
+        doc.close()
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="batch_edit scaling benchmark")
+    parser.add_argument("--ops", type=int, default=None, help="extra op count to measure (e.g. 1000)")
+    args = parser.parse_args()
+
+    op_counts = [10, 40, 120]
+    if args.ops is not None and args.ops not in op_counts:
+        op_counts.append(args.ops)
+
+    print(f"Building {N_PARAGRAPHS}-paragraph document...")
+    persist_path, tmp = build_large_doc()
+    try:
+        print()
+        print(f"{'ops':>5} | {'apply s':>8} {'ms/op':>7} | {'dry_run s':>9} {'ms/op':>7}")
+        print("-" * 46)
+        for n in op_counts:
+            apply_s = run_batch(persist_path, n, dry_run=False)
+            dry_s = run_batch(persist_path, n, dry_run=True)
+            print(f"{n:>5} | {apply_s:>8.3f} {apply_s / n * 1000:>7.2f} | {dry_s:>9.3f} {dry_s / n * 1000:>7.2f}")
+        print()
+        print("All correctness assertions passed (refs valid after each batch).")
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/batch_edit_scaling.py
+++ b/benchmarks/batch_edit_scaling.py
@@ -79,49 +79,58 @@ def build_large_doc(n_paragraphs: int = N_PARAGRAPHS) -> tuple[Path, Path]:
 def run_batch(persist_path: Path, n_ops: int, *, dry_run: bool) -> float:
     """Time one batch_edit of n_ops on a fresh copy; return elapsed seconds."""
     tmp = tempfile.mkdtemp(prefix="bench_scale_run_")
-    dest = Path(tmp) / "b.docx"
-    shutil.copy(persist_path, dest)
-    doc = Document.open(dest, force_recreate=True)
     try:
-        refs = doc.list_paragraphs(limit=None)
-        n_paras = len(refs)
-        # Coprime stride spreads targets across the document; beyond n_paras
-        # ops it revisits paragraphs (valid: hashes are validated upfront
-        # against the pre-batch state, and each paragraph holds three
-        # 'committee' occurrences).
-        assert n_ops <= 2 * n_paras, f"at most {2 * n_paras} ops supported"
-        ops = [
-            EditOperation.replace(
-                "committee",
-                f"BOARD_{i}",
-                paragraph=refs[(i * 397) % n_paras].split("|")[0],
-                occurrence=0,
-            )
-            for i in range(n_ops)
-        ]
-
-        start = time.perf_counter()
-        if dry_run:
-            results = doc.batch_edit(ops, dry_run=True)
-            elapsed = time.perf_counter() - start
-            invalid = [r for r in results if not r.valid]
-            assert not invalid, f"dry_run flagged {len(invalid)} valid op(s) as invalid: {invalid[0].error}"
-        else:
-            results = doc.batch_edit(ops)
-            elapsed = time.perf_counter() - start
-            fresh = {entry.split("|")[0] for entry in doc.list_paragraphs(limit=None)}
-            stale = [r for r in results if str(r) not in fresh]
-            assert not stale, f"{len(stale)} returned ref(s) invalid after batch, e.g. {stale[0]}"
-        return elapsed
+        dest = Path(tmp) / "b.docx"
+        shutil.copy(persist_path, dest)
+        doc = Document.open(dest, force_recreate=True)
+        try:
+            return _timed_batch(doc, n_ops, dry_run=dry_run)
+        finally:
+            doc.close()
     finally:
-        doc.close()
         shutil.rmtree(tmp, ignore_errors=True)
+
+
+def _timed_batch(doc: Document, n_ops: int, *, dry_run: bool) -> float:
+    """Build and time the batch; assert the results are correct."""
+    refs = doc.list_paragraphs(limit=None)
+    n_paras = len(refs)
+    # Coprime stride spreads targets across the document; beyond n_paras
+    # ops it revisits paragraphs (valid: hashes are validated upfront
+    # against the pre-batch state, and each paragraph holds three
+    # 'committee' occurrences).
+    assert n_ops <= 2 * n_paras, f"at most {2 * n_paras} ops supported"
+    ops = [
+        EditOperation.replace(
+            "committee",
+            f"BOARD_{i}",
+            paragraph=refs[(i * 397) % n_paras].split("|")[0],
+            occurrence=0,
+        )
+        for i in range(n_ops)
+    ]
+
+    start = time.perf_counter()
+    if dry_run:
+        results = doc.batch_edit(ops, dry_run=True)
+        elapsed = time.perf_counter() - start
+        invalid = [r for r in results if not r.valid]
+        assert not invalid, f"dry_run flagged {len(invalid)} valid op(s) as invalid: {invalid[0].error}"
+    else:
+        results = doc.batch_edit(ops)
+        elapsed = time.perf_counter() - start
+        fresh = {entry.split("|")[0] for entry in doc.list_paragraphs(limit=None)}
+        stale = [r for r in results if str(r) not in fresh]
+        assert not stale, f"{len(stale)} returned ref(s) invalid after batch, e.g. {stale[0]}"
+    return elapsed
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="batch_edit scaling benchmark")
     parser.add_argument("--ops", type=int, default=None, help="extra op count to measure (e.g. 1000)")
     args = parser.parse_args()
+    if args.ops is not None and args.ops < 1:
+        parser.error("--ops must be >= 1")
 
     op_counts = [10, 40, 120]
     if args.ops is not None and args.ops not in op_counts:

--- a/docx_editor/document.py
+++ b/docx_editor/document.py
@@ -337,17 +337,23 @@ class Document:
         self._ensure_open()
         return self._revision_manager.count_matches(text)
 
-    def _compute_new_ref(self, old_ref: str) -> str:
-        """Compute a fresh paragraph reference after mutation."""
+    def _compute_new_ref(self, old_ref: str, paragraphs: list | None = None) -> str:
+        """Compute a fresh paragraph reference after mutation.
+
+        ``paragraphs`` is an optional pre-fetched <w:p> list so batch callers
+        pay for one full-DOM walk per batch; None fetches fresh.
+        """
         ref = ParagraphRef.parse(old_ref)
-        p = self._document_editor.dom.getElementsByTagName("w:p")[ref.index - 1]
+        if paragraphs is None:
+            paragraphs = self._document_editor.dom.getElementsByTagName("w:p")
+        p = paragraphs[ref.index - 1]
         new_hash = compute_paragraph_hash(p)
         return f"P{ref.index}#{new_hash}"
 
-    def _edit_result(self, old_ref: str, group_id: int | None) -> EditResult:
+    def _edit_result(self, old_ref: str, group_id: int | None, paragraphs: list | None = None) -> EditResult:
         """Build an EditResult from a mutated paragraph's old ref and its group."""
         revision_ids = self._revision_manager.group_revisions(group_id) if group_id is not None else ()
-        return EditResult(self._compute_new_ref(old_ref), group_id=group_id, revision_ids=revision_ids)
+        return EditResult(self._compute_new_ref(old_ref, paragraphs), group_id=group_id, revision_ids=revision_ids)
 
     def paragraph_count(self) -> int:
         """Return the total number of paragraphs in the document.
@@ -1069,8 +1075,11 @@ class Document:
         if dry_run:
             return self._revision_manager.validate_batch(operations)
         change_ids = self._revision_manager.batch_edit(operations)
+        # One <w:p> walk for all result refs — batch ops never change the
+        # paragraph set, so the snapshot is valid for every op.
+        paragraphs = self._document_editor.dom.getElementsByTagName("w:p")
         return [
-            self._edit_result(op.paragraph, self._revision_manager.group_id_of(change_id))
+            self._edit_result(op.paragraph, self._revision_manager.group_id_of(change_id), paragraphs)
             for op, change_id in zip(operations, change_ids, strict=True)
         ]
 

--- a/docx_editor/document.py
+++ b/docx_editor/document.py
@@ -337,7 +337,7 @@ class Document:
         self._ensure_open()
         return self._revision_manager.count_matches(text)
 
-    def _compute_new_ref(self, old_ref: str, paragraphs: list | None = None) -> str:
+    def _compute_new_ref(self, old_ref: str, paragraphs: list[Element] | None = None) -> str:
         """Compute a fresh paragraph reference after mutation.
 
         ``paragraphs`` is an optional pre-fetched <w:p> list so batch callers
@@ -350,7 +350,7 @@ class Document:
         new_hash = compute_paragraph_hash(p)
         return f"P{ref.index}#{new_hash}"
 
-    def _edit_result(self, old_ref: str, group_id: int | None, paragraphs: list | None = None) -> EditResult:
+    def _edit_result(self, old_ref: str, group_id: int | None, paragraphs: list[Element] | None = None) -> EditResult:
         """Build an EditResult from a mutated paragraph's old ref and its group."""
         revision_ids = self._revision_manager.group_revisions(group_id) if group_id is not None else ()
         return EditResult(self._compute_new_ref(old_ref, paragraphs), group_id=group_id, revision_ids=revision_ids)
@@ -1075,6 +1075,8 @@ class Document:
         if dry_run:
             return self._revision_manager.validate_batch(operations)
         change_ids = self._revision_manager.batch_edit(operations)
+        if not change_ids:
+            return []
         # One <w:p> walk for all result refs — batch ops never change the
         # paragraph set, so the snapshot is valid for every op.
         paragraphs = self._document_editor.dom.getElementsByTagName("w:p")

--- a/docx_editor/track_changes.py
+++ b/docx_editor/track_changes.py
@@ -786,11 +786,14 @@ class RevisionManager:
             )
         return members
 
-    def _resolve_paragraph(self, ref: ParagraphRef):
+    def _resolve_paragraph(self, ref: ParagraphRef, paragraphs: list | None = None):
         """Resolve a ParagraphRef to its <w:p> element, validating the hash.
 
         Args:
             ref: Parsed paragraph reference
+            paragraphs: Optional pre-fetched list of every <w:p> element, so
+                batch callers pay for one full-DOM walk per batch instead of
+                one per operation. Default None fetches fresh.
 
         Returns:
             The <w:p> DOM element
@@ -799,7 +802,8 @@ class RevisionManager:
             ParagraphIndexError: If paragraph index is out of range
             HashMismatchError: If the hash doesn't match current content
         """
-        paragraphs = self.editor.dom.getElementsByTagName("w:p")
+        if paragraphs is None:
+            paragraphs = self.editor.dom.getElementsByTagName("w:p")
         if ref.index < 1 or ref.index > len(paragraphs):
             raise ParagraphIndexError(ref.index, len(paragraphs))
         p = paragraphs[ref.index - 1]
@@ -887,6 +891,13 @@ class RevisionManager:
         if not operations:
             return []
 
+        # One full-DOM <w:p> walk shared by the whole batch. Safe because
+        # batch ops never add, remove, or replace <w:p> elements (they only
+        # rewrite runs inside a paragraph) and minidom returns a plain
+        # non-live list. After a rollback the DOM is replaced, but the
+        # exception propagates immediately and this list is never used again.
+        paragraphs = self.editor.dom.getElementsByTagName("w:p")
+
         # Parse and validate all refs upfront
         parsed: list[tuple[int, ParagraphRef, EditOperation]] = []
         for i, op in enumerate(operations):
@@ -896,7 +907,7 @@ class RevisionManager:
                 raise BatchOperationError(i, "paragraph reference is required for batch mode")
             try:
                 ref = ParagraphRef.parse(op.paragraph)
-                self._resolve_paragraph(ref)  # Raises HashMismatchError if stale
+                self._resolve_paragraph(ref, paragraphs)  # Raises HashMismatchError if stale
             except (ValueError, DocxEditError) as e:
                 raise BatchOperationError(i, str(e), original=e) from e
             parsed.append((i, ref, op))
@@ -921,7 +932,7 @@ class RevisionManager:
                         # Each op is its own logical edit: one group per op, so
                         # callers can accept one op and reject another.
                         with self._grouped():
-                            change_id = self._apply_single_edit(op)
+                            change_id = self._apply_single_edit(op, paragraphs)
                     except (ValueError, DocxEditError) as e:
                         raise BatchOperationError(original_idx, str(e), original=e) from e
                     results[original_idx] = change_id
@@ -967,10 +978,16 @@ class RevisionManager:
         else:
             raise ValueError(f"Unknown action: {op.action}")
 
-    def _apply_single_edit(self, op: EditOperation) -> int:
-        """Apply a single edit operation. Paragraph hash was already validated."""
+    def _apply_single_edit(self, op: EditOperation, paragraphs: list | None = None) -> int:
+        """Apply a single edit operation. Paragraph hash was already validated.
+
+        ``paragraphs`` is the batch's shared <w:p> snapshot (see batch_edit);
+        None fetches fresh.
+        """
         ref = ParagraphRef.parse(op.paragraph)
-        p = self.editor.dom.getElementsByTagName("w:p")[ref.index - 1]
+        if paragraphs is None:
+            paragraphs = self.editor.dom.getElementsByTagName("w:p")
+        p = paragraphs[ref.index - 1]
 
         target = self._resolve_action_target(op)
         match = self._locate_in_paragraph(p, op.paragraph, target, op.occurrence)
@@ -1009,6 +1026,9 @@ class RevisionManager:
             that is not an EditOperation at all comes back as an invalid
             result (``paragraph=None``), never as an exception.
         """
+        # One <w:p> walk for the whole dry run — validation is read-only, so
+        # the snapshot is trivially stable (same sharing as batch_edit).
+        paragraphs = self.editor.dom.getElementsByTagName("w:p")
         results = []
         for i, op in enumerate(operations):
             if not isinstance(op, EditOperation):
@@ -1016,7 +1036,7 @@ class RevisionManager:
                     EditValidationResult(index=i, paragraph=None, valid=False, error=_not_an_edit_operation_message(op))
                 )
                 continue
-            error = self._validate_single(op)
+            error = self._validate_single(op, paragraphs)
             results.append(
                 EditValidationResult(
                     index=i,
@@ -1027,14 +1047,15 @@ class RevisionManager:
             )
         return results
 
-    def _validate_single(self, op: EditOperation) -> str | None:
+    def _validate_single(self, op: EditOperation, paragraphs: list | None = None) -> str | None:
         """Return an error message if ``op`` would fail, or None if it is valid.
 
         Reuses ``_resolve_paragraph``, ``_resolve_action_target``, and
         ``_locate_in_paragraph`` — the same helpers ``_apply_single_edit`` uses —
         so dry-run validation cannot drift from real application semantics
         (out-of-range and ambiguous targets produce the same error text).
-        Reads only.
+        Reads only. ``paragraphs`` is the dry run's shared <w:p> snapshot
+        (see validate_batch); None fetches fresh.
         """
         if not op.paragraph:
             return "paragraph reference is required for batch mode"
@@ -1045,7 +1066,7 @@ class RevisionManager:
             return str(e)
 
         try:
-            p = self._resolve_paragraph(ref)
+            p = self._resolve_paragraph(ref, paragraphs)
         except (ParagraphIndexError, HashMismatchError) as e:
             return str(e)
 

--- a/docx_editor/track_changes.py
+++ b/docx_editor/track_changes.py
@@ -786,7 +786,7 @@ class RevisionManager:
             )
         return members
 
-    def _resolve_paragraph(self, ref: ParagraphRef, paragraphs: list | None = None):
+    def _resolve_paragraph(self, ref: ParagraphRef, paragraphs: list[Element] | None = None):
         """Resolve a ParagraphRef to its <w:p> element, validating the hash.
 
         Args:
@@ -978,7 +978,7 @@ class RevisionManager:
         else:
             raise ValueError(f"Unknown action: {op.action}")
 
-    def _apply_single_edit(self, op: EditOperation, paragraphs: list | None = None) -> int:
+    def _apply_single_edit(self, op: EditOperation, paragraphs: list[Element] | None = None) -> int:
         """Apply a single edit operation. Paragraph hash was already validated.
 
         ``paragraphs`` is the batch's shared <w:p> snapshot (see batch_edit);
@@ -1026,6 +1026,8 @@ class RevisionManager:
             that is not an EditOperation at all comes back as an invalid
             result (``paragraph=None``), never as an exception.
         """
+        if not operations:
+            return []
         # One <w:p> walk for the whole dry run — validation is read-only, so
         # the snapshot is trivially stable (same sharing as batch_edit).
         paragraphs = self.editor.dom.getElementsByTagName("w:p")
@@ -1047,7 +1049,7 @@ class RevisionManager:
             )
         return results
 
-    def _validate_single(self, op: EditOperation, paragraphs: list | None = None) -> str | None:
+    def _validate_single(self, op: EditOperation, paragraphs: list[Element] | None = None) -> str | None:
         """Return an error message if ``op`` would fail, or None if it is valid.
 
         Reuses ``_resolve_paragraph``, ``_resolve_action_target``, and

--- a/docx_editor/xml_editor.py
+++ b/docx_editor/xml_editor.py
@@ -1260,6 +1260,7 @@ class DocxXMLEditor(XMLEditor):
         # operation must not let its id be reissued (id-keyed bookkeeping
         # such as revision groups would silently point at the wrong element).
         self._max_change_id = -1
+        self._change_id_seeded = False
         self._tracked_change_collector: list[Element] | None = None
         self._frozen_timestamp: str | None = None
         # Last stamped (author, second) — the one collision counter behind
@@ -1267,18 +1268,28 @@ class DocxXMLEditor(XMLEditor):
         self._last_changeset_stamp: tuple[str, datetime] | None = None
 
     def _get_next_change_id(self) -> int:
-        """Get the next available change ID by checking all tracked change elements."""
-        max_id = self._max_change_id
-        for tag in ("w:ins", "w:del"):
-            elements = self.dom.getElementsByTagName(tag)
-            for elem in elements:
-                change_id = elem.getAttribute("w:id")
-                if change_id:
-                    try:
-                        max_id = max(max_id, int(change_id))
-                    except ValueError:
-                        pass
-        self._max_change_id = max_id + 1
+        """Get the next available change ID.
+
+        The first allocation scans every <w:ins>/<w:del> in the document to
+        seed the high-water mark; every later allocation is a plain
+        increment (no full-DOM walk). Elements that arrive with a pre-set
+        w:id are folded into the mark by _inject_attributes_to_nodes, so
+        allocation can never collide with an id inserted after seeding.
+        """
+        if not self._change_id_seeded:
+            max_id = self._max_change_id
+            for tag in ("w:ins", "w:del"):
+                elements = self.dom.getElementsByTagName(tag)
+                for elem in elements:
+                    change_id = elem.getAttribute("w:id")
+                    if change_id:
+                        try:
+                            max_id = max(max_id, int(change_id))
+                        except ValueError:
+                            pass
+            self._max_change_id = max_id
+            self._change_id_seeded = True
+        self._max_change_id += 1
         return self._max_change_id
 
     @contextmanager
@@ -1435,6 +1446,14 @@ class DocxXMLEditor(XMLEditor):
             is_new = not elem.hasAttribute("w:id")
             if is_new:
                 elem.setAttribute("w:id", str(self._get_next_change_id()))
+            else:
+                # A pre-set id (raw-XML insertion) may exceed the seeded
+                # high-water mark; fold it in so later allocations can never
+                # collide with an id already present in the document.
+                try:
+                    self._max_change_id = max(self._max_change_id, int(elem.getAttribute("w:id")))
+                except ValueError:
+                    pass
             if not elem.hasAttribute("w:author"):
                 elem.setAttribute("w:author", self.author)
             if not elem.hasAttribute("w:date"):

--- a/docx_editor/xml_editor.py
+++ b/docx_editor/xml_editor.py
@@ -1267,14 +1267,44 @@ class DocxXMLEditor(XMLEditor):
         # _get_next_changeset_timestamp.
         self._last_changeset_stamp: tuple[str, datetime] | None = None
 
+    def _fold_change_id(self, raw_id: str) -> None:
+        """Raise the high-water mark to cover an id already present in the XML.
+
+        Non-numeric and empty ids are ignored: they can never be produced by
+        allocation, so they cannot collide with it.
+        """
+        try:
+            self._max_change_id = max(self._max_change_id, int(raw_id))
+        except ValueError:
+            pass
+
+    def _parse_fragment(self, xml_content: str):
+        """Parse a fragment, folding any pre-set w:ids into the high-water mark.
+
+        Every path that brings new XML into the document parses it here, so
+        folding at this choke point keeps allocation collision-free however
+        the caller attaches the parsed nodes — including direct appendChild,
+        which does not run attribute injection. Cost is O(fragment).
+        """
+        nodes = super()._parse_fragment(xml_content)
+        for node in nodes:
+            if node.nodeType != node.ELEMENT_NODE:
+                continue
+            if node.tagName in ("w:ins", "w:del"):
+                self._fold_change_id(node.getAttribute("w:id"))
+            for tag in ("w:ins", "w:del"):
+                for elem in node.getElementsByTagName(tag):
+                    self._fold_change_id(elem.getAttribute("w:id"))
+        return nodes
+
     def _get_next_change_id(self) -> int:
         """Get the next available change ID.
 
         The first allocation scans every <w:ins>/<w:del> in the document to
         seed the high-water mark; every later allocation is a plain
-        increment (no full-DOM walk). Elements that arrive with a pre-set
-        w:id are folded into the mark by _inject_attributes_to_nodes, so
-        allocation can never collide with an id inserted after seeding.
+        increment (no full-DOM walk). Ids that arrive with the XML are folded
+        into the mark by _parse_fragment (and again by attribute injection),
+        so allocation can never collide with an id added after seeding.
         """
         if not self._change_id_seeded:
             max_id = self._max_change_id
@@ -1450,10 +1480,7 @@ class DocxXMLEditor(XMLEditor):
                 # A pre-set id (raw-XML insertion) may exceed the seeded
                 # high-water mark; fold it in so later allocations can never
                 # collide with an id already present in the document.
-                try:
-                    self._max_change_id = max(self._max_change_id, int(elem.getAttribute("w:id")))
-                except ValueError:
-                    pass
+                self._fold_change_id(elem.getAttribute("w:id"))
             if not elem.hasAttribute("w:author"):
                 elem.setAttribute("w:author", self.author)
             if not elem.hasAttribute("w:date"):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import shutil
 import tempfile
 import zipfile
 from pathlib import Path
+from xml.dom import minidom
 
 import defusedxml.minidom
 import pytest
@@ -53,6 +54,24 @@ def parse_paragraph(xml: str):
     """Parse XML string and return the first w:p element."""
     doc = defusedxml.minidom.parseString(f"<root {NS}>{xml}</root>")
     return doc.getElementsByTagName("w:p")[0]
+
+
+def count_dom_walks(monkeypatch) -> list[str]:
+    """Record the tag of every full-document getElementsByTagName call.
+
+    Returns a list that grows as walks happen, so a test can pin that the
+    number of full-DOM walks stays constant in the operation count. Only
+    Document-level walks are counted; paragraph-local ones run on Elements.
+    """
+    walks: list[str] = []
+    original = minidom.Document.getElementsByTagName
+
+    def counting(self, name):
+        walks.append(name)
+        return original(self, name)
+
+    monkeypatch.setattr(minidom.Document, "getElementsByTagName", counting)
+    return walks
 
 
 @pytest.fixture

--- a/tests/test_batch_edit.py
+++ b/tests/test_batch_edit.py
@@ -5,6 +5,7 @@ import tempfile
 from pathlib import Path
 
 import pytest
+from conftest import count_dom_walks
 
 from docx_editor import (
     AmbiguousTextError,
@@ -1167,20 +1168,6 @@ class TestBatchEditFullDomWalks:
     timing-free."""
 
     @staticmethod
-    def _counting_walks(monkeypatch):
-        from xml.dom import minidom
-
-        walks = []
-        original = minidom.Document.getElementsByTagName
-
-        def counting(self, name):
-            walks.append(name)
-            return original(self, name)
-
-        monkeypatch.setattr(minidom.Document, "getElementsByTagName", counting)
-        return walks
-
-    @staticmethod
     def _replace_ops(refs, indices):
         return [
             EditOperation.replace(f"item {i + 1}", f"ITEM_{i + 1}", paragraph=refs[i].split("|")[0]) for i in indices
@@ -1193,7 +1180,7 @@ class TestBatchEditFullDomWalks:
         refs = doc.list_paragraphs()
         doc.batch_edit(self._replace_ops(refs, [9]))
 
-        walks = self._counting_walks(monkeypatch)
+        walks = count_dom_walks(monkeypatch)
 
         refs = doc.list_paragraphs()
         doc.batch_edit(self._replace_ops(refs, [0, 1, 2]))
@@ -1215,7 +1202,7 @@ class TestBatchEditFullDomWalks:
         doc, _ = multi_para_doc
         refs = doc.list_paragraphs()
 
-        walks = self._counting_walks(monkeypatch)
+        walks = count_dom_walks(monkeypatch)
 
         results = doc.batch_edit(self._replace_ops(refs, [0, 1, 2]), dry_run=True)
         assert all(r.valid for r in results)

--- a/tests/test_batch_edit.py
+++ b/tests/test_batch_edit.py
@@ -1157,3 +1157,101 @@ class TestBatchEditTrimming:
         assert results[0].group_id is None
         assert results[0].revision_ids == ()
         assert doc.list_revisions() == []
+
+
+class TestBatchEditFullDomWalks:
+    """Structural performance pin for ISSUES.md #51: the number of full-DOM
+    getElementsByTagName walks per batch is a small constant — it must not
+    grow with the operation count. Counts Document-level walks only (the
+    per-op work is paragraph-local, on Elements), so the test is exact and
+    timing-free."""
+
+    @staticmethod
+    def _counting_walks(monkeypatch):
+        from xml.dom import minidom
+
+        walks = []
+        original = minidom.Document.getElementsByTagName
+
+        def counting(self, name):
+            walks.append(name)
+            return original(self, name)
+
+        monkeypatch.setattr(minidom.Document, "getElementsByTagName", counting)
+        return walks
+
+    @staticmethod
+    def _replace_ops(refs, indices):
+        return [
+            EditOperation.replace(f"item {i + 1}", f"ITEM_{i + 1}", paragraph=refs[i].split("|")[0]) for i in indices
+        ]
+
+    def test_apply_walk_count_is_constant_in_op_count(self, multi_para_doc, monkeypatch):
+        doc, _ = multi_para_doc
+        # Warm-up batch: absorbs the one-time change-id seed scan so the two
+        # counted batches are structurally identical.
+        refs = doc.list_paragraphs()
+        doc.batch_edit(self._replace_ops(refs, [9]))
+
+        walks = self._counting_walks(monkeypatch)
+
+        refs = doc.list_paragraphs()
+        doc.batch_edit(self._replace_ops(refs, [0, 1, 2]))
+        small_batch = len(walks)
+
+        walks.clear()
+        refs = doc.list_paragraphs()
+        # 8 ops: revert the three edits above, edit five fresh paragraphs.
+        large_ops = [
+            EditOperation.replace(f"ITEM_{i + 1}", f"item {i + 1}", paragraph=refs[i].split("|")[0]) for i in (0, 1, 2)
+        ] + self._replace_ops(refs, [3, 4, 5, 6, 7])
+        doc.batch_edit(large_ops)
+        large_batch = len(walks)
+
+        assert small_batch == large_batch
+        assert small_batch <= 4
+
+    def test_dry_run_walk_count_is_constant_in_op_count(self, multi_para_doc, monkeypatch):
+        doc, _ = multi_para_doc
+        refs = doc.list_paragraphs()
+
+        walks = self._counting_walks(monkeypatch)
+
+        results = doc.batch_edit(self._replace_ops(refs, [0, 1, 2]), dry_run=True)
+        assert all(r.valid for r in results)
+        small_batch = len(walks)
+
+        walks.clear()
+        results = doc.batch_edit(self._replace_ops(refs, [0, 1, 2, 3, 4, 5, 6, 7]), dry_run=True)
+        assert all(r.valid for r in results)
+        large_batch = len(walks)
+
+        assert small_batch == large_batch
+        assert small_batch <= 2
+
+    def test_change_ids_not_reused_after_rollback(self, multi_para_doc):
+        """Ids consumed by a rolled-back batch are never reissued (id-keyed
+        bookkeeping such as revision groups must not alias old ids)."""
+        doc, _ = multi_para_doc
+        refs = doc.list_paragraphs()
+
+        first = doc.batch_edit(self._replace_ops(refs, [4]))
+        ids_before = set(first[0].revision_ids)
+        assert ids_before
+
+        # Reverse-order application: the op on P8 applies first and consumes
+        # ids, then the op on P2 fails and the whole batch rolls back.
+        refs = doc.list_paragraphs()
+        failing = [
+            EditOperation.replace("item 8", "ITEM_EIGHT", paragraph=refs[7].split("|")[0]),
+            EditOperation.replace("no such text", "x", paragraph=refs[1].split("|")[0]),
+        ]
+        with pytest.raises(BatchOperationError):
+            doc.batch_edit(failing)
+
+        after = doc.batch_edit(self._replace_ops(refs, [2]))
+        ids_after = set(after[0].revision_ids)
+        assert ids_after
+        # Strictly beyond the burned ids: with reuse, the new batch would
+        # restart at max(ids_before) + 1.
+        assert min(ids_after) > max(ids_before) + 1

--- a/tests/test_xml_editor.py
+++ b/tests/test_xml_editor.py
@@ -427,6 +427,56 @@ class TestDocxXMLEditorGetNextChangeId:
         next_id = editor._get_next_change_id()
         assert next_id == 6
 
+    def test_allocation_increments_after_seeding(self, tracked_changes_xml):
+        """Repeated allocations continue past the seeded high-water mark."""
+        editor = DocxXMLEditor(tracked_changes_xml, rsid="00AABBCC", author="Test")
+        assert editor._get_next_change_id() == 2
+        assert editor._get_next_change_id() == 3
+        assert editor._get_next_change_id() == 4
+
+    def test_second_allocation_does_no_full_dom_scan(self, tracked_changes_xml, monkeypatch):
+        """Only the first allocation scans the document; later ones increment."""
+        from xml.dom import minidom
+
+        editor = DocxXMLEditor(tracked_changes_xml, rsid="00AABBCC", author="Test")
+        assert editor._get_next_change_id() == 2  # seeds via full scan
+
+        walks = []
+        original = minidom.Document.getElementsByTagName
+
+        def counting(self, name):
+            walks.append(name)
+            return original(self, name)
+
+        monkeypatch.setattr(minidom.Document, "getElementsByTagName", counting)
+        assert editor._get_next_change_id() == 3
+        assert editor._get_next_change_id() == 4
+        assert walks == []
+
+    def test_preset_id_after_seeding_bumps_high_water_mark(self, tracked_changes_xml):
+        """Raw XML inserted with a pre-set w:id never collides with later allocations."""
+        editor = DocxXMLEditor(tracked_changes_xml, rsid="00AABBCC", author="Test")
+        assert editor._get_next_change_id() == 2  # seeds via full scan
+        body = editor.dom.getElementsByTagName("w:body")[0]
+        editor.append_to(
+            body,
+            '<w:p><w:ins w:id="100" w:author="A" w:date="2024-01-01T00:00:00Z">'
+            "<w:r><w:t>preset</w:t></w:r></w:ins></w:p>",
+        )
+        assert editor._get_next_change_id() == 101
+
+    def test_preset_non_numeric_id_ignored_by_high_water_mark(self, tracked_changes_xml):
+        """A non-numeric pre-set w:id passes through injection without affecting allocation."""
+        editor = DocxXMLEditor(tracked_changes_xml, rsid="00AABBCC", author="Test")
+        assert editor._get_next_change_id() == 2  # seeds via full scan
+        body = editor.dom.getElementsByTagName("w:body")[0]
+        editor.append_to(
+            body,
+            '<w:p><w:ins w:id="invalid" w:author="A" w:date="2024-01-01T00:00:00Z">'
+            "<w:r><w:t>x</w:t></w:r></w:ins></w:p>",
+        )
+        assert editor._get_next_change_id() == 3
+
 
 class TestDocxXMLEditorNamespaces:
     """Tests for namespace handling in DocxXMLEditor."""

--- a/tests/test_xml_editor.py
+++ b/tests/test_xml_editor.py
@@ -1,7 +1,7 @@
 """Tests for XMLEditor and DocxXMLEditor classes."""
 
 import pytest
-from conftest import parse_paragraph
+from conftest import count_dom_walks, parse_paragraph
 
 from docx_editor.exceptions import MultipleNodesFoundError, NodeNotFoundError
 from docx_editor.xml_editor import (
@@ -436,19 +436,10 @@ class TestDocxXMLEditorGetNextChangeId:
 
     def test_second_allocation_does_no_full_dom_scan(self, tracked_changes_xml, monkeypatch):
         """Only the first allocation scans the document; later ones increment."""
-        from xml.dom import minidom
-
         editor = DocxXMLEditor(tracked_changes_xml, rsid="00AABBCC", author="Test")
         assert editor._get_next_change_id() == 2  # seeds via full scan
 
-        walks = []
-        original = minidom.Document.getElementsByTagName
-
-        def counting(self, name):
-            walks.append(name)
-            return original(self, name)
-
-        monkeypatch.setattr(minidom.Document, "getElementsByTagName", counting)
+        walks = count_dom_walks(monkeypatch)
         assert editor._get_next_change_id() == 3
         assert editor._get_next_change_id() == 4
         assert walks == []
@@ -476,6 +467,20 @@ class TestDocxXMLEditorGetNextChangeId:
             "<w:r><w:t>x</w:t></w:r></w:ins></w:p>",
         )
         assert editor._get_next_change_id() == 3
+
+    def test_parse_fragment_folds_preset_id_attached_directly(self, tracked_changes_xml):
+        """Ids fold in at parse time, so attaching nodes without going through
+        the insert helpers (and therefore without attribute injection) still
+        cannot collide with a later allocation."""
+        editor = DocxXMLEditor(tracked_changes_xml, rsid="00AABBCC", author="Test")
+        assert editor._get_next_change_id() == 2  # seeds via full scan
+        body = editor.dom.getElementsByTagName("w:body")[0]
+        for node in editor._parse_fragment(
+            '<w:p><w:ins w:id="50" w:author="A" w:date="2024-01-01T00:00:00Z">'
+            "<w:r><w:t>direct</w:t></w:r></w:ins></w:p>"
+        ):
+            body.appendChild(node)
+        assert editor._get_next_change_id() == 51
 
 
 class TestDocxXMLEditorNamespaces:


### PR DESCRIPTION
## Problem

`batch_edit` paid two full-DOM walks per operation, so per-op cost scaled with
document size rather than staying flat:

- every change-id allocation rescanned every `w:ins` / `w:del` in the document
- every operation re-fetched the complete `<w:p>` list (in validation, in
  application, and again when building each `EditResult`)

At enterprise scale this dominated: a 1000-op batch extrapolated to ~70 s.

## Change

**Seeded change-id allocation** (`xml_editor.py`) — the full scan runs once per
editor instance to seed the high-water mark; later allocations are a plain
increment. Elements that arrive with a pre-set `w:id` (raw-XML insertion) are
folded into the mark by the attribute-injection guard, so allocation can never
collide with an id inserted after seeding. The monotonic no-reuse contract is
unchanged — `_max_change_id` is never lowered, including across rollback.

**Per-batch `<w:p>` snapshot** (`track_changes.py`, `document.py`) — the
paragraph list is fetched once per batch and threaded through validation,
application, and result building. This is safe because batch operations rewrite
runs *inside* a paragraph and never add, remove, or replace a `<w:p>`, and
minidom returns a plain non-live list. Rollback replaces the DOM, but the
exception propagates immediately and the snapshot is never reused. Single-op
callers pass nothing and keep the previous fetch-fresh behavior.

## Results

600-paragraph document, baseline and fixed measured back-to-back on the same
machine (`benchmarks/batch_edit_scaling.py`):

| ops | baseline apply | fixed apply | baseline dry_run | fixed dry_run |
|----:|---------------:|------------:|-----------------:|--------------:|
| 10 | 24.81 ms/op | 3.74 ms/op | 3.58 ms/op | 0.66 ms/op |
| 40 | 25.70 ms/op | 3.81 ms/op | 3.83 ms/op | 0.70 ms/op |
| 120 | 26.36 ms/op | 1.29 ms/op | 3.53 ms/op | 0.32 ms/op |

Baseline cost is flat per op — linear in ops × document size — while the fixed
version keeps improving as the per-batch fixed cost amortizes. A 1000-op batch
now completes in about a second.

## Verification

- **Differential equivalence**: the same mixed workload (foreign `<w:ins>` with
  high ids, a normal batch, a batch that rolls back, a same-paragraph multi-op
  batch, a dry run) run against a pristine pre-change tree and this branch
  produced byte-identical output — same final `document.xml`, same refs, same
  error text, and the identical `w:id` allocation sequence with no duplicates.
- **Pins are non-vacuous**: the three new structural tests fail against the
  pre-change code and pass here. They count DOM walks rather than asserting on
  timing, so they do not flake.
- Full suite 1265 passed / 2 skipped, `ruff check` clean, `ty check` exit 0
  (7 warnings, all pre-existing in unrelated test files).

## Scope

`batch_rewrite` / `accept_all` / `reject_all` keep their own per-op walks (they
get the seeded allocator for free); deferred per the plan. Refers to ISSUES.md
item #51 — not a GitHub issue number.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved batch editing and dry-run validation efficiency by reducing repeated paragraph lookups.
  - Updated tracked-change ID allocation to be monotonic and collision-safe.
- **Reliability**
  - Ensured empty/failed batches return promptly without unnecessary work.
  - Added constant DOM-walk guarantees across varying batch sizes and verified correctness of batch outputs.
  - Prevented change-ID reuse after rollback and handled pre-existing tracked-change markup safely.
- **Testing**
  - Added benchmarks and expanded tests to cover scaling, rollback, dry-run behavior, and change-ID allocation rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->