### PR TITLE
perf: snapshot-index accept/reject path (ISSUES.md #57)

### DIFF
--- a/benchmarks/accept_scaling.py
+++ b/benchmarks/accept_scaling.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Benchmark: accept-path scaling with revision count (ISSUES.md #57).
+
+Builds a large multi-run document (via ``batch_edit_scaling.build_large_doc``),
+lays down an N-operation ``batch_edit`` redline (one changeset, N groups, 2N
+revisions), then times three ways to resolve it on identical revisions:
+
+    * ``accept_all()``        — the multi-pass baseline (never regressed)
+    * ``accept_changeset()``  — resolves the whole batch's changeset
+    * ``accept_group()`` ×N   — group-by-group resolution loop
+
+Before #57, ``accept_revision``/``reject_revision`` each did a full-document
+``getElementsByTagName`` walk per member, repeated per pass, so the changeset
+and group-loop paths were O(members x doc): on a 3000-paragraph doc a 240-rev
+``accept_changeset`` measured 5.35 s (2.26x ``accept_all``) and the
+``accept_group`` ×120 loop 6.13 s (2.59x) — see scratchpad
+``dogfood4-perfscale/perf-report.md`` §4. After #57 the group/changeset path
+builds one w:id->element index per call and threads it through every member, so
+its cost tracks ``accept_all`` (ratio ~1x).
+
+Usage:
+    uv run python benchmarks/accept_scaling.py [--ops 500] [--paras 3000]
+
+Timing output is informational. The script exits non-zero only on a
+correctness assertion failure (every revision must be resolved, leaving
+``list_revisions() == []``).
+"""
+
+import argparse
+import shutil
+import tempfile
+import time
+from pathlib import Path
+
+from batch_edit_scaling import N_PARAGRAPHS, build_large_doc
+
+from docx_editor import Document, EditOperation
+
+
+def _build_redline(doc: Document, n_ops: int) -> int:
+    """Apply an n_ops ``batch_edit`` redline; return the revision count (2*n_ops)."""
+    refs = doc.list_paragraphs(limit=None)
+    n_paras = len(refs)
+    assert n_ops <= 2 * n_paras, f"at most {2 * n_paras} ops supported"
+    # Coprime stride spreads targets; each paragraph holds three 'committee'
+    # occurrences, so revisiting a paragraph past n_paras ops stays valid.
+    ops = [
+        EditOperation.replace(
+            "committee",
+            f"BOARD_{i}",
+            paragraph=refs[(i * 397) % n_paras].split("|")[0],
+            occurrence=0,
+        )
+        for i in range(n_ops)
+    ]
+    doc.batch_edit(ops)
+    return len(doc.list_revisions())
+
+
+def _unique_group_ids(doc: Document) -> list[int]:
+    """Group ids of the current revisions, in first-seen (document) order."""
+    seen: list[int] = []
+    for rev in doc.list_revisions():
+        if rev.group_id is not None and rev.group_id not in seen:
+            seen.append(rev.group_id)
+    return seen
+
+
+def run_resolve(persist_path: Path, n_ops: int, mode: str) -> tuple[float, int]:
+    """Time one resolution of an n_ops redline on a fresh copy.
+
+    Returns (elapsed seconds, revisions resolved). The redline build is not
+    timed — only the resolve call(s).
+    """
+    tmp = tempfile.mkdtemp(prefix="bench_accept_")
+    try:
+        dest = Path(tmp) / "a.docx"
+        shutil.copy(persist_path, dest)
+        doc = Document.open(dest, force_recreate=True)
+        try:
+            n_revs = _build_redline(doc, n_ops)
+
+            if mode == "accept_all":
+                start = time.perf_counter()
+                resolved = doc.accept_all()
+                elapsed = time.perf_counter() - start
+            elif mode == "accept_changeset":
+                changeset_id = doc.list_revisions()[0].changeset_id
+                assert changeset_id is not None
+                start = time.perf_counter()
+                resolved = doc.accept_changeset(changeset_id)
+                elapsed = time.perf_counter() - start
+            elif mode == "accept_group_loop":
+                group_ids = _unique_group_ids(doc)
+                start = time.perf_counter()
+                resolved = sum(doc.accept_group(gid) for gid in group_ids)
+                elapsed = time.perf_counter() - start
+            else:
+                raise ValueError(f"unknown mode: {mode}")
+
+            assert resolved == n_revs, f"{mode}: resolved {resolved} of {n_revs} revisions"
+            assert doc.list_revisions() == [], f"{mode}: {len(doc.list_revisions())} revisions left unresolved"
+            return elapsed, n_revs
+        finally:
+            doc.close()
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="accept-path scaling benchmark (ISSUES.md #57)")
+    parser.add_argument("--ops", type=int, default=None, help="extra op count to measure (e.g. 500)")
+    parser.add_argument("--paras", type=int, default=N_PARAGRAPHS, help=f"document size (default {N_PARAGRAPHS})")
+    args = parser.parse_args()
+    if args.ops is not None and args.ops < 1:
+        parser.error("--ops must be >= 1")
+    if args.paras < 1:
+        parser.error("--paras must be >= 1")
+
+    op_counts = [10, 40, 120]
+    if args.ops is not None and args.ops not in op_counts:
+        op_counts.append(args.ops)
+
+    print(f"Building {args.paras}-paragraph document...")
+    persist_path, tmp = build_large_doc(args.paras)
+    try:
+        print()
+        header = (
+            f"{'ops':>5} {'revs':>5} | {'accept_all':>10} | "
+            f"{'changeset':>10} {'ratio':>6} | {'group×N':>10} {'ratio':>6}"
+        )
+        print(header)
+        print("-" * len(header))
+        for n in op_counts:
+            all_s, revs = run_resolve(persist_path, n, "accept_all")
+            cs_s, _ = run_resolve(persist_path, n, "accept_changeset")
+            grp_s, _ = run_resolve(persist_path, n, "accept_group_loop")
+            print(
+                f"{n:>5} {revs:>5} | {all_s:>9.3f}s | {cs_s:>9.3f}s {cs_s / all_s:>5.2f}x "
+                f"| {grp_s:>9.3f}s {grp_s / all_s:>5.2f}x"
+            )
+        print()
+        print("Ratios near 1.00x mean the group/changeset path no longer pays O(members x doc)")
+        print("(pre-#57 baseline on doc3000/240-rev: changeset 2.26x, group×N 2.59x).")
+        print("All correctness assertions passed (every revision resolved).")
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/docx_editor/track_changes.py
+++ b/docx_editor/track_changes.py
@@ -2937,17 +2937,23 @@ class RevisionManager:
 
         Built once per group/changeset resolution and threaded through
         ``accept_revision``/``reject_revision`` so locating a member is an O(1)
-        lookup instead of a fresh full-document scan (ISSUES.md #57). w:ins
-        wins over w:del on a duplicate id, matching the fresh-scan priority
-        (insertions are checked before deletions).
+        lookup instead of a fresh full-document scan (ISSUES.md #57).
+
+        One element per id is exact for this path: a duplicate w:id never
+        becomes a group member — ``_reconstruct_groups`` bars every duplicated
+        id from every inferred group, and our own allocator keeps recorded ids
+        unique — so a member id always maps to a single element. The
+        w:ins-before-w:del insertion order only settles a tie-break group
+        members never hit (it mirrors the fresh scan, which checks insertions
+        first).
         """
-        index: dict[str, Element] = {}
+        element_index: dict[str, Element] = {}
         for tag in ("w:ins", "w:del"):
             for elem in self.editor.dom.getElementsByTagName(tag):
-                index.setdefault(elem.getAttribute("w:id"), elem)
-        return index
+                element_index.setdefault(elem.getAttribute("w:id"), elem)
+        return element_index
 
-    def _is_in_document(self, elem: Element) -> bool:
+    def _is_in_document(self, elem) -> bool:
         """True if ``elem`` is still attached to the live document tree.
 
         Accepting/rejecting a revision detaches its element (unwrap or
@@ -2965,15 +2971,15 @@ class RevisionManager:
             node = node.parentNode
         return False
 
-    def _find_revision_element(self, revision_id: int, index: dict[str, Element] | None) -> Element | None:
+    def _find_revision_element(self, revision_id: int, element_index: dict[str, Element] | None) -> Element | None:
         """Locate the live <w:ins>/<w:del> element for ``revision_id``.
 
-        ``index is None`` scans the document fresh (insertions before
+        ``element_index is None`` scans the document fresh (insertions before
         deletions), matching the historical lookup exactly. Otherwise the id is
-        resolved through the pre-built ``index`` and confirmed still-attached
-        via ``_is_in_document``.
+        resolved through the pre-built ``element_index`` and confirmed
+        still-attached via ``_is_in_document``.
         """
-        if index is None:
+        if element_index is None:
             for ins_elem in self.editor.dom.getElementsByTagName("w:ins"):
                 if ins_elem.getAttribute("w:id") == str(revision_id):
                     return ins_elem
@@ -2981,12 +2987,12 @@ class RevisionManager:
                 if del_elem.getAttribute("w:id") == str(revision_id):
                     return del_elem
             return None
-        elem = index.get(str(revision_id))
+        elem = element_index.get(str(revision_id))
         if elem is None or not self._is_in_document(elem):
             return None
         return elem
 
-    def accept_revision(self, revision_id: int, index: dict[str, Element] | None = None) -> bool:
+    def accept_revision(self, revision_id: int, element_index: dict[str, Element] | None = None) -> bool:
         """Accept a revision by ID.
 
         For insertions: removes the w:ins wrapper, keeping the content.
@@ -2994,7 +3000,7 @@ class RevisionManager:
 
         Args:
             revision_id: The w:id of the revision to accept
-            index: Optional pre-built w:id -> element map (see
+            element_index: Optional pre-built w:id -> element map (see
                 ``_revision_element_index``) that lets group/changeset
                 resolution skip a full-DOM scan per member. ``None`` scans
                 fresh (standalone calls, accept_all/reject_all).
@@ -3002,7 +3008,7 @@ class RevisionManager:
         Returns:
             True if revision was accepted, False if not found
         """
-        elem = self._find_revision_element(revision_id, index)
+        elem = self._find_revision_element(revision_id, element_index)
         if elem is None:
             return False
         if elem.tagName == "w:ins":
@@ -3013,7 +3019,7 @@ class RevisionManager:
             self._remove_element(elem)
         return True
 
-    def reject_revision(self, revision_id: int, index: dict[str, Element] | None = None) -> bool:
+    def reject_revision(self, revision_id: int, element_index: dict[str, Element] | None = None) -> bool:
         """Reject a revision by ID.
 
         For insertions: removes the w:ins element and its content entirely.
@@ -3021,7 +3027,7 @@ class RevisionManager:
 
         Args:
             revision_id: The w:id of the revision to reject
-            index: Optional pre-built w:id -> element map (see
+            element_index: Optional pre-built w:id -> element map (see
                 ``_revision_element_index``) that lets group/changeset
                 resolution skip a full-DOM scan per member. ``None`` scans
                 fresh (standalone calls, accept_all/reject_all).
@@ -3029,7 +3035,7 @@ class RevisionManager:
         Returns:
             True if revision was rejected, False if not found
         """
-        elem = self._find_revision_element(revision_id, index)
+        elem = self._find_revision_element(revision_id, element_index)
         if elem is None:
             return False
         if elem.tagName == "w:ins":
@@ -3057,12 +3063,12 @@ class RevisionManager:
         already gone.
         """
         members = list(members)
-        index = self._revision_element_index()
+        element_index = self._revision_element_index()
         count = 0
         while True:
             progressed = False
             for rev_id in sorted(members, reverse=True):
-                if resolve(rev_id, index):
+                if resolve(rev_id, element_index):
                     count += 1
                     progressed = True
             if not progressed:

--- a/docx_editor/track_changes.py
+++ b/docx_editor/track_changes.py
@@ -2932,7 +2932,61 @@ class RevisionManager:
             changeset_source=self._changeset_sources.get(changeset_id) if changeset_id is not None else None,
         )
 
-    def accept_revision(self, revision_id: int) -> bool:
+    def _revision_element_index(self) -> dict[str, Element]:
+        """Map ``w:id`` -> its <w:ins>/<w:del> element, one full-DOM walk per tag.
+
+        Built once per group/changeset resolution and threaded through
+        ``accept_revision``/``reject_revision`` so locating a member is an O(1)
+        lookup instead of a fresh full-document scan (ISSUES.md #57). w:ins
+        wins over w:del on a duplicate id, matching the fresh-scan priority
+        (insertions are checked before deletions).
+        """
+        index: dict[str, Element] = {}
+        for tag in ("w:ins", "w:del"):
+            for elem in self.editor.dom.getElementsByTagName(tag):
+                index.setdefault(elem.getAttribute("w:id"), elem)
+        return index
+
+    def _is_in_document(self, elem: Element) -> bool:
+        """True if ``elem`` is still attached to the live document tree.
+
+        Accepting/rejecting a revision detaches its element (unwrap or
+        removeChild), and a member nested inside an already-resolved member
+        detaches together with its host. Either way the element is no longer
+        reachable from the document root, so a snapshot lookup must treat it as
+        gone — reproducing the "not found by getElementsByTagName" signal the
+        fresh scan relied on for rump tolerance and no-double-count.
+        """
+        node = elem
+        root = self.editor.dom
+        while node is not None:
+            if node is root:
+                return True
+            node = node.parentNode
+        return False
+
+    def _find_revision_element(self, revision_id: int, index: dict[str, Element] | None) -> Element | None:
+        """Locate the live <w:ins>/<w:del> element for ``revision_id``.
+
+        ``index is None`` scans the document fresh (insertions before
+        deletions), matching the historical lookup exactly. Otherwise the id is
+        resolved through the pre-built ``index`` and confirmed still-attached
+        via ``_is_in_document``.
+        """
+        if index is None:
+            for ins_elem in self.editor.dom.getElementsByTagName("w:ins"):
+                if ins_elem.getAttribute("w:id") == str(revision_id):
+                    return ins_elem
+            for del_elem in self.editor.dom.getElementsByTagName("w:del"):
+                if del_elem.getAttribute("w:id") == str(revision_id):
+                    return del_elem
+            return None
+        elem = index.get(str(revision_id))
+        if elem is None or not self._is_in_document(elem):
+            return None
+        return elem
+
+    def accept_revision(self, revision_id: int, index: dict[str, Element] | None = None) -> bool:
         """Accept a revision by ID.
 
         For insertions: removes the w:ins wrapper, keeping the content.
@@ -2940,28 +2994,26 @@ class RevisionManager:
 
         Args:
             revision_id: The w:id of the revision to accept
+            index: Optional pre-built w:id -> element map (see
+                ``_revision_element_index``) that lets group/changeset
+                resolution skip a full-DOM scan per member. ``None`` scans
+                fresh (standalone calls, accept_all/reject_all).
 
         Returns:
             True if revision was accepted, False if not found
         """
-        # Try to find as insertion
-        for ins_elem in self.editor.dom.getElementsByTagName("w:ins"):
-            if ins_elem.getAttribute("w:id") == str(revision_id):
-                # Accept insertion: unwrap the content
-                self._unwrap_element(ins_elem)
-                return True
+        elem = self._find_revision_element(revision_id, index)
+        if elem is None:
+            return False
+        if elem.tagName == "w:ins":
+            # Accept insertion: unwrap the content
+            self._unwrap_element(elem)
+        else:  # w:del
+            # Accept deletion: remove the element entirely
+            self._remove_element(elem)
+        return True
 
-        # Try to find as deletion
-        for del_elem in self.editor.dom.getElementsByTagName("w:del"):
-            if del_elem.getAttribute("w:id") == str(revision_id):
-                # Accept deletion: remove the element entirely
-                parent = del_elem.parentNode
-                parent.removeChild(del_elem)
-                return True
-
-        return False
-
-    def reject_revision(self, revision_id: int) -> bool:
+    def reject_revision(self, revision_id: int, index: dict[str, Element] | None = None) -> bool:
         """Reject a revision by ID.
 
         For insertions: removes the w:ins element and its content entirely.
@@ -2969,28 +3021,26 @@ class RevisionManager:
 
         Args:
             revision_id: The w:id of the revision to reject
+            index: Optional pre-built w:id -> element map (see
+                ``_revision_element_index``) that lets group/changeset
+                resolution skip a full-DOM scan per member. ``None`` scans
+                fresh (standalone calls, accept_all/reject_all).
 
         Returns:
             True if revision was rejected, False if not found
         """
-        # Try to find as insertion
-        for ins_elem in self.editor.dom.getElementsByTagName("w:ins"):
-            if ins_elem.getAttribute("w:id") == str(revision_id):
-                # Reject insertion: remove entirely
-                parent = ins_elem.parentNode
-                parent.removeChild(ins_elem)
-                return True
+        elem = self._find_revision_element(revision_id, index)
+        if elem is None:
+            return False
+        if elem.tagName == "w:ins":
+            # Reject insertion: remove entirely
+            self._remove_element(elem)
+        else:  # w:del
+            # Reject deletion: restore the deleted text
+            self._restore_deletion(elem)
+        return True
 
-        # Try to find as deletion
-        for del_elem in self.editor.dom.getElementsByTagName("w:del"):
-            if del_elem.getAttribute("w:id") == str(revision_id):
-                # Reject deletion: restore the deleted text
-                self._restore_deletion(del_elem)
-                return True
-
-        return False
-
-    def _resolve_ids(self, members: Iterable[int], resolve: Callable[[int], bool]) -> int:
+    def _resolve_ids(self, members: Iterable[int], resolve: Callable[[int, dict[str, Element] | None], bool]) -> int:
         """Apply ``resolve`` (accept/reject_revision) to every id in ``members``.
 
         Same reverse-id, loop-until-no-progress pattern as accept_all/
@@ -2998,23 +3048,31 @@ class RevisionManager:
         resolvable once their host is processed, and members already resolved
         individually are simply skipped. Shared by group and changeset
         resolution (a changeset passes the union of its groups' revisions).
+
+        The w:id -> element index is built once here and threaded through every
+        ``resolve`` call, so resolution costs two full-DOM walks total instead
+        of one scan per member per pass (ISSUES.md #57). The index stays valid
+        across passes: accept/reject only ever *detach* elements, and
+        ``_is_in_document`` (inside ``resolve``) treats a detached member as
+        already gone.
         """
         members = list(members)
+        index = self._revision_element_index()
         count = 0
         while True:
             progressed = False
             for rev_id in sorted(members, reverse=True):
-                if resolve(rev_id):
+                if resolve(rev_id, index):
                     count += 1
                     progressed = True
             if not progressed:
                 return count
 
-    def _resolve_group(self, group_id: int, resolve: Callable[[int], bool]) -> int:
+    def _resolve_group(self, group_id: int, resolve: Callable[[int, dict[str, Element] | None], bool]) -> int:
         """Apply ``resolve`` to every member revision of a group."""
         return self._resolve_ids(self.group_revisions(group_id), resolve)
 
-    def _resolve_changeset(self, changeset_id: int, resolve: Callable[[int], bool]) -> int:
+    def _resolve_changeset(self, changeset_id: int, resolve: Callable[[int, dict[str, Element] | None], bool]) -> int:
         """Apply ``resolve`` to every revision across all groups of a changeset.
 
         A revision belongs to exactly one group, so the changeset's groups
@@ -3151,6 +3209,10 @@ class RevisionManager:
             child = elem.firstChild
             parent.insertBefore(child, elem)
         parent.removeChild(elem)
+
+    def _remove_element(self, elem) -> None:
+        """Detach an element (and its whole subtree) from its parent."""
+        elem.parentNode.removeChild(elem)
 
     def _restore_deletion(self, del_elem) -> None:
         """Restore deleted content by converting w:delText back to w:t."""

--- a/tests/test_revision_groups.py
+++ b/tests/test_revision_groups.py
@@ -1363,6 +1363,19 @@ class TestAcceptPathIndex:
         "<w:r><w:t>gamma</w:t></w:r></w:ins></w:p>"
     )
 
+    # Same nesting, but the host id (5) is HIGHER than the nested id (2), so
+    # reverse-id order processes the host FIRST — before the nested member is
+    # ever resolved on its own. This is the branch _is_in_document is written
+    # for (a member detaching together with its already-resolved host), which
+    # NESTED_BODY (host id 1 < nested id 2) never reaches.
+    NESTED_BODY_HOST_HIGH = (
+        f'<w:p><w:ins w:id="5" w:author="{AUTHOR_A}" w:date="{DATE_A}">'
+        "<w:r><w:t>alpha </w:t></w:r>"
+        f'<w:del w:id="2" w:author="{AUTHOR_A}" w:date="{DATE_A}">'
+        "<w:r><w:delText>beta </w:delText></w:r></w:del>"
+        "<w:r><w:t>gamma</w:t></w:r></w:ins></w:p>"
+    )
+
     @staticmethod
     def _accepted_text(manager: RevisionManager) -> str:
         """Accepted-view text of the manager's DOM (w:delText excluded)."""
@@ -1421,6 +1434,31 @@ class TestAcceptPathIndex:
         # deletion (removed): both members counted once, neither skipped.
         manager = _make_manager(temp_xml(self.NESTED_BODY))
         assert manager.group_revisions(1) == (1, 2)
+
+        assert manager.accept_group(1) == 2
+        assert manager.list_revisions() == []
+        assert self._accepted_text(manager) == "alpha gamma"
+
+    def test_reject_group_host_removed_before_nested_is_resolved(self, temp_xml):
+        # host id 5 > nested id 2, so reverse-id order rejects the host w:ins
+        # FIRST, removing its whole subtree — the nested w:del is gone before it
+        # is ever resolved on its own. The connectivity guard skips it (count 1,
+        # not 2, and no mutation of a detached subtree). This order-dependent
+        # count is pre-existing and identical under the old fresh-scan path (a
+        # fresh scan would likewise not find the removed nested del).
+        manager = _make_manager(temp_xml(self.NESTED_BODY_HOST_HIGH))
+        assert manager.group_revisions(1) == (5, 2)  # host ins first, nested del
+
+        assert manager.reject_group(1) == 1  # host applied; nested detached with it
+        assert manager.list_revisions() == []
+        assert self._accepted_text(manager) == ""
+
+    def test_accept_group_host_high_still_resolves_both(self, temp_xml):
+        # host id 5 > nested id 2: accepting the host UNWRAPS it (content, incl.
+        # the nested del, stays attached), so the nested member is still live
+        # and gets resolved on its own — both counted, unlike the reject case.
+        manager = _make_manager(temp_xml(self.NESTED_BODY_HOST_HIGH))
+        assert manager.group_revisions(1) == (5, 2)
 
         assert manager.accept_group(1) == 2
         assert manager.list_revisions() == []

--- a/tests/test_revision_groups.py
+++ b/tests/test_revision_groups.py
@@ -20,7 +20,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
-from conftest import find_ref
+from conftest import count_dom_walks, find_ref
 
 from docx_editor import Document, EditOperation, EditResult, RevisionError
 from docx_editor.exceptions import BatchOperationError, DocxEditError
@@ -1340,3 +1340,88 @@ class TestChangesetTier:
                 assert rev.changeset_id is not None
                 by_cs.setdefault(rev.changeset_id, set()).add((rev.author, rev.date))
             assert all(len(keys) == 1 for keys in by_cs.values())
+
+
+class TestAcceptPathIndex:
+    """The group/changeset accept path builds one w:id->element index per call
+    instead of scanning the whole document per member (ISSUES.md #57).
+
+    Each resolution does exactly two Document-level walks (one w:ins scan, one
+    w:del scan) to build the index, no matter how many revisions it spans.
+    Pre-#57, accept_revision/reject_revision each did up to two full-document
+    walks, repeated per member per pass (O(members x doc)) — a 240-revision
+    accept_changeset paid ~960 walks.
+    """
+
+    # A host insertion whose content includes a nested deletion, both by the
+    # same author+date so reconstruction bundles them into ONE inferred group.
+    NESTED_BODY = (
+        f'<w:p><w:ins w:id="1" w:author="{AUTHOR_A}" w:date="{DATE_A}">'
+        "<w:r><w:t>alpha </w:t></w:r>"
+        f'<w:del w:id="2" w:author="{AUTHOR_A}" w:date="{DATE_A}">'
+        "<w:r><w:delText>beta </w:delText></w:r></w:del>"
+        "<w:r><w:t>gamma</w:t></w:r></w:ins></w:p>"
+    )
+
+    @staticmethod
+    def _accepted_text(manager: RevisionManager) -> str:
+        """Accepted-view text of the manager's DOM (w:delText excluded)."""
+        return "".join(
+            node.firstChild.data
+            for node in manager.editor.dom.getElementsByTagName("w:t")
+            if node.firstChild is not None
+        )
+
+    @pytest.mark.parametrize("method", ["accept_changeset", "reject_changeset"])
+    def test_changeset_resolution_builds_index_once(self, temp_docx, monkeypatch, method):
+        with Document.open(temp_docx) as doc:
+            ref = find_ref(doc, "quick brown fox")
+            # One batch = one changeset over three groups = six revisions.
+            doc.batch_edit([
+                EditOperation.replace("quick", "speedy", paragraph=ref),
+                EditOperation.replace("brown", "red", paragraph=ref),
+                EditOperation.replace("lazy", "sleepy", paragraph=ref),
+            ])
+            changeset_id = doc.list_revisions()[0].changeset_id
+            assert changeset_id is not None
+            assert len(doc.list_revisions()) == 6
+
+            walks = count_dom_walks(monkeypatch)
+            assert getattr(doc, method)(changeset_id) == 6
+            # One index build, not one scan per member per pass.
+            assert walks == ["w:ins", "w:del"]
+            assert doc.list_revisions() == []
+
+    @pytest.mark.parametrize("method", ["accept_group", "reject_group"])
+    def test_group_resolution_builds_index_once(self, temp_docx, monkeypatch, method):
+        with Document.open(temp_docx) as doc:
+            ref = find_ref(doc, "quick brown fox")
+            result = doc.replace("quick", "speedy", paragraph=ref)  # one group, two revs
+
+            walks = count_dom_walks(monkeypatch)
+            assert getattr(doc, method)(result.group_id) == 2
+            assert walks == ["w:ins", "w:del"]
+            assert doc.list_revisions() == []
+
+    def test_reject_group_with_nested_member_counts_once(self, temp_xml):
+        # Rejecting the host insertion removes its whole subtree; the nested
+        # deletion (id 2, resolved first in reverse-id order) detaches with the
+        # host and must be counted exactly once. Connectivity — not a fresh
+        # per-member scan — is what stops the detached member being re-resolved
+        # (which would mutate a detached subtree and over-count).
+        manager = _make_manager(temp_xml(self.NESTED_BODY))
+        assert manager.group_revisions(1) == (1, 2)  # host ins + nested del
+
+        assert manager.reject_group(1) == 2
+        assert manager.list_revisions() == []
+        assert self._accepted_text(manager) == ""
+
+    def test_accept_group_with_nested_member_counts_once(self, temp_xml):
+        # Accepting keeps the insertion (unwrapped) and applies the nested
+        # deletion (removed): both members counted once, neither skipped.
+        manager = _make_manager(temp_xml(self.NESTED_BODY))
+        assert manager.group_revisions(1) == (1, 2)
+
+        assert manager.accept_group(1) == 2
+        assert manager.list_revisions() == []
+        assert self._accepted_text(manager) == "alpha gamma"


### PR DESCRIPTION
## Summary

Optimizes the group/changeset accept/reject path from **O(members × doc)** to **O(doc + members × depth)** (ISSUES.md #57).

Previously `accept_revision`/`reject_revision` located each member by up to two full-document `getElementsByTagName` walks, and `_resolve_ids` repeated that per member per convergence pass. A 240-revision `accept_changeset` measured 5.35s (2.26× `accept_all`).

Now a `w:id → element` index is built **once** per group/changeset resolution (two Document walks total) and threaded through every member lookup:

- `_revision_element_index()` — builds the map (`w:ins` before `w:del`, so `w:ins` wins a duplicate id).
- `_is_in_document(elem)` — O(depth) `parentNode`-to-root connectivity check that reproduces the "not found by `getElementsByTagName`" signal the fresh scan relied on for rump tolerance and nested-member no-double-count.
- `_find_revision_element(id, index)` — `index is None` reproduces the original fresh scan verbatim; otherwise O(1) dict hit + connectivity check.
- `_remove_element(elem)` — extracted removeChild helper (also fixes minidom `parentNode` type-narrowing).

Standalone calls and `accept_all`/`reject_all` keep `index=None` (fresh scan). The public `Document` API is unchanged — the optional `index` lives only on the semi-internal `RevisionManager` and mirrors the existing `paragraphs=None` perf-parameter idiom in this file.

## Correctness

An element is returned by a fresh `getElementsByTagName` iff it is attached to the document tree. The index is built from the initial DOM; resolution only ever *detaches* nodes (never creates a new `w:ins`/`w:del`), so the index stays valid across all convergence passes and `_is_in_document` catches members that detached with a resolved host.

## Tests & benchmark

- `TestAcceptPathIndex` — pins that resolution builds the index exactly once (`walks == ["w:ins", "w:del"]`) and that a nested member is counted once on both accept and reject.
- `benchmarks/accept_scaling.py` — informational scaling benchmark (changeset/group×N ratio vs `accept_all`).

## Verification

- `pytest tests/test_revision_groups.py` → 73 passed
- `pytest -k "revision or accept or reject or track or mixed or changeset or group or foreign"` → 411 passed
- `ruff check` clean · `ty check` clean
- benchmark correctness assertions pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved the speed of accepting or rejecting revision changesets and groups, especially in documents with many revisions.
  * Reduced repeated processing when resolving grouped or nested changes.

* **Bug Fixes**
  * Improved handling of nested revisions so grouped changes are applied or rejected correctly without duplicate processing.

* **Tests**
  * Added coverage for revision resolution performance and nested group behavior.

* **Documentation**
  * Added a benchmark for measuring revision-resolution performance across document sizes and operation counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->