### PR TITLE
feat: changeset tier — accept/reject_changeset over whole calls (ISSUES.md #54)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -716,6 +716,51 @@ result = doc.rewrite_paragraph(ref, "New text.")
 doc.reject_group(result.group_id)  # undo the whole rewrite
 ```
 
+#### `accept_changeset(changeset_id)` / `reject_changeset(changeset_id)`
+
+Accept (or reject) every revision created by **one whole call** — the *intent*
+tier, one level above a group:
+
+```
+one call (a single edit, or an entire batch_edit / batch_rewrite)
+  = one changeset  ⊇  one-or-more groups  ⊇  revisions
+```
+
+A single edit is a one-group changeset; a whole `batch_edit`/`batch_rewrite` is
+one changeset over all the groups it created. Each returned
+[`EditResult`](#editresult) carries the `changeset_id`, and `list_revisions()`
+stamps `changeset_id`/`changeset_source` on each member revision. Accepting the
+changeset applies the entire call; rejecting it undoes the entire call,
+restoring the exact pre-call text. **There is no tier above this** — the model
+stops at three: revision < group < changeset.
+
+A changeset is the `(author, date)` **equivalence class over groups** — a
+*global* class, not a contiguous run: a `batch_edit` whose ops land in different
+paragraphs is one changeset even though its groups are non-contiguous. Edits
+made here **record** their changeset (`changeset_source == "recorded"`);
+revisions already in the file get **inferred** changesets, partitioning the
+reconstructed groups by identical `w:author` + `w:date`
+(`changeset_source == "inferred"`). Same lifetime and caveats as groups:
+changeset ids are in-memory and per-open-`Document`, renumbered on each open, so
+always take one from the current session's `EditResult` or `list_revisions()`.
+Rump-tolerant — after Word has resolved part of the changeset, the remainder
+resolves fine.
+
+**Parameters:**
+
+- `changeset_id` (int): Changeset id from an `EditResult` (or a `Revision.changeset_id`)
+
+**Returns:** Number of revisions accepted/rejected across the changeset's groups (int). Members already resolved individually are skipped (and not counted).
+
+**Raises:** [`RevisionError`](#revisionerror) if the changeset id is unknown to this open Document.
+
+**Example:**
+
+```python
+results = doc.batch_edit([...])           # one changeset over several groups
+doc.accept_changeset(results[0].changeset_id)  # accept the whole batch at once
+```
+
 #### `accept_all(author=None)`
 
 Accept all revisions.
@@ -851,6 +896,8 @@ from docx_editor import Revision
 | `text` | str | The inserted or deleted text |
 | `group_id` | int or None | Revision group this revision belongs to (see [`accept_group()`](#accept_groupgroup_id)): recorded for this session's edits, inferred by reconstruction for revisions already in the file; None only for ungroupable revisions (missing author/date, outside any paragraph, duplicated id, or a mid-session split half of a foreign insertion) |
 | `group_source` | str or None | Provenance of `group_id`: `"recorded"` (created through this open Document) or `"inferred"` (reconstructed at parse time from same-paragraph contiguity + identical author and date); None iff `group_id` is None |
+| `changeset_id` | int or None | Changeset (one whole call) this revision's group belongs to (see [`accept_changeset()`](#accept_changesetchangeset_id-reject_changesetchangeset_id)) — the `(author, date)` class over groups; None iff `group_id` is None |
+| `changeset_source` | str or None | Provenance of `changeset_id`: `"recorded"` or `"inferred"`; None iff `changeset_id` is None |
 
 ### Example
 
@@ -935,15 +982,17 @@ from docx_editor import EditResult
 | Attribute | Type | Description |
 |-----------|------|-------------|
 | `group_id` | int or None | Revision group holding every revision this edit created, for [`accept_group()`](#accept_groupgroup_id) / [`reject_group()`](#reject_groupgroup_id). None when the edit created no new revisions (e.g. text spliced into one of your own pending insertions, a no-change rewrite, or a rewrite whose changes all merged into your own pending insertions). Valid only while this Document stays open — after reopen the same revisions belong to a freshly inferred group with a new id. |
+| `changeset_id` | int or None | Changeset (one whole call) this edit's group belongs to, for [`accept_changeset()`](#accept_changesetchangeset_id-reject_changesetchangeset_id) / `reject_changeset()`. Every `EditResult` from one `batch_edit`/`batch_rewrite` shares it; None iff `group_id` is None. Per-open-`Document`, like `group_id`. |
 | `revision_ids` | tuple[int, ...] | The `w:id`s of the group's member revisions, in creation order; `()` when `group_id` is None |
 
 ### Example
 
 ```python
 result = doc.replace("30 days", "60 days", paragraph="P2#f3c1")
-print(str(result))         # "P2#c3d4" — the new paragraph ref
-print(result.group_id)     # 1
-print(result.revision_ids) # (0, 1) — the del and the ins
+print(str(result))          # "P2#c3d4" — the new paragraph ref
+print(result.group_id)      # 1
+print(result.changeset_id)  # 1 — a single edit is a one-group changeset
+print(result.revision_ids)  # (0, 1) — the del and the ins
 
 doc.replace("net", "gross", paragraph=result)  # usable as a plain ref
 doc.reject_group(result.group_id)              # undo the first edit entirely
@@ -1129,7 +1178,7 @@ except CommentError as e:
 
 ### `RevisionError`
 
-Raised when a revision operation fails — most commonly an unknown group id passed to `accept_group()` / `reject_group()`. Group ids are per-open-`Document` and renumbered on each open (recorded for this session's edits, inferred by reconstruction for revisions already in the file), so always use a group id from the current session's `EditResult` or `list_revisions()` — a stale id from a previous session may raise this, or worse, silently resolve to a different group. Structured fields: `revision_id` and `group_id` — set when the error is about that specific id (`group_id` for unknown-group errors), `None` otherwise.
+Raised when a revision operation fails — most commonly an unknown group id passed to `accept_group()` / `reject_group()`, or an unknown changeset id passed to `accept_changeset()` / `reject_changeset()`. Group and changeset ids are per-open-`Document` and renumbered on each open (recorded for this session's edits, inferred by reconstruction for revisions already in the file), so always use an id from the current session's `EditResult` or `list_revisions()` — a stale id from a previous session may raise this, or worse, silently resolve to a different group/changeset. Structured fields: `revision_id`, `group_id`, and `changeset_id` — set when the error is about that specific id (`group_id` for unknown-group errors, `changeset_id` for unknown-changeset errors), `None` otherwise.
 
 ```python
 from docx_editor.exceptions import RevisionError

--- a/docs/api.md
+++ b/docs/api.md
@@ -330,7 +330,7 @@ Words shared by `find` and `replace_with` at either end are trimmed first, so on
 - `paragraph` (str): Paragraph reference from `list_paragraphs()`, such as `P2#f3c1`
 - `occurrence` (int | None): Which occurrence within the paragraph, 0-based (0 = first). Omitted → the target must be unique within the paragraph; if it matches more than once, [`AmbiguousTextError`](#ambiguoustexterror) is raised instead of silently editing the first match.
 
-**Returns:** Updated paragraph reference ([`EditResult`](#editresult) — a `str` subclass also carrying the edit's `group_id`/`revision_ids`)
+**Returns:** Updated paragraph reference ([`EditResult`](#editresult) — a `str` subclass also carrying the edit's `group_id`/`changeset_id`/`revision_ids`)
 
 **Example:**
 
@@ -349,7 +349,7 @@ Mark text as deleted with tracked changes. Deleting text inside another author's
 - `paragraph` (str): Paragraph reference from `list_paragraphs()`, such as `P2#f3c1`
 - `occurrence` (int | None): Which occurrence within the paragraph, 0-based (0 = first). Omitted → the target must be unique within the paragraph; if it matches more than once, [`AmbiguousTextError`](#ambiguoustexterror) is raised instead of silently editing the first match.
 
-**Returns:** Updated paragraph reference ([`EditResult`](#editresult) — a `str` subclass also carrying the edit's `group_id`/`revision_ids`)
+**Returns:** Updated paragraph reference ([`EditResult`](#editresult) — a `str` subclass also carrying the edit's `group_id`/`changeset_id`/`revision_ids`)
 
 **Example:**
 
@@ -368,7 +368,7 @@ Insert text after anchor with tracked changes. An anchor inside another author's
 - `paragraph` (str): Paragraph reference from `list_paragraphs()`, such as `P2#f3c1`
 - `occurrence` (int | None): Which occurrence within the paragraph, 0-based (0 = first). Omitted → the target must be unique within the paragraph; if it matches more than once, [`AmbiguousTextError`](#ambiguoustexterror) is raised instead of silently editing the first match.
 
-**Returns:** Updated paragraph reference ([`EditResult`](#editresult) — a `str` subclass also carrying the edit's `group_id`/`revision_ids`)
+**Returns:** Updated paragraph reference ([`EditResult`](#editresult) — a `str` subclass also carrying the edit's `group_id`/`changeset_id`/`revision_ids`)
 
 **Example:**
 
@@ -387,7 +387,7 @@ Insert text before anchor with tracked changes. Foreign pending insertions are t
 - `paragraph` (str): Paragraph reference from `list_paragraphs()`, such as `P2#f3c1`
 - `occurrence` (int | None): Which occurrence within the paragraph, 0-based (0 = first). Omitted → the target must be unique within the paragraph; if it matches more than once, [`AmbiguousTextError`](#ambiguoustexterror) is raised instead of silently editing the first match.
 
-**Returns:** Updated paragraph reference ([`EditResult`](#editresult) — a `str` subclass also carrying the edit's `group_id`/`revision_ids`)
+**Returns:** Updated paragraph reference ([`EditResult`](#editresult) — a `str` subclass also carrying the edit's `group_id`/`changeset_id`/`revision_ids`)
 
 **Example:**
 
@@ -410,7 +410,7 @@ resolve them as a unit with [`accept_group()`](#accept_groupgroup_id) /
 - `ref` (str): Paragraph reference from `list_paragraphs()`
 - `new_text` (str): Desired paragraph text
 
-**Returns:** Updated paragraph reference ([`EditResult`](#editresult) — a `str` subclass also carrying the edit's `group_id`/`revision_ids`; `group_id` is `None` when `new_text` equals the current text, or when every change landed inside your own pending insertions and was merged in place)
+**Returns:** Updated paragraph reference ([`EditResult`](#editresult) — a `str` subclass also carrying the edit's `group_id`/`changeset_id`/`revision_ids`; `group_id` is `None` when `new_text` equals the current text, or when every change landed inside your own pending insertions and was merged in place)
 
 **Example:**
 
@@ -716,10 +716,10 @@ result = doc.rewrite_paragraph(ref, "New text.")
 doc.reject_group(result.group_id)  # undo the whole rewrite
 ```
 
-#### `accept_changeset(changeset_id)` / `reject_changeset(changeset_id)`
+#### `accept_changeset(changeset_id)`
 
-Accept (or reject) every revision created by **one whole call** — the *intent*
-tier, one level above a group:
+Accept every revision created by **one whole call** — the *intent* tier, one
+level above a group:
 
 ```
 one call (a single edit, or an entire batch_edit / batch_rewrite)
@@ -730,8 +730,7 @@ A single edit is a one-group changeset; a whole `batch_edit`/`batch_rewrite` is
 one changeset over all the groups it created. Each returned
 [`EditResult`](#editresult) carries the `changeset_id`, and `list_revisions()`
 stamps `changeset_id`/`changeset_source` on each member revision. Accepting the
-changeset applies the entire call; rejecting it undoes the entire call,
-restoring the exact pre-call text. **There is no tier above this** — the model
+changeset applies the entire call. **There is no tier above this** — the model
 stops at three: revision < group < changeset.
 
 A changeset is the `(author, date)` **equivalence class over groups** — a
@@ -750,7 +749,7 @@ resolves fine.
 
 - `changeset_id` (int): Changeset id from an `EditResult` (or a `Revision.changeset_id`)
 
-**Returns:** Number of revisions accepted/rejected across the changeset's groups (int). Members already resolved individually are skipped (and not counted).
+**Returns:** Number of revisions accepted across the changeset's groups (int). Members already resolved individually are skipped (and not counted).
 
 **Raises:** [`RevisionError`](#revisionerror) if the changeset id is unknown to this open Document.
 
@@ -759,6 +758,29 @@ resolves fine.
 ```python
 results = doc.batch_edit([...])           # one changeset over several groups
 doc.accept_changeset(results[0].changeset_id)  # accept the whole batch at once
+```
+
+#### `reject_changeset(changeset_id)`
+
+Reject every revision created by one whole call — the counterpart of
+[`accept_changeset()`](#accept_changesetchangeset_id). Rejecting the changeset
+undoes the entire call (every group), restoring the exact pre-call text. Same
+changeset semantics and lifetime as `accept_changeset()` — including recorded
+vs inferred changesets and per-open renumbering.
+
+**Parameters:**
+
+- `changeset_id` (int): Changeset id from an `EditResult` (or a `Revision.changeset_id`)
+
+**Returns:** Number of revisions rejected across the changeset's groups (int). Members already resolved individually are skipped (and not counted).
+
+**Raises:** [`RevisionError`](#revisionerror) if the changeset id is unknown to this open Document.
+
+**Example:**
+
+```python
+results = doc.batch_edit([...])
+doc.reject_changeset(results[0].changeset_id)  # undo the whole batch
 ```
 
 #### `accept_all(author=None)`
@@ -896,7 +918,7 @@ from docx_editor import Revision
 | `text` | str | The inserted or deleted text |
 | `group_id` | int or None | Revision group this revision belongs to (see [`accept_group()`](#accept_groupgroup_id)): recorded for this session's edits, inferred by reconstruction for revisions already in the file; None only for ungroupable revisions (missing author/date, outside any paragraph, duplicated id, or a mid-session split half of a foreign insertion) |
 | `group_source` | str or None | Provenance of `group_id`: `"recorded"` (created through this open Document) or `"inferred"` (reconstructed at parse time from same-paragraph contiguity + identical author and date); None iff `group_id` is None |
-| `changeset_id` | int or None | Changeset (one whole call) this revision's group belongs to (see [`accept_changeset()`](#accept_changesetchangeset_id-reject_changesetchangeset_id)) — the `(author, date)` class over groups; None iff `group_id` is None |
+| `changeset_id` | int or None | Changeset (one whole call) this revision's group belongs to (see [`accept_changeset()`](#accept_changesetchangeset_id) / [`reject_changeset()`](#reject_changesetchangeset_id)) — the `(author, date)` class over groups; None iff `group_id` is None |
 | `changeset_source` | str or None | Provenance of `changeset_id`: `"recorded"` or `"inferred"`; None iff `changeset_id` is None |
 
 ### Example
@@ -982,7 +1004,7 @@ from docx_editor import EditResult
 | Attribute | Type | Description |
 |-----------|------|-------------|
 | `group_id` | int or None | Revision group holding every revision this edit created, for [`accept_group()`](#accept_groupgroup_id) / [`reject_group()`](#reject_groupgroup_id). None when the edit created no new revisions (e.g. text spliced into one of your own pending insertions, a no-change rewrite, or a rewrite whose changes all merged into your own pending insertions). Valid only while this Document stays open — after reopen the same revisions belong to a freshly inferred group with a new id. |
-| `changeset_id` | int or None | Changeset (one whole call) this edit's group belongs to, for [`accept_changeset()`](#accept_changesetchangeset_id-reject_changesetchangeset_id) / `reject_changeset()`. Every `EditResult` from one `batch_edit`/`batch_rewrite` shares it; None iff `group_id` is None. Per-open-`Document`, like `group_id`. |
+| `changeset_id` | int or None | Changeset (one whole call) this edit's group belongs to, for [`accept_changeset()`](#accept_changesetchangeset_id) / [`reject_changeset()`](#reject_changesetchangeset_id). Every `EditResult` from one `batch_edit`/`batch_rewrite` shares it; None iff `group_id` is None. Per-open-`Document`, like `group_id`. |
 | `revision_ids` | tuple[int, ...] | The `w:id`s of the group's member revisions, in creation order; `()` when `group_id` is None |
 
 ### Example

--- a/docx_editor/document.py
+++ b/docx_editor/document.py
@@ -351,9 +351,15 @@ class Document:
         return f"P{ref.index}#{new_hash}"
 
     def _edit_result(self, old_ref: str, group_id: int | None, paragraphs: list[Element] | None = None) -> EditResult:
-        """Build an EditResult from a mutated paragraph's old ref and its group."""
+        """Build an EditResult from a mutated paragraph's old ref, group, and changeset."""
         revision_ids = self._revision_manager.group_revisions(group_id) if group_id is not None else ()
-        return EditResult(self._compute_new_ref(old_ref, paragraphs), group_id=group_id, revision_ids=revision_ids)
+        changeset_id = self._revision_manager.changeset_id_of(group_id) if group_id is not None else None
+        return EditResult(
+            self._compute_new_ref(old_ref, paragraphs),
+            group_id=group_id,
+            revision_ids=revision_ids,
+            changeset_id=changeset_id,
+        )
 
     def paragraph_count(self) -> int:
         """Return the total number of paragraphs in the document.
@@ -1423,6 +1429,77 @@ class Document:
         """
         self._ensure_open()
         return self._revision_manager.reject_group(group_id)
+
+    def accept_changeset(self, changeset_id: int) -> int:
+        """Accept every revision created by one whole call (a changeset).
+
+        A changeset is the intent tier — one level above a group:
+
+            one call (a single edit, or an entire batch_edit/batch_rewrite)
+            = one changeset ⊇ one-or-more groups ⊇ revisions
+
+        Accepting the changeset applies every group the call created. Its
+        ``changeset_id`` is carried by each EditResult the call returned (and
+        by every Revision's ``changeset_id``). There is no tier above this —
+        the model stops at three (revision < group < changeset).
+
+        A changeset is the ``(author, date)`` equivalence class over groups:
+        for edits made here it bundles the whole call; for revisions already
+        in the file it partitions the reconstructed groups by identical
+        author + date (``changeset_source == "inferred"``). A ``batch_edit``
+        whose ops land in different paragraphs is therefore one changeset even
+        though its groups are non-contiguous.
+
+        Changeset ids are in-memory and per-open-Document, renumbered on each
+        open, exactly like group ids — always use one from this session's
+        EditResult or list_revisions(). Rump-tolerant: after Word has already
+        resolved part of the changeset, accepting resolves whatever survives.
+
+        Args:
+            changeset_id: Changeset id from an EditResult (or a Revision's
+                ``changeset_id``)
+
+        Returns:
+            Number of revisions accepted across the changeset's groups.
+            Members already resolved individually are skipped (and not
+            counted).
+
+        Raises:
+            RevisionError: If the changeset id is unknown to this open Document.
+
+        Example:
+            results = doc.batch_edit([...])
+            doc.accept_changeset(results[0].changeset_id)  # accept the whole batch
+        """
+        self._ensure_open()
+        return self._revision_manager.accept_changeset(changeset_id)
+
+    def reject_changeset(self, changeset_id: int) -> int:
+        """Reject every revision created by one whole call (a changeset).
+
+        The counterpart of :meth:`accept_changeset` — rejecting the changeset
+        undoes the entire call (every group), restoring the exact pre-call
+        text. Same changeset semantics and lifetime as accept_changeset(),
+        including inferred changesets after reopen. No tier exists above this.
+
+        Args:
+            changeset_id: Changeset id from an EditResult (or a Revision's
+                ``changeset_id``)
+
+        Returns:
+            Number of revisions rejected across the changeset's groups.
+            Members already resolved individually are skipped (and not
+            counted).
+
+        Raises:
+            RevisionError: If the changeset id is unknown to this open Document.
+
+        Example:
+            results = doc.batch_edit([...])
+            doc.reject_changeset(results[0].changeset_id)  # undo the whole batch
+        """
+        self._ensure_open()
+        return self._revision_manager.reject_changeset(changeset_id)
 
     def accept_all(self, author: str | None = None) -> int:
         """Accept all revisions.

--- a/docx_editor/exceptions.py
+++ b/docx_editor/exceptions.py
@@ -184,6 +184,10 @@ class RevisionError(DocxEditError):
         group_id: The revision group id the operation targeted (e.g. an
             unknown group passed to ``accept_group``/``reject_group``), or
             None if the error is not about a group.
+        changeset_id: The changeset id the operation targeted (e.g. an
+            unknown changeset passed to
+            ``accept_changeset``/``reject_changeset``), or None if the error
+            is not about a changeset.
     """
 
     def __init__(
@@ -192,9 +196,11 @@ class RevisionError(DocxEditError):
         *,
         revision_id: int | None = None,
         group_id: int | None = None,
+        changeset_id: int | None = None,
     ):
         self.revision_id = revision_id
         self.group_id = group_id
+        self.changeset_id = changeset_id
         super().__init__(message)
 
 

--- a/docx_editor/track_changes.py
+++ b/docx_editor/track_changes.py
@@ -56,7 +56,7 @@ class _RegistrySnapshot:
     group_sources: dict[int, GroupSource]
     changeset_counter: int
     changesets: dict[int, tuple[int, ...]]
-    group_changesets: dict[int, int | None]
+    group_changesets: dict[int, int]
     changeset_sources: dict[int, GroupSource]
 
 
@@ -518,13 +518,6 @@ class _GroupCapture:
     group_id: int | None = None
 
 
-@dataclass
-class _ChangesetCapture:
-    """Filled in by ``RevisionManager._changeset`` when its with-block exits."""
-
-    changeset_id: int | None = None
-
-
 def _occurrence_in_text_map(tm: TextMap, elem, text: str) -> int | None:
     """0-based occurrence index of ``text`` at ``elem``'s own span in ``tm``.
 
@@ -617,7 +610,7 @@ class RevisionManager:
         # mirror the group ones exactly, one level up. Recorded changesets
         # continue this counter past the inferred ones, just as groups do.
         self._changesets: dict[int, tuple[int, ...]] = {}
-        self._group_changesets: dict[int, int | None] = {}
+        self._group_changesets: dict[int, int] = {}
         self._changeset_sources: dict[int, GroupSource] = {}
         self._changeset_counter = 1
         # Reentrancy flag for _changeset(): only the outermost boundary
@@ -793,20 +786,24 @@ class RevisionManager:
             capture.group_id = group_id
 
     @contextmanager
-    def _changeset(self) -> Iterator[_ChangesetCapture]:
+    def _changeset(self) -> Iterator[None]:
         """Bundle every group one public call creates as one changeset.
 
         The changeset is the intent tier: one whole ``batch_edit``/
         ``batch_rewrite`` call, or one single edit, contains ≥1 group.
 
         Reentrant by reuse (mirrors ``editor.frozen_timestamp``): a nested
-        entry yields a bare capture and defers to the enclosing boundary, so
-        ``batch_rewrite`` -> ``rewrite_paragraph`` merges into ONE changeset
-        while a standalone ``rewrite_paragraph`` gets its own. Only the
-        outermost entry bundles, and only on clean exit — an exception
-        propagates out of the generator at the ``yield`` before the bundling
-        code runs, so a failed batch never bundles a ghost changeset (its
-        registry is restored by ``_restore_registry`` anyway).
+        entry defers to the enclosing boundary, so ``batch_rewrite`` ->
+        ``rewrite_paragraph`` merges into ONE changeset while a standalone
+        ``rewrite_paragraph`` gets its own. Only the outermost entry bundles,
+        and only on clean exit — an exception propagates out of the generator
+        at the ``yield`` before the bundling code runs, so a failed batch never
+        bundles a ghost changeset (its registry is restored by
+        ``_restore_registry`` anyway).
+
+        Yields nothing: the bundled id is read back through
+        ``changeset_id_of(group_id)`` (via ``_edit_result``/``list_revisions``),
+        never off the context manager itself.
 
         Members are the *recorded* groups whose ids fall in
         ``[start, group_counter)`` and are not yet assigned to a changeset. A
@@ -814,14 +811,13 @@ class RevisionManager:
         allocates no new id in range) stays with that group's changeset and is
         never re-bundled.
         """
-        capture = _ChangesetCapture()
         if self._in_changeset:
-            yield capture
+            yield
             return
         self._in_changeset = True
         start = self._group_counter
         try:
-            yield capture
+            yield
         finally:
             self._in_changeset = False
         members = [
@@ -836,7 +832,6 @@ class RevisionManager:
             for gid in members:
                 self._group_changesets[gid] = changeset_id
             self._changeset_sources[changeset_id] = "recorded"
-            capture.changeset_id = changeset_id
 
     def _adopt_split_tail(self, original_ins, new_nodes) -> None:
         """Keep a split-off tail of one of our own insertions in its origin group.
@@ -917,7 +912,8 @@ class RevisionManager:
         return self._group_changesets.get(group_id)
 
     def changeset_groups(self, changeset_id: int) -> tuple[int, ...]:
-        """Member group ids of ``changeset_id``.
+        """Member group ids of ``changeset_id``, in group-creation order
+        (recorded changesets) or document order (inferred changesets).
 
         Raises:
             RevisionError: If the changeset id is unknown to this manager

--- a/docx_editor/track_changes.py
+++ b/docx_editor/track_changes.py
@@ -6,7 +6,7 @@ Provides RevisionManager for creating and managing tracked changes (insertions/d
 import difflib
 import re
 from collections import OrderedDict
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Iterable, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime
@@ -48,12 +48,16 @@ GroupSource = Literal["recorded", "inferred"]
 
 @dataclass
 class _RegistrySnapshot:
-    """Copy of the group registry, for rollback alongside a DOM snapshot."""
+    """Copy of the group + changeset registry, for rollback with a DOM snapshot."""
 
     counter: int
     groups: dict[int, tuple[int, ...]]
     revision_groups: dict[int, int | None]
     group_sources: dict[int, GroupSource]
+    changeset_counter: int
+    changesets: dict[int, tuple[int, ...]]
+    group_changesets: dict[int, int | None]
+    changeset_sources: dict[int, GroupSource]
 
 
 @dataclass
@@ -241,6 +245,13 @@ class EditResult(str):
       and renumbered on each open — after close()/reopen the same revisions
       belong to a freshly inferred group with a new id, so never carry a
       group_id across sessions (see ``Document.accept_group``).
+    - ``changeset_id``: id of the changeset (one whole call: this single
+      edit, or the entire ``batch_edit``/``batch_rewrite``) that this
+      operation's group belongs to, usable with
+      ``accept_changeset``/``reject_changeset``. One changeset contains ≥1
+      group; a single edit is a one-group changeset. None whenever
+      ``group_id`` is None. Per-open-Document and renumbered on each open,
+      exactly like ``group_id``.
     - ``revision_ids``: the w:ids of the group's member revisions, in
       creation order, as of this edit's return; ``()`` when ``group_id`` is
       None. A later edit that splits one of these insertions adds the
@@ -249,11 +260,19 @@ class EditResult(str):
     """
 
     group_id: int | None
+    changeset_id: int | None
     revision_ids: tuple[int, ...]
 
-    def __new__(cls, ref: str, group_id: int | None = None, revision_ids: tuple[int, ...] = ()) -> "EditResult":
+    def __new__(
+        cls,
+        ref: str,
+        group_id: int | None = None,
+        revision_ids: tuple[int, ...] = (),
+        changeset_id: int | None = None,
+    ) -> "EditResult":
         result = super().__new__(cls, ref)
         result.group_id = group_id
+        result.changeset_id = changeset_id
         result.revision_ids = revision_ids
         return result
 
@@ -354,6 +373,18 @@ class Revision:
       so own writes from a previous session merge like foreign revisions:
       identical author + date can still over-merge (``w:date`` has second
       precision). None iff ``group_id`` is None.
+    - ``changeset_id``: id of the changeset (one whole call — see
+      ``EditResult.changeset_id``) this revision's group belongs to,
+      resolvable with ``Document.accept_changeset``/``reject_changeset``.
+      A changeset is the ``(author, date)`` equivalence class over groups:
+      every group sharing this revision's ``w:author`` + ``w:date`` is in
+      the same changeset (recorded edits bundle one call; inferred
+      changesets partition reconstructed groups by that key). None iff
+      ``group_id`` is None.
+    - ``changeset_source``: provenance of ``changeset_id`` — ``"recorded"``
+      for changesets bundled by a call through this open Document,
+      ``"inferred"`` for changesets partitioned at parse time. None iff
+      ``changeset_id`` is None.
     """
 
     id: int
@@ -367,6 +398,8 @@ class Revision:
     contains_ids: tuple[int, ...] = ()
     group_id: int | None = None
     group_source: GroupSource | None = None
+    changeset_id: int | None = None
+    changeset_source: GroupSource | None = None
 
     def __repr__(self) -> str:
         kind = "ins" if self.type == "insertion" else "del"
@@ -376,7 +409,8 @@ class Revision:
         contains = f", contains={list(self.contains_ids)}" if self.contains_ids else ""
         inferred = "(inferred)" if self.group_source == "inferred" else ""
         group = f", group={self.group_id}{inferred}" if self.group_id is not None else ""
-        return f"Revision({kind} {self.id}{location}: '{preview}' by {self.author}{nested}{contains}{group})"
+        changeset = f", cs={self.changeset_id}" if self.changeset_id is not None else ""
+        return f"Revision({kind} {self.id}{location}: '{preview}' by {self.author}{nested}{contains}{group}{changeset})"
 
 
 def _ancestor_paragraph(elem) -> Element | None:
@@ -484,6 +518,13 @@ class _GroupCapture:
     group_id: int | None = None
 
 
+@dataclass
+class _ChangesetCapture:
+    """Filled in by ``RevisionManager._changeset`` when its with-block exits."""
+
+    changeset_id: int | None = None
+
+
 def _occurrence_in_text_map(tm: TextMap, elem, text: str) -> int | None:
     """0-based occurrence index of ``text`` at ``elem``'s own span in ``tm``.
 
@@ -571,6 +612,18 @@ class RevisionManager:
         # Maps group id -> provenance ("recorded" | "inferred").
         self._group_sources: dict[int, GroupSource] = {}
         self._group_counter = 1
+        # Changeset tier (one whole call ⊇ ≥1 group). A changeset is the
+        # (author, date) equivalence class over groups; these registries
+        # mirror the group ones exactly, one level up. Recorded changesets
+        # continue this counter past the inferred ones, just as groups do.
+        self._changesets: dict[int, tuple[int, ...]] = {}
+        self._group_changesets: dict[int, int | None] = {}
+        self._changeset_sources: dict[int, GroupSource] = {}
+        self._changeset_counter = 1
+        # Reentrancy flag for _changeset(): only the outermost boundary
+        # bundles, so batch_rewrite -> rewrite_paragraph merges into one
+        # changeset (mirrors editor.frozen_timestamp's reuse guard).
+        self._in_changeset = False
         self._reconstruct_groups()
 
     def _reconstruct_groups(self) -> None:
@@ -617,6 +670,10 @@ class RevisionManager:
         """
         run_key: tuple[int, str, str] | None = None
         run_members: list[int] = []
+        # (author, date) -> changeset id, for the inferred changeset tier.
+        # Groups anywhere in the document sharing an (author, date) join one
+        # changeset — a global equivalence class, not a contiguous run.
+        changeset_by_key: dict[tuple[str, str], int] = {}
 
         def close_run() -> None:
             nonlocal run_members
@@ -627,6 +684,21 @@ class RevisionManager:
                 for rev_id in run_members:
                     self._revision_groups[rev_id] = group_id
                 self._group_sources[group_id] = "inferred"
+                # run_members non-empty guarantees run_key is set (members are
+                # only appended after run_key becomes non-None). Its author+date
+                # are the group's; drop the paragraph identity so groups in
+                # different paragraphs still share one changeset.
+                assert run_key is not None
+                _, author, date = run_key
+                cs_key = (author, date)
+                cs_id = changeset_by_key.get(cs_key)
+                if cs_id is None:
+                    cs_id = self._changeset_counter
+                    self._changeset_counter += 1
+                    changeset_by_key[cs_key] = cs_id
+                    self._changeset_sources[cs_id] = "inferred"
+                self._changesets[cs_id] = (*self._changesets.get(cs_id, ()), group_id)
+                self._group_changesets[group_id] = cs_id
                 run_members = []
 
         elements = _revision_elements(self.editor.dom.documentElement)
@@ -720,6 +792,52 @@ class RevisionManager:
             self._group_sources[group_id] = "recorded"
             capture.group_id = group_id
 
+    @contextmanager
+    def _changeset(self) -> Iterator[_ChangesetCapture]:
+        """Bundle every group one public call creates as one changeset.
+
+        The changeset is the intent tier: one whole ``batch_edit``/
+        ``batch_rewrite`` call, or one single edit, contains ≥1 group.
+
+        Reentrant by reuse (mirrors ``editor.frozen_timestamp``): a nested
+        entry yields a bare capture and defers to the enclosing boundary, so
+        ``batch_rewrite`` -> ``rewrite_paragraph`` merges into ONE changeset
+        while a standalone ``rewrite_paragraph`` gets its own. Only the
+        outermost entry bundles, and only on clean exit — an exception
+        propagates out of the generator at the ``yield`` before the bundling
+        code runs, so a failed batch never bundles a ghost changeset (its
+        registry is restored by ``_restore_registry`` anyway).
+
+        Members are the *recorded* groups whose ids fall in
+        ``[start, group_counter)`` and are not yet assigned to a changeset. A
+        split tail adopted into an existing group's id (``_adopt_split_tail``
+        allocates no new id in range) stays with that group's changeset and is
+        never re-bundled.
+        """
+        capture = _ChangesetCapture()
+        if self._in_changeset:
+            yield capture
+            return
+        self._in_changeset = True
+        start = self._group_counter
+        try:
+            yield capture
+        finally:
+            self._in_changeset = False
+        members = [
+            gid
+            for gid in range(start, self._group_counter)
+            if gid in self._groups and self._group_sources.get(gid) == "recorded" and gid not in self._group_changesets
+        ]
+        if members:
+            changeset_id = self._changeset_counter
+            self._changeset_counter += 1
+            self._changesets[changeset_id] = tuple(members)
+            for gid in members:
+                self._group_changesets[gid] = changeset_id
+            self._changeset_sources[changeset_id] = "recorded"
+            capture.changeset_id = changeset_id
+
     def _adopt_split_tail(self, original_ins, new_nodes) -> None:
         """Keep a split-off tail of one of our own insertions in its origin group.
 
@@ -748,20 +866,28 @@ class RevisionManager:
                     self._groups[origin_group] = (*self._groups[origin_group], tail_id)
 
     def _registry_snapshot(self) -> _RegistrySnapshot:
-        """Snapshot the group registry for rollback alongside a DOM snapshot."""
+        """Snapshot the group + changeset registry for rollback with a DOM snapshot."""
         return _RegistrySnapshot(
             counter=self._group_counter,
             groups=dict(self._groups),
             revision_groups=dict(self._revision_groups),
             group_sources=dict(self._group_sources),
+            changeset_counter=self._changeset_counter,
+            changesets=dict(self._changesets),
+            group_changesets=dict(self._group_changesets),
+            changeset_sources=dict(self._changeset_sources),
         )
 
     def _restore_registry(self, snapshot: _RegistrySnapshot) -> None:
-        """Restore the group registry captured by ``_registry_snapshot``."""
+        """Restore the group + changeset registry captured by ``_registry_snapshot``."""
         self._group_counter = snapshot.counter
         self._groups = snapshot.groups
         self._revision_groups = snapshot.revision_groups
         self._group_sources = snapshot.group_sources
+        self._changeset_counter = snapshot.changeset_counter
+        self._changesets = snapshot.changesets
+        self._group_changesets = snapshot.group_changesets
+        self._changeset_sources = snapshot.changeset_sources
 
     def group_id_of(self, revision_id: int) -> int | None:
         """Group id of a revision (recorded or inferred), or None if ungrouped."""
@@ -783,6 +909,29 @@ class RevisionManager:
                 f"reconstruction for revisions already in the file); use a group_id from "
                 f"this session's EditResult or list_revisions().",
                 group_id=group_id,
+            )
+        return members
+
+    def changeset_id_of(self, group_id: int) -> int | None:
+        """Changeset id of a group (recorded or inferred), or None if unassigned."""
+        return self._group_changesets.get(group_id)
+
+    def changeset_groups(self, changeset_id: int) -> tuple[int, ...]:
+        """Member group ids of ``changeset_id``.
+
+        Raises:
+            RevisionError: If the changeset id is unknown to this manager
+                (changeset ids are per-open-Document and renumbered on each
+                open, exactly like group ids).
+        """
+        members = self._changesets.get(changeset_id)
+        if members is None:
+            raise RevisionError(
+                f"Unknown changeset: {changeset_id}. Changeset ids are per-open-Document and "
+                f"renumbered on each open (recorded for this session's calls, inferred by "
+                f"reconstruction for revisions already in the file); use a changeset_id from "
+                f"this session's EditResult or list_revisions().",
+                changeset_id=changeset_id,
             )
         return members
 
@@ -925,8 +1074,11 @@ class RevisionManager:
         try:
             results = [0] * len(operations)
             # One batch call = one changeset: every op's revisions share one
-            # w:date (the per-op _grouped() freezes join this outer scope).
-            with self.editor.frozen_timestamp():
+            # w:date (the per-op _grouped() freezes join this outer scope) and
+            # every op's group bundles into that one changeset. Inside the try
+            # so a failed op never bundles a changeset (the generator raises at
+            # its yield before bundling) and rollback restores the registry.
+            with self._changeset(), self.editor.frozen_timestamp():
                 for original_idx, _ref, op in parsed:
                     try:
                         # Each op is its own logical edit: one group per op, so
@@ -1146,9 +1298,12 @@ class RevisionManager:
             # reconstruction keeps one group per paragraph despite the
             # shared date).
             group_ids: list[int | None] = [None] * len(rewrites)
-            with self.editor.frozen_timestamp():
+            with self._changeset(), self.editor.frozen_timestamp():
                 for original_idx, ref, new_text in parsed:
                     try:
+                        # The inner rewrite_paragraph's own _changeset() becomes
+                        # a no-op (reentrancy guard), so the whole call is one
+                        # changeset with one group per rewrite.
                         group_ids[original_idx] = self.rewrite_paragraph(f"P{ref.index}#{ref.hash}", new_text)
                     except (ValueError, DocxEditError) as e:
                         raise BatchOperationError(original_idx, str(e), original=e) from e
@@ -1192,7 +1347,7 @@ class RevisionManager:
                 f"rewrite_paragraph(): 'new_text' must be a string "
                 f"(empty string is allowed — it deletes all text), got {new_text!r}"
             )
-        with self._grouped() as capture:
+        with self._changeset(), self._grouped() as capture:
             self._rewrite_paragraph_inner(ref_str, new_text)
         return capture.group_id
 
@@ -1588,7 +1743,7 @@ class RevisionManager:
         """
         if not isinstance(replace_with, str):
             raise ValueError(f"'replace_with' must be a string (empty string is allowed), got {replace_with!r}")
-        with self._grouped():
+        with self._changeset(), self._grouped():
             if paragraph is not None:
                 ref = ParagraphRef.parse(paragraph)
                 p = self._resolve_paragraph(ref)
@@ -1619,7 +1774,7 @@ class RevisionManager:
                 matches more than once in the search scope
             HashMismatchError: If the paragraph hash doesn't match
         """
-        with self._grouped():
+        with self._changeset(), self._grouped():
             if paragraph is not None:
                 ref = ParagraphRef.parse(paragraph)
                 p = self._resolve_paragraph(ref)
@@ -2542,7 +2697,7 @@ class RevisionManager:
         """Insert text before or after anchor with tracked changes."""
         if not isinstance(text, str):
             raise ValueError(f"'text' must be a string (empty string is allowed), got {text!r}")
-        with self._grouped():
+        with self._changeset(), self._grouped():
             if paragraph is not None:
                 ref = ParagraphRef.parse(paragraph)
                 p = self._resolve_paragraph(ref)
@@ -2764,6 +2919,7 @@ class RevisionManager:
                     occurrence = _occurrence_in_text_map(ctx.text_map(paragraph, view), elem, text)
 
         group_id = self._revision_groups.get(rev_id_int)
+        changeset_id = self.changeset_id_of(group_id) if group_id is not None else None
         return Revision(
             id=rev_id_int,
             type=rev_type,
@@ -2776,6 +2932,8 @@ class RevisionManager:
             contains_ids=_descendant_revision_ids(elem),
             group_id=group_id,
             group_source=self._group_sources.get(group_id) if group_id is not None else None,
+            changeset_id=changeset_id,
+            changeset_source=self._changeset_sources.get(changeset_id) if changeset_id is not None else None,
         )
 
     def accept_revision(self, revision_id: int) -> bool:
@@ -2836,15 +2994,16 @@ class RevisionManager:
 
         return False
 
-    def _resolve_group(self, group_id: int, resolve: Callable[[int], bool]) -> int:
-        """Apply ``resolve`` (accept/reject_revision) to every member of a group.
+    def _resolve_ids(self, members: Iterable[int], resolve: Callable[[int], bool]) -> int:
+        """Apply ``resolve`` (accept/reject_revision) to every id in ``members``.
 
         Same reverse-id, loop-until-no-progress pattern as accept_all/
-        reject_all, restricted to the group's members: nested members become
+        reject_all, restricted to ``members``: nested members become
         resolvable once their host is processed, and members already resolved
-        individually are simply skipped.
+        individually are simply skipped. Shared by group and changeset
+        resolution (a changeset passes the union of its groups' revisions).
         """
-        members = self.group_revisions(group_id)
+        members = list(members)
         count = 0
         while True:
             progressed = False
@@ -2854,6 +3013,20 @@ class RevisionManager:
                     progressed = True
             if not progressed:
                 return count
+
+    def _resolve_group(self, group_id: int, resolve: Callable[[int], bool]) -> int:
+        """Apply ``resolve`` to every member revision of a group."""
+        return self._resolve_ids(self.group_revisions(group_id), resolve)
+
+    def _resolve_changeset(self, changeset_id: int, resolve: Callable[[int], bool]) -> int:
+        """Apply ``resolve`` to every revision across all groups of a changeset.
+
+        A revision belongs to exactly one group, so the changeset's groups
+        never share a member — the flattened list has no duplicates, and
+        ``_resolve_ids`` would tolerate any anyway (a re-resolve returns False).
+        """
+        revision_ids = [rev_id for group_id in self.changeset_groups(changeset_id) for rev_id in self._groups[group_id]]
+        return self._resolve_ids(revision_ids, resolve)
 
     def accept_group(self, group_id: int) -> int:
         """Accept every revision in a revision group.
@@ -2886,6 +3059,38 @@ class RevisionManager:
             RevisionError: If the group id is unknown to this manager.
         """
         return self._resolve_group(group_id, self.reject_revision)
+
+    def accept_changeset(self, changeset_id: int) -> int:
+        """Accept every revision in a changeset (one whole call's groups).
+
+        Args:
+            changeset_id: Changeset id from an edit's :class:`EditResult` (or
+                a Revision's ``changeset_id``).
+
+        Returns:
+            Number of revisions accepted across the changeset's groups.
+            Members already resolved individually are skipped (rump-tolerant).
+
+        Raises:
+            RevisionError: If the changeset id is unknown to this manager.
+        """
+        return self._resolve_changeset(changeset_id, self.accept_revision)
+
+    def reject_changeset(self, changeset_id: int) -> int:
+        """Reject every revision in a changeset (one whole call's groups).
+
+        Args:
+            changeset_id: Changeset id from an edit's :class:`EditResult` (or
+                a Revision's ``changeset_id``).
+
+        Returns:
+            Number of revisions rejected across the changeset's groups.
+            Members already resolved individually are skipped (rump-tolerant).
+
+        Raises:
+            RevisionError: If the changeset id is unknown to this manager.
+        """
+        return self._resolve_changeset(changeset_id, self.reject_revision)
 
     def accept_all(self, author: str | None = None) -> int:
         """Accept all revisions, optionally filtered by author.

--- a/tests/test_foreign_revisions.py
+++ b/tests/test_foreign_revisions.py
@@ -39,7 +39,10 @@ from docx_editor import Document, Revision
 # identical text in the same paragraph — type + occurrence (in each type's own
 # view) is what tells them apart. Every revision differs from its document-
 # order neighbor by paragraph, author, or date, so group reconstruction
-# infers eight singleton groups, numbered 1-8 in document order.
+# infers eight singleton groups, numbered 1-8 in document order. Every
+# revision also has a distinct (author, date) pair, so the changeset tier
+# partitions them into eight singleton inferred changesets — changeset_id
+# equals group_id here (1-8), each changeset_source "inferred".
 EXPECTED_REVISIONS = [
     Revision(
         id=1001,
@@ -51,6 +54,8 @@ EXPECTED_REVISIONS = [
         occurrence=0,
         group_id=1,
         group_source="inferred",
+        changeset_id=1,
+        changeset_source="inferred",
     ),
     Revision(
         id=1002,
@@ -62,6 +67,8 @@ EXPECTED_REVISIONS = [
         occurrence=0,
         group_id=2,
         group_source="inferred",
+        changeset_id=2,
+        changeset_source="inferred",
     ),
     Revision(
         id=1003,
@@ -73,6 +80,8 @@ EXPECTED_REVISIONS = [
         occurrence=0,
         group_id=3,
         group_source="inferred",
+        changeset_id=3,
+        changeset_source="inferred",
     ),
     Revision(
         id=1004,
@@ -84,6 +93,8 @@ EXPECTED_REVISIONS = [
         occurrence=0,
         group_id=4,
         group_source="inferred",
+        changeset_id=4,
+        changeset_source="inferred",
     ),
     Revision(
         id=1005,
@@ -95,6 +106,8 @@ EXPECTED_REVISIONS = [
         occurrence=0,
         group_id=5,
         group_source="inferred",
+        changeset_id=5,
+        changeset_source="inferred",
     ),
     Revision(
         id=1006,
@@ -106,6 +119,8 @@ EXPECTED_REVISIONS = [
         occurrence=0,
         group_id=6,
         group_source="inferred",
+        changeset_id=6,
+        changeset_source="inferred",
     ),
     Revision(
         id=1007,
@@ -117,6 +132,8 @@ EXPECTED_REVISIONS = [
         occurrence=0,
         group_id=7,
         group_source="inferred",
+        changeset_id=7,
+        changeset_source="inferred",
     ),
     Revision(
         id=1008,
@@ -128,6 +145,8 @@ EXPECTED_REVISIONS = [
         occurrence=0,
         group_id=8,
         group_source="inferred",
+        changeset_id=8,
+        changeset_source="inferred",
     ),
 ]
 

--- a/tests/test_revision_groups.py
+++ b/tests/test_revision_groups.py
@@ -1068,3 +1068,275 @@ class TestMonotonicChangeIds:
             with manager._grouped():
                 with manager._grouped():
                     pass  # pragma: no cover
+
+
+class TestChangesetTier:
+    """Changeset tier (ISSUES.md #54): one whole call ⊇ ≥1 group ⊇ revisions.
+
+    A changeset is the ``(author, date)`` equivalence class over groups — a
+    global (non-contiguous) class, not a contiguous run. A single edit is a
+    one-group changeset; a whole ``batch_edit``/``batch_rewrite`` is one
+    changeset over all its groups. Recorded live and reconstructed on reopen,
+    exactly like the group tier one level down. There is no fourth tier.
+    """
+
+    def test_single_edit_is_one_group_one_changeset(self, doc):
+        ref = find_ref(doc, "quick brown fox")
+        result = doc.replace("quick", "speedy", paragraph=ref)
+
+        assert result.group_id is not None
+        assert result.changeset_id is not None
+        for rev in doc.list_revisions():
+            assert rev.group_id == result.group_id
+            assert rev.changeset_id == result.changeset_id
+            assert rev.changeset_source == "recorded"
+            assert f", cs={result.changeset_id}" in repr(rev)
+        # accept_changeset applies the whole edit as a unit.
+        assert doc.accept_changeset(result.changeset_id) == 2
+        assert "speedy brown fox" in _paragraph_text(doc, 1)
+        assert doc.list_revisions() == []
+
+    def test_batch_edit_is_one_changeset_over_many_groups(self, doc):
+        ref1 = find_ref(doc, "quick brown fox")
+        ref2 = find_ref(doc, "sample document for testing")
+        results = doc.batch_edit([
+            EditOperation.replace("quick", "speedy", paragraph=ref1),
+            EditOperation.delete("sample ", paragraph=ref2),
+        ])
+
+        # Two groups (one per op), non-contiguous (different paragraphs), one
+        # changeset — the headline: a changeset is not a contiguous run.
+        assert results[0].group_id != results[1].group_id
+        assert results[0].changeset_id is not None
+        assert results[0].changeset_id == results[1].changeset_id
+        assert {rev.changeset_id for rev in doc.list_revisions()} == {results[0].changeset_id}
+
+        # reject_changeset undoes the entire batch (both groups' 3 revisions).
+        assert doc.reject_changeset(results[0].changeset_id) == 3
+        assert "quick brown fox" in _paragraph_text(doc, 1)
+        assert "sample document for testing" in doc.get_visible_text()
+        assert doc.list_revisions() == []
+
+    def test_batch_rewrite_is_one_changeset_one_group_per_rewrite(self, doc):
+        ref1 = find_ref(doc, "quick brown fox")
+        ref2 = find_ref(doc, "sample document for testing")
+        results = doc.batch_rewrite([
+            (ref1, "A slow red cat sits."),
+            (ref2, "This paragraph was fully rewritten for the test."),
+        ])
+
+        # The inner rewrite_paragraph _changeset() calls no-op via reentrancy:
+        # one changeset for the whole call, one group per rewrite.
+        assert results[0].group_id != results[1].group_id
+        assert results[0].changeset_id is not None
+        assert results[0].changeset_id == results[1].changeset_id
+        assert {rev.changeset_id for rev in doc.list_revisions()} == {results[0].changeset_id}
+
+    def test_standalone_rewrite_is_its_own_changeset(self, doc):
+        # The reentrancy flip side: two standalone rewrite_paragraph calls are
+        # two changesets (each is its own outermost boundary).
+        ref1 = find_ref(doc, "quick brown fox")
+        ref2 = find_ref(doc, "sample document for testing")
+        r1 = doc.rewrite_paragraph(ref1, "A slow red cat sits.")
+        r2 = doc.rewrite_paragraph(ref2, "Entirely different sample text.")
+
+        assert r1.changeset_id is not None and r2.changeset_id is not None
+        assert r1.changeset_id != r2.changeset_id
+        assert r1.group_id != r2.group_id
+
+    def test_unknown_changeset_raises(self, doc):
+        with pytest.raises(RevisionError, match="Unknown changeset: 999"):
+            doc.accept_changeset(999)
+        with pytest.raises(RevisionError, match="Unknown changeset: 999"):
+            doc.reject_changeset(999)
+
+    def test_changeset_flag_resets_after_edit(self, doc):
+        ref = find_ref(doc, "quick brown fox")
+        doc.replace("quick", "speedy", paragraph=ref)
+        assert doc._revision_manager._in_changeset is False
+
+    def test_batch_edit_rollback_restores_changeset_registry(self, doc):
+        ref1 = find_ref(doc, "quick brown fox")
+        manager = doc._revision_manager
+        cs_counter_before = manager._changeset_counter
+
+        with pytest.raises(BatchOperationError):
+            doc.batch_edit([
+                EditOperation.replace("quick", "speedy", paragraph=ref1),
+                EditOperation.delete("no such text anywhere", paragraph=ref1),
+            ])
+
+        # No ghost changeset from the failed batch; the flag is released.
+        assert manager._changeset_counter == cs_counter_before
+        assert manager._changesets == {}
+        assert manager._group_changesets == {}
+        assert manager._changeset_sources == {}
+        assert manager._in_changeset is False
+        assert doc.list_revisions() == []
+
+    def test_roundtrip_two_paragraph_batch_plus_single_edit(self, temp_docx, frozen_clock):
+        # Headline round-trip: a batch over two paragraphs (one changeset,
+        # two groups) plus a separate single edit (a second changeset). After
+        # save + reopen: exactly 2 inferred changesets / 3 groups, and each
+        # changeset resolves as a unit.
+        with Document.open(temp_docx) as doc:
+            ref1 = find_ref(doc, "quick brown fox")
+            ref2 = find_ref(doc, "sample document for testing")
+            results = doc.batch_edit([
+                EditOperation.replace("quick", "speedy", paragraph=ref1),
+                EditOperation.delete("sample ", paragraph=ref2),
+            ])
+            third = doc.replace("well-structured", "tidy", paragraph=find_ref(doc, "well-structured document"))
+            # Recorded: 3 groups, 2 changesets (the batch's two groups share
+            # one changeset; the single edit gets a collision-bumped date and
+            # its own changeset).
+            assert len({r.group_id for r in [*results, third]}) == 3
+            assert results[0].changeset_id == results[1].changeset_id
+            assert third.changeset_id not in {results[0].changeset_id}
+            manager = doc._revision_manager
+            assert len(manager._changesets) == 2
+            assert len(manager._groups) == 3
+            doc.save()
+
+        with Document.open(temp_docx) as doc:
+            revisions = doc.list_revisions()
+            by_cs: dict[int, set[int]] = {}
+            for rev in revisions:
+                assert rev.changeset_id is not None
+                assert rev.group_id is not None
+                assert rev.changeset_source == "inferred"
+                by_cs.setdefault(rev.changeset_id, set()).add(rev.group_id)
+            # Exactly two changesets; three groups total.
+            assert len(by_cs) == 2
+            assert len({gid for gids in by_cs.values() for gid in gids}) == 3
+            # One changeset spans two groups (the batch), the other spans one.
+            assert sorted(len(gids) for gids in by_cs.values()) == [1, 2]
+
+            batch_cs = next(cs for cs, gids in by_cs.items() if len(gids) == 2)
+            single_cs = next(cs for cs, gids in by_cs.items() if len(gids) == 1)
+            # Each changeset resolves as a unit, independently.
+            assert doc.accept_changeset(batch_cs) == 3  # replace (del+ins) + delete
+            assert doc.reject_changeset(single_cs) == 2  # replace (del+ins) undone
+            assert doc.list_revisions() == []
+            text = doc.get_visible_text()
+            assert "speedy brown fox" in text
+            assert "sample " not in text
+            assert "well-structured" in text  # the single edit was rejected
+
+    def test_same_paragraph_batch_over_merges_after_reopen(self, temp_docx, frozen_clock):
+        # Accepted imprecision (carried up from #46): two batch ops in the
+        # SAME paragraph share (author, date) and paragraph, so #46 merges
+        # them into ONE group on reopen — hence one changeset. Pinned so the
+        # collapse is a known contract, not a silent regression.
+        with Document.open(temp_docx) as doc:
+            ref = find_ref(doc, "quick brown fox")
+            results = doc.batch_edit([
+                EditOperation.replace("quick", "speedy", paragraph=ref),
+                EditOperation.replace("lazy", "sleepy", paragraph=ref),
+            ])
+            # Recorded: two groups, one changeset.
+            assert results[0].group_id != results[1].group_id
+            assert results[0].changeset_id == results[1].changeset_id
+            doc.save()
+
+        with Document.open(temp_docx) as doc:
+            revisions = doc.list_revisions()
+            assert len(revisions) == 4
+            gids = {rev.group_id for rev in revisions}
+            cs_ids = {rev.changeset_id for rev in revisions}
+            assert len(gids) == 1  # #46 merges same-paragraph same-date ops
+            assert len(cs_ids) == 1 and None not in cs_ids
+
+    def test_rump_changeset_after_partial_word_accept(self, temp_xml):
+        # A changeset spanned two paragraphs (revs 1-4, one author+date).
+        # Word accepted rev 1 (unwrapped it to plain text), leaving revs
+        # 2,3,4. The survivors reconstruct as a rump changeset — its first
+        # group lost a member — that reject_changeset resolves as a unit.
+        survivors = (
+            f"<w:p><w:r><w:t>one </w:t></w:r>{_del_xml(2, 'two ')}</w:p>"
+            f"<w:p>{_ins_xml(3, 'three ')}{_del_xml(4, 'four')}</w:p>"
+        )
+        manager = _make_manager(temp_xml(survivors))
+
+        # Two groups (one per paragraph), one changeset (shared author+date).
+        assert len(manager._groups) == 2
+        (cs_id,) = manager._changesets
+        assert manager._changeset_sources[cs_id] == "inferred"
+        assert set(manager.changeset_groups(cs_id)) == set(manager._groups)
+        # The rump resolves without error (3 survivors across two groups).
+        assert manager.reject_changeset(cs_id) == 3
+        assert manager.list_revisions() == []
+
+    def test_partially_resolved_changeset_is_rump_tolerant(self, temp_xml):
+        # Resolve one group of a two-group changeset individually, then the
+        # changeset still resolves the survivors (skips the resolved pair).
+        body = (
+            f"<w:p>{_ins_xml(1, 'one ')}{_del_xml(2, 'two ')}</w:p>"
+            f"<w:p>{_ins_xml(3, 'three ')}{_del_xml(4, 'four')}</w:p>"
+        )
+        manager = _make_manager(temp_xml(body))
+        (cs_id,) = manager._changesets
+
+        first_group = manager.group_id_of(1)
+        assert first_group is not None
+        assert manager.accept_group(first_group) == 2  # revs 1,2 resolved
+
+        assert manager.accept_changeset(cs_id) == 2  # only revs 3,4 remain
+        assert manager.list_revisions() == []
+
+    def test_reconstruction_partitions_by_author_date(self, temp_xml):
+        # Same (author, date) in two paragraphs → two groups, ONE changeset
+        # (global equivalence class). A different date → a distinct changeset.
+        body = (
+            f"<w:p>{_ins_xml(1, 'a')}</w:p>"
+            f"<w:p>{_ins_xml(2, 'b')}</w:p>"  # same author+date as rev 1
+            f"<w:p>{_ins_xml(3, 'c', date=DATE_B)}</w:p>"  # different date
+        )
+        manager = _make_manager(temp_xml(body))
+
+        assert manager._groups == {1: (1,), 2: (2,), 3: (3,)}
+        # Groups 1 and 2 share a changeset; group 3 is its own.
+        cs1 = manager.changeset_id_of(1)
+        cs2 = manager.changeset_id_of(2)
+        cs3 = manager.changeset_id_of(3)
+        assert cs1 is not None and cs3 is not None
+        assert cs1 == cs2 and cs1 != cs3
+        assert set(manager.changeset_groups(cs1)) == {1, 2}
+        assert manager.changeset_groups(cs3) == (3,)
+        assert all(src == "inferred" for src in manager._changeset_sources.values())
+
+    def test_ungrouped_revision_has_no_changeset(self, temp_xml):
+        # A revision with no date is ungroupable → no group, no changeset.
+        body = (
+            f"<w:p>{_ins_xml(1, 'one ')}"
+            f'<w:ins w:id="2" w:author="{AUTHOR_A}"><w:r><w:t>no date</w:t></w:r></w:ins></w:p>'
+        )
+        manager = _make_manager(temp_xml(body))
+        by_id = {rev.id: rev for rev in manager.list_revisions()}
+
+        assert by_id[1].changeset_id is not None
+        assert by_id[1].changeset_source == "inferred"
+        assert by_id[2].group_id is None
+        assert by_id[2].changeset_id is None
+        assert by_id[2].changeset_source is None
+        assert "cs=" not in repr(by_id[2])
+
+    def test_foreign_revisions_carry_inferred_changesets(self, test_data_dir, temp_dir):
+        # Every foreign revision now carries an inferred changeset, and
+        # changeset membership never crosses an (author, date) boundary
+        # (same changeset ⇒ same author+date — the equivalence-class contract).
+        fixture = test_data_dir / "OXML_TrackChanges_Test.docx"
+        dest = temp_dir / "foreign.docx"
+        shutil.copy(fixture, dest)
+        with Document.open(dest) as doc:
+            revisions = doc.list_revisions()
+            assert revisions
+            assert all(rev.changeset_id is not None for rev in revisions)
+            assert all(rev.changeset_source == "inferred" for rev in revisions)
+            assert all(f", cs={rev.changeset_id}" in repr(rev) for rev in revisions)
+
+            by_cs: dict[int, set[tuple[str, object]]] = {}
+            for rev in revisions:
+                assert rev.changeset_id is not None
+                by_cs.setdefault(rev.changeset_id, set()).add((rev.author, rev.date))
+            assert all(len(keys) == 1 for keys in by_cs.values())


### PR DESCRIPTION
Implements the **changeset tier** (ISSUES.md #54, v0.7.0) — the third
revision-tracking tier, one level above revision groups:

```
one call (a single edit, or a whole batch_edit / batch_rewrite)
  = one changeset  ⊇  one-or-more groups  ⊇  revisions
```

A changeset is the `(author, date)` **equivalence class over groups** — a
*global* class, not a contiguous run — so a `batch_edit` whose ops land in
different paragraphs is one changeset even though its groups are non-contiguous.

## What's new

- **`Document.accept_changeset(id)` / `reject_changeset(id)`** — resolve every
  group a whole call created, as one unit. Rump-tolerant.
- **`EditResult.changeset_id`** — carried by every result a call returns
  (shared across a batch); `None` iff `group_id` is `None`.
- **`Revision.changeset_id` / `changeset_source`** — stamped by
  `list_revisions()`; `"recorded"` for this session's calls, `"inferred"` for
  revisions reconstructed at parse time.
- **`RevisionError.changeset_id`** — structured field for unknown-changeset errors.

## Mechanics

- Recorded live via a reentrant `_changeset()` boundary that mirrors
  `frozen_timestamp`: only the outermost call bundles, so a nested
  `rewrite_paragraph` inside `batch_rewrite` merges into one changeset while a
  standalone call gets its own.
- Reconstructed as inferred changesets at parse time, partitioning groups by
  identical `w:author` + `w:date`.
- Registry snapshot/restore extended to the changeset maps, so a failed
  `batch_edit`/`batch_rewrite` never leaves a ghost changeset.
- All `EditResult` construction routes through the single `_edit_result`
  factory; the `_resolve_group` internals were extracted into a shared
  `_resolve_ids` reused by group and changeset resolution.

## Tests & docs

- 14 new `TestChangesetTier` tests (single edit, non-contiguous batch,
  batch_rewrite reentrancy, standalone separation, unknown-id error, rollback
  registry restore, save/reopen round-trip, same-paragraph over-merge contract,
  rump changesets, partial resolution, author/date partitioning, ungrouped,
  foreign) + updated `test_foreign_revisions` fixtures.
- `docs/api.md` updated for the new methods and fields.

## Verification

- Changeset + foreign tests: 86 passed · batch_edit + session: 136 passed (no regression)
- `ruff check` / `ruff format --check`: clean · `ty check`: exit 0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added changeset tracking for edits and revisions.
  * Added the ability to accept or reject all revisions from a single edit call.
  * Added changeset details to edit results and revision information.
  * Added changeset identifiers to revision errors for clearer error reporting.

* **Documentation**
  * Updated API documentation and examples to describe changeset behavior and metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->