### PR TITLE
docs: full SKILL/docs audit — changeset tier, dry_run, occurrence, exception sections (ISSUES.md #55)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Pure Python library for Word document track changes and comments, without requir
 - **Cross-Boundary Editing**: Find and replace text spanning multiple XML elements and revision boundaries
 - **Mixed-State Editing**: Atomic decomposition for text spanning `<w:ins>`/`<w:del>` boundaries
 - **Comments**: Add, reply, resolve, and delete comments
-- **Revision Management**: List, accept, and reject tracked changes
-- **Session Mode**: Optional persistent kernel (`docx-session start/exec/eval/stop`) keeps documents open across many small commands — ideal for AI agents (`pip install "docx-editor[session]"`)
+- **Revision Management**: List, accept, and reject tracked changes at three granularities — individual revisions, groups (one logical edit), and changesets (one whole `batch_edit`/`batch_rewrite` call); `EditResult` and `Revision` objects carry `group_id` and `changeset_id`
+- **Session Mode**: Optional persistent kernel (`docx-session start/exec/eval/status/stop`) keeps documents open across many small commands — ideal for AI agents (`pip install "docx-editor[session]"`)
 - **Cross-Platform**: Works on Linux, macOS, and Windows
 - **No Dependencies**: Only requires `defusedxml` for secure XML parsing
 
@@ -89,6 +89,9 @@ with Document.open("contract.docx", author=author) as doc:
     doc.replace("net", "gross", paragraph=r)  # chain without list_paragraphs()
     doc.delete("obsolete text", paragraph="P5#d4e5")
     doc.insert_after("Section 5", " (as amended)", paragraph="P3#b2c4")
+    # Repeated text? Pass occurrence= (0-based) to pick which match; omitting it
+    # requires a unique match, else AmbiguousTextError.
+    doc.replace("the", "The", paragraph="P4#c5d6", occurrence=2)
 
     # Rewrite entire paragraph (automatic word-level diff)
     doc.rewrite_paragraph("P2#f3c1",
@@ -151,6 +154,10 @@ with Document.open("contract.docx", author="Editor") as doc:
     ])
     doc.save()
 ```
+
+Pass `dry_run=True` to validate every operation up front without touching the
+document — `doc.batch_edit(ops, dry_run=True)` returns a list of
+`EditValidationResult` instead of applying the edits.
 
 ### Saving into synced folders
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -134,7 +134,7 @@ Return one paragraph as a structured `ParagraphInfo` record — the single-item 
 
 **Returns:** `ParagraphInfo` (index, hash-anchored ref, full untruncated text) for the paragraph at `index`.
 
-**Raises:** [`ParagraphIndexError`](#exceptions) if `index` is out of range (`< 1` or greater than `paragraph_count()`).
+**Raises:** [`ParagraphIndexError`](#paragraphindexerror) if `index` is out of range (`< 1` or greater than `paragraph_count()`).
 
 **Example:**
 
@@ -154,7 +154,7 @@ Return the paragraphs surrounding `ref`, in document order — the "show me the 
 
 **Returns:** List of `ParagraphInfo` records (index, ref, full text) — identical to what `list_paragraphs_structured()` would emit for the same span.
 
-**Raises:** `ValueError` if `ref` is malformed or `window < 0`; [`ParagraphIndexError`](#exceptions) / [`HashMismatchError`](#exceptions) for an out-of-range or stale `ref`.
+**Raises:** `ValueError` if `ref` is malformed or `window < 0`; [`ParagraphIndexError`](#paragraphindexerror) / [`HashMismatchError`](#hashmismatcherror) for an out-of-range or stale `ref`.
 
 **Example:**
 
@@ -246,7 +246,7 @@ Find text in the document, including text spanning XML element boundaries.
 
 **Returns:** [`SearchResult`](#searchresult), or None if not found
 
-**Raises:** `ValueError` if `text` is empty or `paragraph` is malformed; [`ParagraphIndexError`](#exceptions) / [`HashMismatchError`](#exceptions) for an out-of-range or stale `paragraph`.
+**Raises:** `ValueError` if `text` is empty or `paragraph` is malformed; [`ParagraphIndexError`](#paragraphindexerror) / [`HashMismatchError`](#hashmismatcherror) for an out-of-range or stale `paragraph`.
 
 **Example:**
 
@@ -275,7 +275,7 @@ what a follow-up edit needs.
 
 **Returns:** list of [`SearchResult`](#searchresult), empty when nothing matches (no-match is not an error for an enumeration API)
 
-**Raises:** `ValueError` if `text` is empty or `paragraph` is malformed; [`ParagraphIndexError`](#exceptions) / [`HashMismatchError`](#exceptions) for an out-of-range or stale `paragraph`.
+**Raises:** `ValueError` if `text` is empty or `paragraph` is malformed; [`ParagraphIndexError`](#paragraphindexerror) / [`HashMismatchError`](#hashmismatcherror) for an out-of-range or stale `paragraph`.
 
 **Example:**
 
@@ -585,7 +585,7 @@ List all tracked changes in the document.
 
 **Returns:** List of Revision objects
 
-**Raises:** The `paragraph` ref is validated exactly like in the edit methods — `ValueError` (malformed ref), [`ParagraphIndexError`](#exceptions) (index out of range), [`HashMismatchError`](#exceptions) (stale hash).
+**Raises:** The `paragraph` ref is validated exactly like in the edit methods — `ValueError` (malformed ref), [`ParagraphIndexError`](#paragraphindexerror) (index out of range), [`HashMismatchError`](#hashmismatcherror) (stale hash).
 
 **Example:**
 
@@ -916,6 +916,10 @@ from docx_editor import Revision
 | `author` | str | The revision author |
 | `date` | datetime or None | When the revision was made |
 | `text` | str | The inserted or deleted text |
+| `paragraph_ref` | str or None | Hash-anchored reference (`"P{i}#{hash}"`) of the containing paragraph; None when the revision sits outside any `<w:p>` (e.g. a `<w:trPr>` row marker) |
+| `occurrence` | int or None | 0-based occurrence index of `text` within the containing paragraph, counted in the view where the revision's text lives (the visible view for insertions, the original pre-revision view for deletions). For insertions it plugs directly into the `occurrence=` parameter of the anchor APIs; None whenever targeting-by-text does not apply (empty text, a host insertion partly consumed by a nested deletion, or a nested deletion) |
+| `nested_under` | int or None | id of the nearest enclosing revision (e.g. a foreign deletion inside another author's pending insertion), else None |
+| `contains_ids` | tuple[int, ...] | ids of the revisions nested inside this one, in document order (empty tuple when none) |
 | `group_id` | int or None | Revision group this revision belongs to (see [`accept_group()`](#accept_groupgroup_id)): recorded for this session's edits, inferred by reconstruction for revisions already in the file; None only for ungroupable revisions (missing author/date, outside any paragraph, duplicated id, or a mid-session split half of a foreign insertion) |
 | `group_source` | str or None | Provenance of `group_id`: `"recorded"` (created through this open Document) or `"inferred"` (reconstructed at parse time from same-paragraph contiguity + identical author and date); None iff `group_id` is None |
 | `changeset_id` | int or None | Changeset (one whole call) this revision's group belongs to (see [`accept_changeset()`](#accept_changesetchangeset_id) / [`reject_changeset()`](#reject_changesetchangeset_id)) — the `(author, date)` class over groups; None iff `group_id` is None |
@@ -1161,6 +1165,41 @@ except AmbiguousTextError as e:
                 occurrence=r.paragraph_occurrence)
 ```
 
+### `HashMismatchError`
+
+Raised when a `paragraph` ref's hash no longer matches the paragraph's current
+content — the paragraph changed (usually by an earlier edit) since the ref was
+listed, so the ref is stale. Structured fields: `paragraph_index` (1-based),
+`expected_hash` (the hash in the stale ref), `actual_hash` (the paragraph's
+current hash), and `paragraph_preview` (the current text). Recover by retrying
+with the fresh ref `P{paragraph_index}#{actual_hash}`, or re-list paragraphs.
+
+```python
+from docx_editor.exceptions import HashMismatchError
+
+try:
+    doc.replace("old", "new", paragraph="P2#f3c1")
+except HashMismatchError as e:
+    doc.replace("old", "new", paragraph=f"P{e.paragraph_index}#{e.actual_hash}")
+```
+
+### `ParagraphIndexError`
+
+Raised when a paragraph index is out of range — `< 1` or greater than
+`paragraph_count()` (for example `get_paragraph(0)`). Structured fields:
+`index` (the offending index) and `total_paragraphs` (how many the document
+has). Clamp to `1..total_paragraphs` and retry, or call `list_paragraphs()`
+to pick a valid ref.
+
+```python
+from docx_editor.exceptions import ParagraphIndexError
+
+try:
+    para = doc.get_paragraph(index)
+except ParagraphIndexError as e:
+    para = doc.get_paragraph(max(1, min(e.index, e.total_paragraphs)))
+```
+
 ### `BatchOperationError`
 
 The only exception `batch_edit()` / `batch_rewrite()` raise for a failing
@@ -1212,6 +1251,18 @@ Raised by `Document.open()` when the source file does not exist. Structured fiel
 
 ```python
 from docx_editor.exceptions import DocumentNotFoundError
+```
+
+### `InvalidDocumentError`
+
+Raised by `Document.open()` when the source path is not a valid `.docx` — wrong
+suffix, a directory, an empty/truncated file, not a ZIP, missing
+`word/document.xml`, or malformed OOXML. Structured field: `path` (the source
+path). Not an in-loop retry: the message names which check failed; fix or
+re-export the input file.
+
+```python
+from docx_editor.exceptions import InvalidDocumentError
 ```
 
 ### `DocumentClosedError`

--- a/docs/api.md
+++ b/docs/api.md
@@ -1257,7 +1257,7 @@ from docx_editor.exceptions import DocumentNotFoundError
 
 Raised by `Document.open()` when the source path is not a valid `.docx` — wrong
 suffix, a directory, an empty/truncated file, not a ZIP, missing
-`word/document.xml`, or malformed OOXML. Structured field: `path` (the source
+`word/document.xml`, or malformed XML. Structured field: `path` (the source
 path). Not an in-loop retry: the message names which check failed; fix or
 re-export the input file.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ Pure Python library for Word document track changes and comments, without requir
 - **Paragraph Rewrite**: rewrite a paragraph and generate tracked changes from the diff
 - **Track Changes**: Replace, delete, and insert text with revision tracking
 - **Comments**: Add, reply, resolve, and delete comments
-- **Revision Management**: List, accept, and reject tracked changes
+- **Revision Management**: Accept/reject tracked changes at three granularities — individual revisions, groups (one logical edit), and changesets (one whole `batch_edit`/`batch_rewrite` call)
 - **Cross-Boundary Editing**: Find and replace text spanning multiple XML elements
 - **Cross-Platform**: Works on Linux, macOS, and Windows
 - **No Dependencies**: Only requires `defusedxml` for secure XML parsing
@@ -38,6 +38,8 @@ with Document.open("contract.docx", author="Legal Team") as doc:
     # P2#f3c1| Payment is due within 30 days...
 
     # Edit methods require a paragraph ref and return the updated ref.
+    # Pass occurrence= (0-based) to disambiguate repeated text; omitting it
+    # requires a unique match, else AmbiguousTextError.
     ref = doc.replace("30 days", "60 days", paragraph="P2#f3c1")
     ref = doc.insert_after("Payment", " terms", paragraph=ref)
     doc.delete("obsolete text", paragraph="P5#d4e5")

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -221,15 +221,16 @@ Revisions form three nested tiers: an individual **revision**, the **group** of 
 from docx_editor import EditOperation
 
 # Every edit method returns an EditResult carrying group_id and changeset_id.
-result = doc.rewrite_paragraph("P2#f3c1", "Payment is due within 90 days.")
+result = doc.rewrite_paragraph("P3#b2c4", "Section 5 has been revised in full.")
 doc.accept_group(result.group_id)           # resolve one logical edit as a unit
 
-# One batch_edit is one changeset that may span several groups:
-refs = doc.batch_edit([
+# One batch_edit is one changeset that may span several groups (edit paragraphs
+# the rewrite above didn't touch, so their refs are still fresh):
+new_refs = doc.batch_edit([
     EditOperation.replace("30 days", "60 days", paragraph="P2#f3c1"),
     EditOperation.delete("obsolete clause", paragraph="P5#d4e5"),
 ])
-doc.reject_changeset(refs[0].changeset_id)  # undo the whole batch in one call
+doc.reject_changeset(new_refs[0].changeset_id)  # undo the whole batch in one call
 ```
 
 Every `Revision` also carries `group_id`/`group_source` and `changeset_id`/`changeset_source` — the source is `"recorded"` for edits made in this session and `"inferred"` for revisions reconstructed when an existing document is reopened. Group and changeset ids are renumbered each time the document is opened, so always resolve them with an id from the current session's `EditResult` or `list_revisions()`.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -72,6 +72,8 @@ with Document.open("contract.docx") as doc:
 
 Use the `P{index}#{hash}` part as the `paragraph=` argument. Edit methods return a new paragraph ref after the hash changes, so keep the returned value when chaining edits in the same paragraph.
 
+When the search text appears more than once in the target paragraph, pass `occurrence=` (0-based, so `occurrence=1` is the second match) to `replace()`, `delete()`, `insert_after()`, `insert_before()`, and `add_comment()`. Omitting it requires a unique match — otherwise the call raises `AmbiguousTextError`.
+
 ## Track Changes
 
 ### Replace Text
@@ -83,7 +85,7 @@ with Document.open("contract.docx") as doc:
     doc.save()
 ```
 
-This creates a tracked deletion of `30 days` and a tracked insertion of `60 days`.
+This creates a tracked deletion of `30` and a tracked insertion of `60`. `replace()` trims the common prefix and suffix and tracks only the differing words, so the unchanged surrounding word (` days`) is left intact rather than deleted and re-inserted.
 
 ### Delete Text
 
@@ -128,6 +130,18 @@ with Document.open("contract.docx") as doc:
     ])
     print(new_refs)
     doc.save()
+```
+
+To validate a batch before applying it, pass `dry_run=True`. This checks every operation up front and returns a list of `EditValidationResult` objects (each with `valid` and `error`) without modifying the document:
+
+```python
+with Document.open("contract.docx") as doc:
+    results = doc.batch_edit([
+        EditOperation.replace("30 days", "60 days", paragraph="P2#f3c1"),
+        EditOperation.delete("obsolete clause", paragraph="P5#d4e5"),
+    ], dry_run=True)
+    for r in results:
+        print(r.index, r.valid, r.error)
 ```
 
 ## Comments
@@ -198,6 +212,27 @@ doc.accept_revision(revision_id=1)
 # For deletions, reject restores the deleted content.
 doc.reject_revision(revision_id=1)
 ```
+
+### Accept or Reject a Group or Changeset
+
+Revisions form three nested tiers: an individual **revision**, the **group** of revisions from one logical edit (e.g. a single `replace()` or `rewrite_paragraph()`), and the **changeset** of all groups from one whole call (`batch_edit()` / `batch_rewrite()`). Accept or reject a whole tier in one call:
+
+```python
+from docx_editor import EditOperation
+
+# Every edit method returns an EditResult carrying group_id and changeset_id.
+result = doc.rewrite_paragraph("P2#f3c1", "Payment is due within 90 days.")
+doc.accept_group(result.group_id)           # resolve one logical edit as a unit
+
+# One batch_edit is one changeset that may span several groups:
+refs = doc.batch_edit([
+    EditOperation.replace("30 days", "60 days", paragraph="P2#f3c1"),
+    EditOperation.delete("obsolete clause", paragraph="P5#d4e5"),
+])
+doc.reject_changeset(refs[0].changeset_id)  # undo the whole batch in one call
+```
+
+Every `Revision` also carries `group_id`/`group_source` and `changeset_id`/`changeset_source` — the source is `"recorded"` for edits made in this session and `"inferred"` for revisions reconstructed when an existing document is reopened. Group and changeset ids are renumbered each time the document is opened, so always resolve them with an id from the current session's `EditResult` or `list_revisions()`.
 
 ### Accept or Reject All
 

--- a/skills/docx/SKILL.md
+++ b/skills/docx/SKILL.md
@@ -512,12 +512,12 @@ doc.reject_group(result.group_id)   # undo the whole rewrite, or:
 # the same recorded-vs-inferred semantics as the group fields. changeset ids
 # are per-open-Document (renumbered on each open, like group ids). Raises
 # RevisionError for an unknown changeset id.
-batch = doc.batch_edit([
+results = doc.batch_edit([
     EditOperation.replace("old", "new", paragraph="P4#1a2b"),
     EditOperation.delete("stale clause", paragraph="P6#3c4d"),
 ])
-doc.reject_changeset(batch[0].changeset_id)   # undo the whole call, or:
-# doc.accept_changeset(batch[0].changeset_id) # apply it in full
+doc.reject_changeset(results[0].changeset_id)   # undo the whole call, or:
+# doc.accept_changeset(results[0].changeset_id) # apply it in full
 
 # Group ids are in-memory and per-open-Document, renumbered on each open.
 # Pre-existing revisions (previous sessions, foreign reviewers, Word

--- a/skills/docx/SKILL.md
+++ b/skills/docx/SKILL.md
@@ -260,6 +260,9 @@ match = doc.find_text("30 days")
 # Optionally scope to one paragraph — occurrence then counts within it:
 match = doc.find_text("30 days", paragraph="P2#f3c1")
 
+# Just need the count? doc.count_matches("30 days") returns the document-wide
+# occurrence total (no paragraph scope) without building SearchResults.
+
 # Enumerate EVERY match in one call (returns list[SearchResult], [] if none).
 # Each result plugs straight into a follow-up edit — no occurrence math needed.
 # Edit them all in one atomic batch; reversed() puts same-paragraph ops in the
@@ -445,7 +448,7 @@ doc.close()
 ### Revision Management API
 
 ```python
-from docx_editor import Document
+from docx_editor import Document, EditOperation
 import os
 
 author = os.environ.get("USER") or "Reviewer"
@@ -466,6 +469,9 @@ for r in revisions:
     # outside any paragraph, duplicated id, or a mid-session split half
     # of a foreign insertion).
     print(f"  group_id={r.group_id} group_source={r.group_source}")
+    # Changeset: the whole edit CALL the group belongs to (see below).
+    # changeset_source mirrors group_source ("recorded" vs "inferred").
+    print(f"  changeset_id={r.changeset_id} changeset_source={r.changeset_source}")
 
 # Filter by author
 their_changes = doc.list_revisions(author="OtherUser")
@@ -496,6 +502,22 @@ doc.reject_revision(their_changes[0].id)
 result = doc.rewrite_paragraph("P3#a7b2", "Entirely new paragraph text.")
 doc.reject_group(result.group_id)   # undo the whole rewrite, or:
 # doc.accept_group(result.group_id) # apply it in full
+
+# Accept or reject a whole edit CALL as one changeset (returns count
+# processed). The tiers nest: revision < group < changeset. One
+# batch_edit/batch_rewrite is ONE changeset that may span several groups, so
+# accept_changeset resolves the entire call at once while accept_group resolves
+# a single logical edit within it. Every EditResult carries changeset_id
+# alongside group_id; Revision objects carry changeset_id/changeset_source with
+# the same recorded-vs-inferred semantics as the group fields. changeset ids
+# are per-open-Document (renumbered on each open, like group ids). Raises
+# RevisionError for an unknown changeset id.
+batch = doc.batch_edit([
+    EditOperation.replace("old", "new", paragraph="P4#1a2b"),
+    EditOperation.delete("stale clause", paragraph="P6#3c4d"),
+])
+doc.reject_changeset(batch[0].changeset_id)   # undo the whole call, or:
+# doc.accept_changeset(batch[0].changeset_id) # apply it in full
 
 # Group ids are in-memory and per-open-Document, renumbered on each open.
 # Pre-existing revisions (previous sessions, foreign reviewers, Word
@@ -779,7 +801,7 @@ All LLM-facing errors inherit from `DocxEditError` and carry structured fields s
 | `AmbiguousTextError`   | `search_text`, `paragraph_ref`, `paragraph_preview`, `total_occurrences`                | The target matched more than once with no `occurrence` given. Enumerate with `find_all()` and pick, or pass an explicit `occurrence` (0-based).      |
 | `ParagraphIndexError`  | `index`, `total_paragraphs`                                                             | Clamp to `1..total_paragraphs` and retry with `get_paragraph(i)`, or call `list_paragraphs()` to pick a valid ref. |
 | `BatchOperationError`  | `operation_index`, `reason`, `original`                                                 | Fix the op at `operations[operation_index]` (or drop it) and retry the batch; `original` is the underlying typed error (e.g. use its `actual_hash` to re-target a stale ref), or None for batch-level rules with no underlying exception (a missing paragraph ref, an element that is not an `EditOperation`, or a duplicate paragraph in `batch_rewrite` — `batch_edit` allows repeats, applied sequentially). Batch methods never raise the inner types directly. |
-| `RevisionError`        | `revision_id`, `group_id` (set when the error is about that id, else None)              | Unknown `group_id` passed to `accept_group()`/`reject_group()`. Group ids are per-open-Document and renumbered on each open (recorded for this session's edits, inferred for pre-existing revisions): use a `group_id` from this session's `EditResult` or `list_revisions()`, never one saved from a previous session. |
+| `RevisionError`        | `revision_id`, `group_id`, `changeset_id` (whichever the error is about is set, the rest None) | Unknown `group_id` passed to `accept_group()`/`reject_group()`, or unknown `changeset_id` passed to `accept_changeset()`/`reject_changeset()`. Group and changeset ids are per-open-Document and renumbered on each open (recorded for this session's edits, inferred for pre-existing revisions): use an id from this session's `EditResult` or `list_revisions()`, never one saved from a previous session. |
 | `CommentError`         | `comment_id` (set when a comment id was targeted, else None)                            | Replying to a nonexistent comment id — call `list_comments()` and retry with a real id. With `comment_id=None` the arguments themselves were invalid; fix them per the message. |
 | `DocumentClosedError`  | `path`                                                                                  | The `Document` was used after `close()`. Reopen with `Document.open(e.path)`; edits not saved before the `close()` were discarded with the workspace. |
 | `DocumentNotFoundError`| `path`                                                                                  | The file doesn't exist at `path` — fix the path (typo, wrong cwd) before retrying. |
@@ -983,7 +1005,7 @@ Rules:
 - Exit code 1 means the code raised: the traceback is on stderr, the session survives — fix the call and continue (introspect with `docx-session exec "import inspect; print(inspect.signature(doc.replace))"` when unsure).
 - Exit code 2 means timeout — the kernel is alive and your code is still running. Exit code 3 means no session is running.
 - Exit code 4 means the kernel died mid-exec or is unreachable: its state (open documents, variables) is lost. Recover with `docx-session stop` then `start`, and re-open your documents.
-- `eval` output: library dataclasses (SearchResult, ParagraphInfo, ParagraphLocation, Revision, Comment) arrive as real JSON objects (`"serialized": true`, datetimes as ISO strings, tuples as lists) — access fields directly, never string-parse a repr. `"serialized": false` means the value wasn't JSON-serializable and `value` holds its `repr` string. On exit 1 the envelope carries `"error": {"type", "message", <structured recovery fields — e.g. actual_hash, total_occurrences>}` plus a compact, path-free `traceback` (`"error"` is null for the rare raise that bypasses the kernel-side capture, e.g. SystemExit — fall back to `traceback`). On exit 4 the envelope has `"status": "dead"`; on exit 3 (no session) there is no envelope at all.
+- `eval` output: library dataclasses (SearchResult, ParagraphInfo, ParagraphLocation, Revision, Comment) arrive as real JSON objects (`"serialized": true`, datetimes as ISO strings, tuples as lists) — access fields directly, never string-parse a repr. `"serialized": false` means the value wasn't JSON-serializable and `value` holds its `repr` string. On exit 1 the envelope carries `"error": {"type", "message", <structured recovery fields — e.g. actual_hash, total_occurrences>}` plus a compact, machine-path-stripped `traceback` (library frames appear as relative `docx_editor/...` paths and the eval line as `<docx-session eval>`; only absolute machine paths are stripped) (`"error"` is null for the rare raise that bypasses the kernel-side capture, e.g. SystemExit — fall back to `traceback`). On exit 4 the envelope has `"status": "dead"`; on exit 3 (no session) there is no envelope at all.
 - `eval` of an edit call returns the `EditResult` as a plain JSON *string* (it is a `str` subclass, so its value is just the new ref) — `group_id`/`revision_ids` are lost in transit. Keep the result in a kernel-side variable and eval a dict projection when you need them: `docx-session exec "r = doc.replace(...)"` then `docx-session eval "{'ref': str(r), 'group_id': r.group_id}"`.
 - `status` reports `state: busy` while an exec is in flight — a busy session is healthy, don't stop/restart it. The report is a point-in-time snapshot: a sub-second exec can already read `idle` by the time you check, so never conclude from `idle` that code didn't run.
 - Variables persist between `exec` calls: keep refs returned by edits in Python variables instead of re-running `list_paragraphs()`.


### PR DESCRIPTION
## Summary

Pre-0.7.0 documentation audit (ISSUES.md #55). Syncs `README.md`,
`docs/{api,index,quickstart}.md`, and `skills/docx/SKILL.md` to the current API
surface. **Docs-only — no Python changed.**

Every added claim was verified against the source:

- **Changeset tier** — Revision Management documented at three granularities
  (revision / group / changeset). `EditResult` and `Revision` carry `group_id`
  and `changeset_id`; new `accept_changeset`/`reject_changeset` with
  recorded-vs-inferred semantics.
- **occurrence=** disambiguation documented on `replace` / `delete` /
  `insert_after` / `insert_before` / `add_comment` (the five methods that accept it).
- **dry_run=True** on `batch_edit` returning `EditValidationResult`
  (`index`/`valid`/`error`).
- **count_matches**, session `status` subcommand, and the machine-path-stripped
  eval traceback (relative `docx_editor/...` frames, `<docx-session eval>` line).
- **New api.md exception sections** — `HashMismatchError`, `ParagraphIndexError`,
  `InvalidDocumentError` — and retargeting of stale `#exceptions` anchors to
  per-exception ids.
- **Revision table** gains `paragraph_ref` / `occurrence` / `nested_under` /
  `contains_ids`.
- quickstart word-trim example corrected (`30 days` → `60 days` tracks `30`/`60`).

## Verification

- Every documented field/method/subcommand checked against `docx_editor/` source.
- Word-trim behavior confirmed live (`_trim_replace_affixes` → `30`/`60`).
- All 54 in-page anchor links in `docs/api.md` resolve.
- `mkdocs build --strict` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded tracked-change acceptance/rejection guidance across revision, group, and changeset granularities, including examples and tier semantics.
  * Clarified Quick Start edit targeting with the optional 0-based `occurrence` parameter, including how ambiguity is handled.
  * Added `dry_run=True` documentation for batch editing to validate operations upfront and return validation results without altering documents.
  * Improved replacement behavior explanations (preserving surrounding text while tracking word-level differences).
  * Enhanced API references for revision context/metadata and added dedicated documentation for document integrity exceptions, including updated “raises” links and recovery guidance.
  * Updated session command set and structured output descriptions for the DOCX workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->