### PR TITLE
feat: tracked paragraph splits on newline (ISSUES.md #58+61)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -395,6 +395,38 @@ Insert text before anchor with tracked changes. Foreign pending insertions are t
 ref = doc.insert_before("Section 6", "New clause: ", paragraph="P4#a7b2")
 ```
 
+> **Newlines split paragraphs.** A `\n` in any content text (`replace`'s
+> `replace_with`, `insert_after`/`insert_before`'s `text`, `rewrite_paragraph`'s
+> `new_text`, or a `batch_edit` op) is a **tracked paragraph split**: the first
+> paragraph's mark is flagged inserted and the tail moves into a new paragraph.
+> Accepting keeps the split; rejecting rejoins. All other C0 control characters
+> (`\t`, `\r`, …) are rejected with a teaching `ValueError`. See
+> [`split_paragraph`](#split_paragraphref-before-occurrencenone) and [`EditResult`](#editresult).
+
+#### `split_paragraph(ref, *, before, occurrence=None)`
+
+Split a paragraph into two with a tracked paragraph break, cutting immediately
+before `before`. Explicit sugar for the `\n`-means-split behavior (equivalent to
+`insert_before(before, "\n", ...)`): the paragraph mark is flagged as an inserted
+revision and the tail (from `before` on) moves into a new following paragraph.
+Accepting keeps the split; rejecting the group rejoins the two paragraphs.
+
+**Parameters:**
+
+- `ref` (str): Paragraph reference from `list_paragraphs()`, such as `P2#f3c1`
+- `before` (str, keyword-only): Text to split before; the break lands at its start. Must be a non-empty string in the paragraph.
+- `occurrence` (int | None): Which occurrence of `before` within the paragraph, 0-based. Omitted → `before` must be unique in the paragraph, else [`AmbiguousTextError`](#ambiguoustexterror).
+
+**Returns:** The first paragraph's reference ([`EditResult`](#editresult)); its `refs` tuple carries the refs of **both** resulting paragraphs.
+
+**Example:**
+
+```python
+result = doc.split_paragraph("P2#f3c1", before="However,")
+first_ref, second_ref = result.refs
+doc.reject_group(result.group_id)  # rejoin
+```
+
 #### `rewrite_paragraph(ref, new_text)`
 
 Rewrite a paragraph using tracked changes generated from a word-level diff.
@@ -1010,6 +1042,7 @@ from docx_editor import EditResult
 | `group_id` | int or None | Revision group holding every revision this edit created, for [`accept_group()`](#accept_groupgroup_id) / [`reject_group()`](#reject_groupgroup_id). None when the edit created no new revisions (e.g. text spliced into one of your own pending insertions, a no-change rewrite, or a rewrite whose changes all merged into your own pending insertions). Valid only while this Document stays open — after reopen the same revisions belong to a freshly inferred group with a new id. |
 | `changeset_id` | int or None | Changeset (one whole call) this edit's group belongs to, for [`accept_changeset()`](#accept_changesetchangeset_id) / [`reject_changeset()`](#reject_changesetchangeset_id). Every `EditResult` from one `batch_edit`/`batch_rewrite` shares it; None iff `group_id` is None. Per-open-`Document`, like `group_id`. |
 | `revision_ids` | tuple[int, ...] | The `w:id`s of the group's member revisions, in creation order; `()` when `group_id` is None |
+| `refs` | tuple[str, ...] | Every resulting paragraph ref, in document order. `(str(self),)` for a normal edit; for a `\n` paragraph split it carries the first paragraph (== the string value) plus one ref per new paragraph the split created. A split shifts later indexes, so re-resolve stale refs before reuse. |
 
 ### Example
 
@@ -1019,6 +1052,11 @@ print(str(result))          # "P2#c3d4" — the new paragraph ref
 print(result.group_id)      # 1
 print(result.changeset_id)  # 1 — a single edit is a one-group changeset
 print(result.revision_ids)  # (0, 1) — the del and the ins
+print(result.refs)          # ("P2#c3d4",) — one ref (a split would give more)
+
+# A newline splits the paragraph; refs covers both halves:
+split = doc.replace("end.", "end.\nNew paragraph.", paragraph="P2#c3d4")
+print(split.refs)           # ("P2#…", "P3#…")
 
 doc.replace("net", "gross", paragraph=result)  # usable as a plain ref
 doc.reject_group(result.group_id)              # undo the first edit entirely

--- a/docx_editor/comments.py
+++ b/docx_editor/comments.py
@@ -425,7 +425,7 @@ class CommentManager:
         if not isinstance(reply_text, str) or not reply_text:
             raise ValueError(f"reply_to_comment(): 'reply' must be a non-empty string, got {reply_text!r}")
         try:
-            _reject_control_chars(reply_text, field="reply", ctx="reply_to_comment(): ", allow_newline=False)
+            _reject_control_chars(reply_text, field="'reply'", ctx="reply_to_comment(): ", allow_newline=False)
         except ValueError as e:
             raise CommentError(str(e)) from e
         if parent_comment_id not in self.existing_comments:

--- a/docx_editor/comments.py
+++ b/docx_editor/comments.py
@@ -24,6 +24,7 @@ from .xml_editor import (
     TextMapMatch,
     _escape_xml,
     _generate_hex_id,
+    _reject_control_chars,
     _require_valid_occurrence,
     build_text_map,
     compute_paragraph_hash,
@@ -166,6 +167,13 @@ class CommentManager:
             # Must fail here, before _place_markers mutates document.xml —
             # a crash later (html.escape) would leave orphaned range markers.
             raise CommentError(f"comment_text must be a string, got {comment_text!r}")
+        # Comments carry no split semantics, so reject '\n' too — a literal
+        # newline in a single <w:t> would be an invisible, unreviewable artifact.
+        try:
+            _reject_control_chars(anchor_text, field="anchor_text", ctx="add_comment(): ", allow_newline=False)
+            _reject_control_chars(comment_text, field="comment_text", ctx="add_comment(): ", allow_newline=False)
+        except ValueError as e:
+            raise CommentError(str(e)) from e
         _, match = self._locate_anchor(anchor_text, paragraph, occurrence)
 
         comment_id = self.next_comment_id
@@ -416,6 +424,10 @@ class CommentManager:
         # reply would otherwise be serialized into comments.xml as "None".
         if not isinstance(reply_text, str) or not reply_text:
             raise ValueError(f"reply_to_comment(): 'reply' must be a non-empty string, got {reply_text!r}")
+        try:
+            _reject_control_chars(reply_text, field="reply", ctx="reply_to_comment(): ", allow_newline=False)
+        except ValueError as e:
+            raise CommentError(str(e)) from e
         if parent_comment_id not in self.existing_comments:
             raise CommentError(
                 f"Parent comment with id={parent_comment_id} not found",

--- a/docx_editor/document.py
+++ b/docx_editor/document.py
@@ -412,12 +412,15 @@ class Document:
             and (para := _ancestor_paragraph(elem)) is not None
             and id(para) in index_map
         ]
-        if not member_paras:
+        # Both fallbacks below are defensive: a split group's revisions always
+        # resolve to live, consecutive paragraphs, so member_paras is non-empty
+        # and the sibling walk never runs short.
+        if not member_paras:  # pragma: no cover
             return (self._compute_new_ref(old_ref, paragraphs),)
         current = min(member_paras, key=lambda p: index_map[id(p)])
         refs: list[str] = []
         for _ in range(mgr.split_count(group_id) + 1):
-            if current is None or id(current) not in index_map:
+            if current is None or id(current) not in index_map:  # pragma: no cover
                 break
             refs.append(f"P{index_map[id(current)]}#{compute_paragraph_hash(current)}")
             sibling = current.nextSibling

--- a/docx_editor/document.py
+++ b/docx_editor/document.py
@@ -20,6 +20,7 @@ from .track_changes import (
     Revision,
     RevisionManager,
     SearchResult,
+    _ancestor_paragraph,
 )
 from .workspace import Workspace
 from .xml_editor import (
@@ -350,16 +351,80 @@ class Document:
         new_hash = compute_paragraph_hash(p)
         return f"P{ref.index}#{new_hash}"
 
-    def _edit_result(self, old_ref: str, group_id: int | None, paragraphs: list[Element] | None = None) -> EditResult:
+    def _edit_result(
+        self,
+        old_ref: str,
+        group_id: int | None,
+        paragraphs: list[Element] | None = None,
+        element_index: dict[str, Element] | None = None,
+    ) -> EditResult:
         """Build an EditResult from a mutated paragraph's old ref, group, and changeset."""
         revision_ids = self._revision_manager.group_revisions(group_id) if group_id is not None else ()
         changeset_id = self._revision_manager.changeset_id_of(group_id) if group_id is not None else None
+        if paragraphs is None:
+            paragraphs = self._document_editor.dom.getElementsByTagName("w:p")
+        refs = self._resulting_refs(old_ref, group_id, paragraphs, element_index)
         return EditResult(
-            self._compute_new_ref(old_ref, paragraphs),
+            refs[0],
             group_id=group_id,
             revision_ids=revision_ids,
             changeset_id=changeset_id,
+            refs=refs,
         )
+
+    def _resulting_refs(
+        self,
+        old_ref: str,
+        group_id: int | None,
+        paragraphs: list[Element],
+        element_index: dict[str, Element] | None = None,
+    ) -> tuple[str, ...]:
+        """Refs of every paragraph a group's revisions landed in, document order.
+
+        A ``\\n`` edit splits one paragraph into several, so the group spans
+        more than one; this reads the *live* positions of the group's own
+        paragraphs, staying correct even when a split elsewhere in the same
+        batch shifted every later index. ``element_index`` (a pre-built ``w:id``
+        -> element map) is passed by a batch in which some op split, forcing the
+        identity path for *every* op so a shifted non-split op still resolves to
+        its live paragraph. Falls back to the single recomputed ref at
+        ``old_ref``'s index when the edit created no group (a no-op).
+        """
+        mgr = self._revision_manager
+        # Cheap path: no group, or (outside a splitting batch) a group that made
+        # no split — one paragraph at ``old_ref``'s index. split_count() is
+        # DOM-walk-free, so a no-split edit never pays for an element index.
+        if group_id is None or (element_index is None and mgr.split_count(group_id) == 0):
+            return (self._compute_new_ref(old_ref, paragraphs),)
+        # Locate the group's paragraphs by identity so refs stay correct even
+        # after a split shifted every later index.
+        if element_index is None:
+            element_index = mgr._revision_element_index()
+        index_map = {id(p): i for i, p in enumerate(paragraphs, start=1)}
+        # First resulting paragraph = the lowest live index among the group's
+        # own paragraphs. A pure split (split_paragraph) leaves the tail
+        # paragraph with no revision of its own, so the resulting paragraphs are
+        # `split_count + 1` consecutive siblings starting there — walk them.
+        member_paras = [
+            para
+            for rev_id in mgr.group_revisions(group_id)
+            if (elem := element_index.get(str(rev_id))) is not None
+            and (para := _ancestor_paragraph(elem)) is not None
+            and id(para) in index_map
+        ]
+        if not member_paras:
+            return (self._compute_new_ref(old_ref, paragraphs),)
+        current = min(member_paras, key=lambda p: index_map[id(p)])
+        refs: list[str] = []
+        for _ in range(mgr.split_count(group_id) + 1):
+            if current is None or id(current) not in index_map:
+                break
+            refs.append(f"P{index_map[id(current)]}#{compute_paragraph_hash(current)}")
+            sibling = current.nextSibling
+            while sibling is not None and (sibling.nodeType != sibling.ELEMENT_NODE or sibling.tagName != "w:p"):
+                sibling = sibling.nextSibling
+            current = sibling
+        return tuple(refs) if refs else (self._compute_new_ref(old_ref, paragraphs),)
 
     def paragraph_count(self) -> int:
         """Return the total number of paragraphs in the document.
@@ -1017,6 +1082,47 @@ class Document:
         change_id = self._revision_manager.insert_text_before(anchor, text, occurrence=occurrence, paragraph=paragraph)
         return self._edit_result(paragraph, self._revision_manager.group_id_of(change_id))
 
+    def split_paragraph(self, ref: str, *, before: str, occurrence: int | None = None) -> EditResult:
+        """Split a paragraph into two with a tracked paragraph break.
+
+        Explicit sugar for the ``\\n``-means-split behavior: the paragraph is
+        cut immediately before ``before``, its paragraph mark flagged as an
+        inserted revision and the tail (from ``before`` on) moved into a new
+        following paragraph. Accepting keeps the split; rejecting the group
+        rejoins the two paragraphs. Equivalent to
+        ``insert_before(before, "\\n", ...)``.
+
+        Args:
+            ref: Paragraph reference from list_paragraphs() (e.g., "P2#f3c1").
+            before: Text to split before (keyword-only); the break lands at its
+                start. Must be a non-empty string present in the paragraph.
+            occurrence: Which occurrence of ``before`` within the paragraph
+                (0 = first). Omitted → ``before`` must be unique in the
+                paragraph, else AmbiguousTextError.
+
+        Returns:
+            EditResult — the first paragraph's ref (with updated hash); its
+            ``refs`` tuple carries the refs of both resulting paragraphs, and
+            ``group_id``/``revision_ids`` cover the whole split.
+
+        Raises:
+            ValueError: If ``before`` is not a non-empty string, ``ref`` is not
+                a ref string, or ``occurrence`` is negative or not an integer.
+            TextNotFoundError: If ``before`` is absent or ``occurrence`` is out
+                of range for the paragraph.
+            AmbiguousTextError: If ``occurrence`` is omitted and ``before``
+                matches more than once in the paragraph.
+            HashMismatchError: If the paragraph hash is stale.
+
+        Example:
+            result = doc.split_paragraph("P2#f3c1", before="However,")
+            r1, r2 = result.refs
+        """
+        self._ensure_open()
+        _require_ref_string(ref)
+        change_id = self._revision_manager.insert_text_before(before, "\n", occurrence=occurrence, paragraph=ref)
+        return self._edit_result(ref, self._revision_manager.group_id_of(change_id))
+
     @overload
     def batch_edit(self, operations: list[EditOperation], *, dry_run: Literal[False] = ...) -> list[EditResult]: ...
 
@@ -1083,12 +1189,19 @@ class Document:
         change_ids = self._revision_manager.batch_edit(operations)
         if not change_ids:
             return []
-        # One <w:p> walk for all result refs — batch ops never change the
-        # paragraph set, so the snapshot is valid for every op.
+        # One shared <w:p> walk for all result refs. A \n split shifts every
+        # later paragraph's index, so if ANY op split, resolve EVERY op's ref by
+        # element identity (one shared revision-element index) — otherwise a
+        # shifted non-split op would report a stale index. A no-split batch skips
+        # the index entirely, so its DOM-walk count stays constant (ISSUES.md #51).
+        mgr = self._revision_manager
+        group_ids = [mgr.group_id_of(change_id) for change_id in change_ids]
+        any_split = any(gid is not None and mgr.split_count(gid) for gid in group_ids)
         paragraphs = self._document_editor.dom.getElementsByTagName("w:p")
+        element_index = mgr._revision_element_index() if any_split else None
         return [
-            self._edit_result(op.paragraph, self._revision_manager.group_id_of(change_id), paragraphs)
-            for op, change_id in zip(operations, change_ids, strict=True)
+            self._edit_result(op.paragraph, gid, paragraphs, element_index)
+            for op, gid in zip(operations, group_ids, strict=True)
         ]
 
     def rewrite_paragraph(self, ref: str, new_text: str) -> EditResult:
@@ -1162,7 +1275,16 @@ class Document:
         if not isinstance(rewrites, list):
             raise ValueError(f"batch_rewrite(): 'rewrites' must be a list of (ref, new_text) tuples, got {rewrites!r}")
         group_ids = self._revision_manager.batch_rewrite(rewrites)
-        return [self._edit_result(ref, group_id) for (ref, _), group_id in zip(rewrites, group_ids, strict=True)]
+        # Shared <w:p> walk; if any rewrite split, resolve every ref by element
+        # identity so a shifted later rewrite never reports a stale index.
+        mgr = self._revision_manager
+        any_split = any(gid is not None and mgr.split_count(gid) for gid in group_ids)
+        paragraphs = self._document_editor.dom.getElementsByTagName("w:p")
+        element_index = mgr._revision_element_index() if any_split else None
+        return [
+            self._edit_result(ref, group_id, paragraphs, element_index)
+            for (ref, _), group_id in zip(rewrites, group_ids, strict=True)
+        ]
 
     # ==================== Comments API ====================
 

--- a/docx_editor/track_changes.py
+++ b/docx_editor/track_changes.py
@@ -29,6 +29,7 @@ from .xml_editor import (
     TextMapMatch,
     TextPosition,
     _escape_xml,
+    _reject_control_chars,
     _require_valid_occurrence,
     build_text_map,
     compute_paragraph_hash,
@@ -113,6 +114,8 @@ class EditOperation:
                 f"EditOperation.replace(): 'replace_with' must be a string (empty string is allowed), "
                 f"got {replace_with!r}"
             )
+        _reject_control_chars(find, field="'find'", ctx="EditOperation.replace(): ", allow_newline=False)
+        _reject_control_chars(replace_with, field="'replace_with'", ctx="EditOperation.replace(): ", allow_newline=True)
         return cls(
             action="replace",
             paragraph=paragraph,
@@ -142,6 +145,7 @@ class EditOperation:
             raise ValueError(
                 f"EditOperation.delete(): 'text' must be a non-empty string — the text to mark as deleted, got {text!r}"
             )
+        _reject_control_chars(text, field="'text'", ctx="EditOperation.delete(): ", allow_newline=False)
         return cls(action="delete", paragraph=paragraph, text=text, occurrence=occurrence)
 
     @classmethod
@@ -163,6 +167,8 @@ class EditOperation:
             raise ValueError(
                 f"EditOperation.{action}(): 'text' must be a string (empty string is allowed), got {text!r}"
             )
+        _reject_control_chars(anchor, field="'anchor'", ctx=f"EditOperation.{action}(): ", allow_newline=False)
+        _reject_control_chars(text, field="'text'", ctx=f"EditOperation.{action}(): ", allow_newline=True)
         return cls(action=action, paragraph=paragraph, anchor=anchor, text=text, occurrence=occurrence)
 
     @classmethod
@@ -257,11 +263,20 @@ class EditResult(str):
       None. A later edit that splits one of these insertions adds the
       split-off half to the group — ``Document.list_revisions`` reflects
       live membership.
+    - ``refs``: every resulting paragraph ref, in document order. A normal
+      edit stays inside one paragraph, so ``refs`` is ``(str(self),)``. A
+      ``\\n`` edit is a tracked paragraph split, so ``refs`` carries the first
+      paragraph (== the string value) plus one ref per new paragraph the split
+      created (``("P2#…", "P3#…", …)``). Like all refs these are valid until
+      the next structural edit; after a split, later paragraphs' indexes have
+      shifted, so re-resolve (``list_paragraphs``/``find_text``) before reusing
+      stale refs.
     """
 
     group_id: int | None
     changeset_id: int | None
     revision_ids: tuple[int, ...]
+    refs: tuple[str, ...]
 
     def __new__(
         cls,
@@ -269,11 +284,13 @@ class EditResult(str):
         group_id: int | None = None,
         revision_ids: tuple[int, ...] = (),
         changeset_id: int | None = None,
+        refs: tuple[str, ...] | None = None,
     ) -> "EditResult":
         result = super().__new__(cls, ref)
         result.group_id = group_id
         result.changeset_id = changeset_id
         result.revision_ids = revision_ids
+        result.refs = refs if refs is not None else (str(ref),)
         return result
 
 
@@ -511,6 +528,44 @@ def _has_ancestor(node, ancestor) -> bool:
     return False
 
 
+def _first_child_element(parent, tag: str) -> Element | None:
+    """The first *direct* child of ``parent`` with tag name ``tag``, or None."""
+    for child in parent.childNodes:
+        if child.nodeType == child.ELEMENT_NODE and getattr(child, "tagName", "") == tag:
+            return child
+    return None
+
+
+def _next_element_sibling(node):
+    """The next sibling that is an element (skipping text/whitespace nodes)."""
+    while node is not None and node.nodeType != node.ELEMENT_NODE:
+        node = node.nextSibling
+    return node
+
+
+def _paragraph_mark_ins(paragraph) -> Element | None:
+    """The paragraph-mark insertion of ``paragraph``: the ``<w:ins>`` marker
+    inside ``<w:pPr><w:rPr>`` that flags this paragraph's mark as an inserted
+    revision (a tracked paragraph split), or None when the mark is not tracked.
+    """
+    pPr = _first_child_element(paragraph, "w:pPr")
+    if pPr is None:
+        return None
+    rPr = _first_child_element(pPr, "w:rPr")
+    if rPr is None:
+        return None
+    return _first_child_element(rPr, "w:ins")
+
+
+def _is_paragraph_mark_ins(ins) -> bool:
+    """True if ``ins`` is a paragraph-mark insertion (child of ``w:pPr/w:rPr``)."""
+    parent = ins.parentNode
+    if parent is None or getattr(parent, "tagName", "") != "w:rPr":
+        return False
+    grandparent = parent.parentNode
+    return grandparent is not None and getattr(grandparent, "tagName", "") == "w:pPr"
+
+
 @dataclass
 class _GroupCapture:
     """Filled in by ``RevisionManager._grouped`` when its with-block exits."""
@@ -617,6 +672,10 @@ class RevisionManager:
         # bundles, so batch_rewrite -> rewrite_paragraph merges into one
         # changeset (mirrors editor.frozen_timestamp's reuse guard).
         self._in_changeset = False
+        # Ids of paragraph-mark insertions (tracked splits), recorded and
+        # inferred alike. Lets split_count() answer without a DOM walk, so
+        # result-ref building stays cheap for the common no-split edit.
+        self._paragraph_mark_ids: set[int] = set()
         self._reconstruct_groups()
 
     def _reconstruct_groups(self) -> None:
@@ -662,6 +721,7 @@ class RevisionManager:
         contain an ambiguous member.
         """
         run_key: tuple[int, str, str] | None = None
+        run_para: Element | None = None
         run_members: list[int] = []
         # (author, date) -> changeset id, for the inferred changeset tier.
         # Groups anywhere in the document sharing an (author, date) join one
@@ -719,18 +779,48 @@ class RevisionManager:
                 rev_id = int(elem.getAttribute("w:id"))
             except ValueError:
                 rev_id = None
+            if rev_id is not None and _is_paragraph_mark_ins(elem):
+                self._paragraph_mark_ids.add(rev_id)
             if paragraph is None or not author or not date or rev_id is None or rev_id in duplicate_ids:
                 if rev_id is not None and rev_id in duplicate_ids:
                     self._revision_groups[rev_id] = None  # explicitly ungrouped
                 close_run()
                 run_key = None
+                run_para = None
                 continue
-            key = (id(paragraph), author, date)
-            if key != run_key:
+            # A paragraph boundary whose mark is an inserted revision by the
+            # same author+date is NOT a group boundary: the two paragraphs were
+            # one before a tracked split, so their revisions stay one group.
+            same_run = (
+                run_key is not None
+                and author == run_key[1]
+                and date == run_key[2]
+                and (paragraph is run_para or self._is_split_continuation(run_para, paragraph, author, date))
+            )
+            if not same_run:
                 close_run()
-                run_key = key
+            run_key = (id(paragraph), author, date)
+            run_para = paragraph
             run_members.append(rev_id)
         close_run()
+
+    def _is_split_continuation(self, prev_para, new_para, author: str, date: str) -> bool:
+        """True if ``new_para`` is the tail half of a tracked split of ``prev_para``.
+
+        The signal is durable and Word-preserved: ``prev_para`` carries a
+        paragraph-mark insertion (``<w:pPr><w:rPr><w:ins>``) by this same
+        author+date and ``new_para`` is its immediate next paragraph. Without
+        this, a reopened split — whose revisions span two paragraphs — would
+        reconstruct as two separate inferred groups.
+        """
+        if prev_para is None:
+            return False
+        mark = _paragraph_mark_ins(prev_para)
+        if mark is None:
+            return False
+        if mark.getAttribute("w:author") != author or mark.getAttribute("w:date") != date:
+            return False
+        return _next_element_sibling(prev_para.nextSibling) is new_para
 
     @contextmanager
     def _grouped(self) -> Iterator[_GroupCapture]:
@@ -910,6 +1000,16 @@ class RevisionManager:
     def changeset_id_of(self, group_id: int) -> int | None:
         """Changeset id of a group (recorded or inferred), or None if unassigned."""
         return self._group_changesets.get(group_id)
+
+    def split_count(self, group_id: int) -> int:
+        """Number of tracked paragraph splits a group made.
+
+        Counts the group's paragraph-mark insertions; the split spans
+        ``split_count + 1`` consecutive paragraphs. Zero for a normal edit.
+        Answered from ``_paragraph_mark_ids`` — no DOM walk — so building an
+        EditResult stays cheap for the common no-split edit.
+        """
+        return sum(1 for rev_id in self._groups.get(group_id, ()) if rev_id in self._paragraph_mark_ids)
 
     def changeset_groups(self, changeset_id: int) -> tuple[int, ...]:
         """Member group ids of ``changeset_id``, in group-creation order
@@ -1114,14 +1214,19 @@ class RevisionManager:
         if op.action == "replace":
             if not op.find or not isinstance(op.replace_with, str):
                 raise ValueError("replace requires 'find' and a string 'replace_with'")
+            _reject_control_chars(op.find, field="'find'", ctx="replace(): ", allow_newline=False)
+            _reject_control_chars(op.replace_with, field="'replace_with'", ctx="replace(): ", allow_newline=True)
             return op.find
         elif op.action == "delete":
             if not op.text:
                 raise ValueError("delete requires 'text'")
+            _reject_control_chars(op.text, field="'text'", ctx="delete(): ", allow_newline=False)
             return op.text
         elif op.action in ("insert_after", "insert_before"):
             if not op.anchor or not isinstance(op.text, str):
                 raise ValueError(f"{op.action} requires 'anchor' and a string 'text'")
+            _reject_control_chars(op.anchor, field="'anchor'", ctx=f"{op.action}(): ", allow_newline=False)
+            _reject_control_chars(op.text, field="'text'", ctx=f"{op.action}(): ", allow_newline=True)
             return op.anchor
         else:
             raise ValueError(f"Unknown action: {op.action}")
@@ -1343,6 +1448,7 @@ class RevisionManager:
                 f"rewrite_paragraph(): 'new_text' must be a string "
                 f"(empty string is allowed — it deletes all text), got {new_text!r}"
             )
+        _reject_control_chars(new_text, field="'new_text'", ctx="rewrite_paragraph(): ", allow_newline=True)
         with self._changeset(), self._grouped() as capture:
             self._rewrite_paragraph_inner(ref_str, new_text)
         return capture.group_id
@@ -1449,6 +1555,13 @@ class RevisionManager:
             char_pos: Character position in visible text to insert at
             text: Text to insert
         """
+        if "\n" in text:
+            self._ensure_splittable(paragraph)
+            segments = text.split("\n")
+            if segments[0]:
+                self._rewrite_insert_at(paragraph, text_map, char_pos, segments[0])
+            self._apply_paragraph_splits(paragraph, char_pos + len(segments[0]), segments[1:])
+            return
         if not text_map.positions:
             # Empty paragraph — append insertion
             # Get rPr from any existing run, or use empty
@@ -1739,6 +1852,8 @@ class RevisionManager:
         """
         if not isinstance(replace_with, str):
             raise ValueError(f"'replace_with' must be a string (empty string is allowed), got {replace_with!r}")
+        _reject_control_chars(find, field="'find'", ctx="replace(): ", allow_newline=False)
+        _reject_control_chars(replace_with, field="'replace_with'", ctx="replace(): ", allow_newline=True)
         with self._changeset(), self._grouped():
             if paragraph is not None:
                 ref = ParagraphRef.parse(paragraph)
@@ -1770,6 +1885,7 @@ class RevisionManager:
                 matches more than once in the search scope
             HashMismatchError: If the paragraph hash doesn't match
         """
+        _reject_control_chars(text, field="'text'", ctx="delete(): ", allow_newline=False)
         with self._changeset(), self._grouped():
             if paragraph is not None:
                 ref = ParagraphRef.parse(paragraph)
@@ -1889,7 +2005,12 @@ class RevisionManager:
         replace whose span trims to nothing on one side degenerates into a
         pure insertion or deletion; one that trims away entirely (replacement
         equals the match) is a no-op returning -1.
+
+        A ``\\n`` in ``replace_with`` means a tracked paragraph split — routed
+        to :meth:`_split_replace` (no affix-trimming).
         """
+        if "\n" in replace_with:
+            return self._split_replace(match, replace_with)
         prefix, suffix = _trim_replace_affixes(match.text, replace_with)
         del_text = match.text[prefix : len(match.text) - suffix]
         ins_text = replace_with[prefix : len(replace_with) - suffix]
@@ -2693,6 +2814,8 @@ class RevisionManager:
         """Insert text before or after anchor with tracked changes."""
         if not isinstance(text, str):
             raise ValueError(f"'text' must be a string (empty string is allowed), got {text!r}")
+        _reject_control_chars(anchor, field="'anchor'", ctx=f"insert_{position}(): ", allow_newline=False)
+        _reject_control_chars(text, field="'text'", ctx=f"insert_{position}(): ", allow_newline=True)
         with self._changeset(), self._grouped():
             if paragraph is not None:
                 ref = ParagraphRef.parse(paragraph)
@@ -2704,7 +2827,13 @@ class RevisionManager:
             return self._insert_near_match(match, text, position)
 
     def _insert_near_match(self, match: TextMapMatch, text: str, position: Literal["before", "after"]) -> int:
-        """Insert text before/after a match, splitting the edge w:t at the match boundary."""
+        """Insert text before/after a match, splitting the edge w:t at the match boundary.
+
+        A ``\\n`` in ``text`` means a tracked paragraph split — routed to
+        :meth:`_split_insert`.
+        """
+        if "\n" in text:
+            return self._split_insert(match, text, position)
         positions = match.positions
         if not positions:
             return -1
@@ -2758,6 +2887,230 @@ class RevisionManager:
             if node.nodeType == node.ELEMENT_NODE and node.tagName == "w:ins":
                 return int(node.getAttribute("w:id"))
         return -1
+
+    # ==================== Paragraph splits (\n) ====================
+
+    def _ensure_splittable(self, p1) -> None:
+        """Refuse to split a paragraph that ends a document section.
+
+        A paragraph-level ``w:sectPr`` marks a section boundary; moving it (or
+        duplicating it) across a split would silently corrupt the section
+        structure. Uncommon — the document-final section mark lives on
+        ``w:body``, not in a paragraph — so refuse cleanly rather than guess.
+        """
+        pPr = _first_child_element(p1, "w:pPr")
+        if pPr is not None and _first_child_element(pPr, "w:sectPr") is not None:
+            raise RevisionError(
+                "Cannot split a paragraph that carries a section mark (w:sectPr) — the section "
+                "boundary would be ambiguous. Edit around the section break instead."
+            )
+
+    def _reject_unsplittable_boundary(self, paragraph, text_map: TextMap, pos: int) -> None:
+        """Refuse a split whose boundary would cut inside an existing revision.
+
+        A split at visible position ``pos`` must fall on a run that is a *direct*
+        child of ``paragraph``; a boundary inside a pre-existing
+        ``<w:ins>``/``<w:del>``, hyperlink, or other inline container is not yet
+        supported. Called up front — before any delete/insert — by the split
+        dispatchers so a refused split never leaves a partial mutation (single
+        edits have no DOM rollback), and again by ``_collect_tail_nodes`` as the
+        backstop for the multi-op rewrite path. End-of-paragraph splits (empty
+        tail) are always fine.
+        """
+        if pos >= len(text_map.text):
+            return
+        edge = text_map.positions[pos]
+        run = self._find_ancestor(edge.node, "w:r")
+        if run is None or run.parentNode is not paragraph:
+            raise RevisionError(
+                "Cannot split a paragraph at a point inside an existing revision, "
+                "hyperlink, or other inline container (not yet supported)."
+            )
+
+    def _split_replace(self, match: TextMapMatch, replace_with: str) -> int:
+        """Replace ``match`` with text containing ``\\n`` — a tracked split.
+
+        Deletes the whole matched text, inserts the first segment where it was,
+        then splits the paragraph once per ``\\n``, inserting each following
+        segment at the start of the new paragraph. All revisions (del, the
+        per-paragraph insertions, and each inserted paragraph mark) are created
+        inside the caller's active ``_grouped``/``_changeset`` scope, so the
+        whole split is one revision group and one changeset. Affix-trimming is
+        deliberately skipped: a structural change reads clearer as a whole-find
+        deletion plus segmented insertions.
+        """
+        segments = replace_with.split("\n")
+        p1 = _ancestor_paragraph(match.positions[0].node)
+        self._ensure_splittable(p1)
+        # The first split lands where the match's tail begins (match.end, since
+        # the match is deleted and segment 0 reinserted where it was). Reject an
+        # unsplittable boundary now, before mutating (no single-op rollback).
+        self._reject_unsplittable_boundary(p1, build_text_map(p1), match.end)
+        start = match.start
+        self._delete_across_nodes(match)
+        if segments[0]:
+            self._rewrite_insert_at(p1, build_text_map(p1), start, segments[0])
+        return self._apply_paragraph_splits(p1, start + len(segments[0]), segments[1:])
+
+    def _split_insert(self, match: TextMapMatch, text: str, position: Literal["before", "after"]) -> int:
+        """Insert ``text`` (containing ``\\n``) near ``match`` — a tracked split.
+
+        The first segment is inserted at the anchor boundary; each subsequent
+        ``\\n`` splits the paragraph, its segment landing at the start of the
+        new paragraph. One group, one changeset (see :meth:`_split_replace`).
+        """
+        segments = text.split("\n")
+        p1 = _ancestor_paragraph(match.positions[0].node)
+        self._ensure_splittable(p1)
+        base = match.end if position == "after" else match.start
+        # The first split lands at the anchor boundary (segment 0 is inserted
+        # there, pushing the original content right). Reject an unsplittable
+        # boundary now, before mutating (no single-op rollback).
+        self._reject_unsplittable_boundary(p1, build_text_map(p1), base)
+        if segments[0]:
+            self._rewrite_insert_at(p1, build_text_map(p1), base, segments[0])
+        return self._apply_paragraph_splits(p1, base + len(segments[0]), segments[1:])
+
+    def _apply_paragraph_splits(self, p1, split_pos: int, segments: list[str]) -> int:
+        """Split ``p1`` once per entry in ``segments``, threading the tail.
+
+        ``split_pos`` is the visible-text position in the current paragraph
+        where the first split falls; each segment is inserted at the start of
+        the paragraph it opens. Returns the id of the last inserted paragraph
+        mark (a member of the operation's group), so the caller's EditResult
+        reaches the group.
+        """
+        member_id = -1
+        current_p = p1
+        pos = split_pos
+        for segment in segments:
+            new_p, mark_id = self._split_paragraph_at_position(current_p, pos)
+            member_id = mark_id
+            if segment:
+                self._insert_ins_at_paragraph_start(new_p, segment)
+            current_p = new_p
+            pos = len(segment)
+        return member_id
+
+    def _split_paragraph_at_position(self, p1, pos: int):
+        """Split ``p1`` at visible position ``pos``.
+
+        Everything from ``pos`` onward moves into a new following paragraph
+        (a copy of ``p1``'s properties, minus any section mark); ``p1``'s
+        paragraph mark is flagged as an inserted revision. Returns the new
+        paragraph element and the mark insertion's id.
+        """
+        tail = self._collect_tail_nodes(p1, pos)
+        new_p = self._new_tail_paragraph(p1)
+        for node in tail:
+            new_p.appendChild(node)
+        mark_id = self._flag_paragraph_mark_inserted(p1)
+        return new_p, mark_id
+
+    def _collect_tail_nodes(self, p1, pos: int) -> list:
+        """Direct children of ``p1`` (in order) holding visible text from ``pos`` on.
+
+        Splits the run at the boundary when ``pos`` falls mid-run. The
+        paragraph properties (``w:pPr``) are never included. Raises
+        RevisionError when the boundary sits inside an existing revision or
+        other inline container (deferred — our own split flows always cut on a
+        run that is a direct child of the paragraph).
+        """
+        text_map = build_text_map(p1)
+        if pos >= len(text_map.text):
+            return []
+        self._reject_unsplittable_boundary(p1, text_map, pos)
+        edge = text_map.positions[pos]
+        run = self._find_ancestor(edge.node, "w:r")
+        if run is None:  # pragma: no cover - guarded by _reject_unsplittable_boundary
+            return []
+        if edge.offset_in_node == 0:
+            first_tail = run
+        else:
+            # Split the run at the offset; the tail starts at the right half.
+            boundary = self._split_foreign_ins_at(edge.node, edge.offset_in_node)
+            first_tail = _next_element_sibling(boundary.nextSibling) if boundary is not None else None
+        tail: list = []
+        node = first_tail
+        while node is not None:
+            nxt = node.nextSibling
+            tail.append(node)
+            node = nxt
+        return tail
+
+    def _new_tail_paragraph(self, p1):
+        """Create and insert an empty following paragraph copying ``p1``'s pPr.
+
+        The copy drops any section mark (``w:sectPr`` stays on the last
+        paragraph only), pPr-change tracking, and any inherited paragraph-mark
+        revision. The new ``w:p`` is stamped (paraId/rsids) via injection.
+        """
+        doc = self.editor.dom
+        new_p = doc.createElement("w:p")
+        orig_pPr = _first_child_element(p1, "w:pPr")
+        if orig_pPr is not None:
+            pPr_copy = orig_pPr.cloneNode(True)
+            assert pPr_copy is not None  # cloneNode of an element returns an element
+            # A section mark stays on the last paragraph only; pPr-change
+            # tracking and any inherited mark revision do not belong on the copy.
+            for tag in ("w:sectPr", "w:pPrChange"):
+                child = _first_child_element(pPr_copy, tag)
+                if child is not None:
+                    pPr_copy.removeChild(child)
+            rPr = _first_child_element(pPr_copy, "w:rPr")
+            if rPr is not None:
+                for tag in ("w:ins", "w:del"):
+                    mark = _first_child_element(rPr, tag)
+                    if mark is not None:
+                        rPr.removeChild(mark)
+            new_p.appendChild(pPr_copy)
+        p1.parentNode.insertBefore(new_p, p1.nextSibling)
+        self.editor._inject_attributes_to_nodes([new_p])
+        return new_p
+
+    def _flag_paragraph_mark_inserted(self, p1) -> int:
+        """Flag ``p1``'s paragraph mark as an inserted revision.
+
+        Adds an empty ``<w:ins>`` as the first child of the paragraph-mark
+        ``<w:pPr><w:rPr>`` (created in schema order when absent). Injection
+        stamps id/author/date and, inside an active ``_grouped`` scope, records
+        it as a group member. Returns the mark insertion's id.
+        """
+        doc = self.editor.dom
+        pPr = _first_child_element(p1, "w:pPr")
+        if pPr is None:
+            pPr = doc.createElement("w:pPr")
+            p1.insertBefore(pPr, p1.firstChild)
+        rPr = _first_child_element(pPr, "w:rPr")
+        if rPr is None:
+            rPr = doc.createElement("w:rPr")
+            anchor = _first_child_element(pPr, "w:sectPr") or _first_child_element(pPr, "w:pPrChange")
+            if anchor is not None:
+                pPr.insertBefore(rPr, anchor)
+            else:
+                pPr.appendChild(rPr)
+        ins = doc.createElement("w:ins")
+        rPr.insertBefore(ins, rPr.firstChild)
+        self.editor._inject_attributes_to_nodes([ins])
+        mark_id = int(ins.getAttribute("w:id"))
+        self._paragraph_mark_ids.add(mark_id)
+        return mark_id
+
+    def _insert_ins_at_paragraph_start(self, paragraph, text: str) -> None:
+        """Insert ``text`` as a tracked insertion at the start of ``paragraph``.
+
+        Lands right after ``w:pPr`` (before any moved tail content).
+        """
+        ins_xml = f"<w:ins><w:r><w:t>{_escape_xml(text)}</w:t></w:r></w:ins>"
+        pPr = _first_child_element(paragraph, "w:pPr")
+        if pPr is not None:
+            self.editor.insert_after(pPr, ins_xml)
+            return
+        first = _next_element_sibling(paragraph.firstChild)
+        if first is not None:
+            self.editor.insert_before(first, ins_xml)
+        else:
+            self.editor.append_to(paragraph, ins_xml)
 
     def list_revisions(
         self,
@@ -3039,8 +3392,13 @@ class RevisionManager:
         if elem is None:
             return False
         if elem.tagName == "w:ins":
-            # Reject insertion: remove entirely
-            self._remove_element(elem)
+            if _is_paragraph_mark_ins(elem):
+                # Reject a paragraph-mark insertion: remove the mark and rejoin
+                # the tail paragraph (the inverse of the tracked split).
+                self._rejoin_paragraph(elem)
+            else:
+                # Reject insertion: remove entirely
+                self._remove_element(elem)
         else:  # w:del
             # Reject deletion: restore the deleted text
             self._restore_deletion(elem)
@@ -3242,6 +3600,39 @@ class RevisionManager:
 
         # Unwrap the w:del element
         self._unwrap_element(del_elem)
+
+    def _rejoin_paragraph(self, mark_ins) -> None:
+        """Reject a paragraph-mark insertion: drop the mark and merge the next
+        paragraph's content back into this one — the inverse of a tracked split.
+
+        The paragraph owning the mark survives (keeping its original
+        properties, including any section mark); the following paragraph's
+        content is appended and that paragraph is removed. Order-independent
+        across a multi-split group: ``_resolve_ids`` dissolves the later (higher
+        id) marks first, so an intermediate paragraph is never removed while it
+        still owns a pending mark.
+        """
+        p1 = _ancestor_paragraph(mark_ins)
+        rPr = mark_ins.parentNode
+        rPr.removeChild(mark_ins)
+        # Tidy the empty property wrappers the split created (keep any that
+        # carried other properties).
+        if not _next_element_sibling(rPr.firstChild):
+            pPr = rPr.parentNode
+            pPr.removeChild(rPr)
+            if not _next_element_sibling(pPr.firstChild):
+                pPr.parentNode.removeChild(pPr)
+        if p1 is None:  # pragma: no cover - a mark-ins always sits in a paragraph
+            return
+        p2 = _next_element_sibling(p1.nextSibling)
+        if p2 is None or getattr(p2, "tagName", "") != "w:p":
+            return  # best effort: no following paragraph to rejoin into
+        p2_pPr = _first_child_element(p2, "w:pPr")
+        for child in list(p2.childNodes):
+            if child is p2_pPr:
+                continue
+            p1.appendChild(child)
+        p2.parentNode.removeChild(p2)
 
 
 def _tokenize_words(text: str) -> list[str]:

--- a/docx_editor/track_changes.py
+++ b/docx_editor/track_changes.py
@@ -536,7 +536,7 @@ def _first_child_element(parent, tag: str) -> Element | None:
     return None
 
 
-def _next_element_sibling(node):
+def _next_element_sibling(node) -> Element | None:
     """The next sibling that is an element (skipping text/whitespace nodes)."""
     while node is not None and node.nodeType != node.ELEMENT_NODE:
         node = node.nextSibling
@@ -720,7 +720,9 @@ class RevisionManager:
         id-keyed lookup cannot tell the occurrences apart, so no group may
         contain an ambiguous member.
         """
-        run_key: tuple[int, str, str] | None = None
+        # (author, date) of the current run. Paragraph identity is tracked
+        # separately in run_para, so it is not part of the key.
+        run_key: tuple[str, str] | None = None
         run_para: Element | None = None
         run_members: list[int] = []
         # (author, date) -> changeset id, for the inferred changeset tier.
@@ -739,11 +741,10 @@ class RevisionManager:
                 self._group_sources[group_id] = "inferred"
                 # run_members non-empty guarantees run_key is set (members are
                 # only appended after run_key becomes non-None). Its author+date
-                # are the group's; drop the paragraph identity so groups in
-                # different paragraphs still share one changeset.
+                # are the group's changeset key, so groups in different
+                # paragraphs sharing them still join one changeset.
                 assert run_key is not None
-                _, author, date = run_key
-                cs_key = (author, date)
+                cs_key = run_key
                 cs_id = changeset_by_key.get(cs_key)
                 if cs_id is None:
                     cs_id = self._changeset_counter
@@ -793,13 +794,13 @@ class RevisionManager:
             # one before a tracked split, so their revisions stay one group.
             same_run = (
                 run_key is not None
-                and author == run_key[1]
-                and date == run_key[2]
+                and author == run_key[0]
+                and date == run_key[1]
                 and (paragraph is run_para or self._is_split_continuation(run_para, paragraph, author, date))
             )
             if not same_run:
                 close_run()
-            run_key = (id(paragraph), author, date)
+            run_key = (author, date)
             run_para = paragraph
             run_members.append(rev_id)
         close_run()
@@ -1497,6 +1498,27 @@ class RevisionManager:
             new_fragment = "".join(new_tokens[j1:j2])
 
             hunks.append((tag, old_char_start, old_char_end, new_fragment))
+
+        # Preflight the split (\n) hunks against the pre-mutation state: the
+        # reversed hunk loop below has no rollback, so anything that can't split
+        # cleanly must refuse before any hunk mutates.
+        split_hunks = [(tag, s, e, frag) for (tag, s, e, frag) in hunks if tag != "delete" and "\n" in frag]
+        if len(split_hunks) > 1:
+            # Every split hunk targets this one paragraph, so a second would
+            # re-mark it (invalid — see _ensure_splittable). A single hunk with
+            # several \n is fine (it threads through fresh tail paragraphs).
+            raise RevisionError(
+                "Cannot rewrite a paragraph with newlines that fall in separate edits — that "
+                "would split one paragraph in more than one place. Use separate split_paragraph()/"
+                "replace() calls, or keep the rewrite's newlines within one contiguous change."
+            )
+        # A replace splits at its match end, an insert at its start; higher-position
+        # hunks never shift these lower/equal boundaries, so the pre-mutation
+        # positions stay valid.
+        for tag, old_char_start, old_char_end, _frag in split_hunks:
+            self._ensure_splittable(p)
+            boundary = old_char_end if tag == "replace" else old_char_start
+            self._reject_unsplittable_boundary(p, text_map, boundary)
 
         # Process hunks in reverse order for position stability
         for tag, old_char_start, old_char_end, new_fragment in reversed(hunks):
@@ -2891,18 +2913,31 @@ class RevisionManager:
     # ==================== Paragraph splits (\n) ====================
 
     def _ensure_splittable(self, p1) -> None:
-        """Refuse to split a paragraph that ends a document section.
+        """Refuse to split a paragraph that can't take a fresh tracked mark.
 
-        A paragraph-level ``w:sectPr`` marks a section boundary; moving it (or
-        duplicating it) across a split would silently corrupt the section
-        structure. Uncommon — the document-final section mark lives on
-        ``w:body``, not in a paragraph — so refuse cleanly rather than guess.
+        Two cases refuse cleanly (before any mutation):
+
+        - A paragraph-level ``w:sectPr`` marks a section boundary; moving it (or
+          duplicating it) across a split would silently corrupt the section
+          structure. Uncommon — the document-final section mark lives on
+          ``w:body``, not in a paragraph.
+        - The paragraph already carries a pending inserted paragraph mark. A
+          second split would add a second ``<w:ins>`` to one ``<w:pPr><w:rPr>``
+          (invalid OOXML — ``CT_ParaRPr`` allows one ``ins``) and mis-attribute
+          the marks to the wrong breaks. A single multi-``\\n`` op never trips
+          this (each split lands on a fresh tail paragraph); only re-splitting an
+          already-split half in a separate op does.
         """
         pPr = _first_child_element(p1, "w:pPr")
         if pPr is not None and _first_child_element(pPr, "w:sectPr") is not None:
             raise RevisionError(
                 "Cannot split a paragraph that carries a section mark (w:sectPr) — the section "
                 "boundary would be ambiguous. Edit around the section break instead."
+            )
+        if _paragraph_mark_ins(p1) is not None:
+            raise RevisionError(
+                "Cannot split a paragraph that already has a pending inserted paragraph mark — "
+                "accept or reject that split before splitting the same paragraph again."
             )
 
     def _reject_unsplittable_boundary(self, paragraph, text_map: TextMap, pos: int) -> None:
@@ -2992,7 +3027,7 @@ class RevisionManager:
             pos = len(segment)
         return member_id
 
-    def _split_paragraph_at_position(self, p1, pos: int):
+    def _split_paragraph_at_position(self, p1, pos: int) -> tuple[Element, int]:
         """Split ``p1`` at visible position ``pos``.
 
         Everything from ``pos`` onward moves into a new following paragraph
@@ -3038,7 +3073,7 @@ class RevisionManager:
             node = nxt
         return tail
 
-    def _new_tail_paragraph(self, p1):
+    def _new_tail_paragraph(self, p1) -> Element:
         """Create and insert an empty following paragraph copying ``p1``'s pPr.
 
         The copy drops any section mark (``w:sectPr`` stays on the last
@@ -3068,13 +3103,9 @@ class RevisionManager:
         self.editor._inject_attributes_to_nodes([new_p])
         return new_p
 
-    def _flag_paragraph_mark_inserted(self, p1) -> int:
-        """Flag ``p1``'s paragraph mark as an inserted revision.
-
-        Adds an empty ``<w:ins>`` as the first child of the paragraph-mark
-        ``<w:pPr><w:rPr>`` (created in schema order when absent). Injection
-        stamps id/author/date and, inside an active ``_grouped`` scope, records
-        it as a group member. Returns the mark insertion's id.
+    def _paragraph_mark_rPr(self, p1) -> Element:
+        """Return ``p1``'s paragraph-mark ``<w:pPr><w:rPr>``, creating both in
+        schema order (``w:rPr`` before any ``w:sectPr``/``w:pPrChange``) if absent.
         """
         doc = self.editor.dom
         pPr = _first_child_element(p1, "w:pPr")
@@ -3089,7 +3120,18 @@ class RevisionManager:
                 pPr.insertBefore(rPr, anchor)
             else:
                 pPr.appendChild(rPr)
-        ins = doc.createElement("w:ins")
+        return rPr
+
+    def _flag_paragraph_mark_inserted(self, p1) -> int:
+        """Flag ``p1``'s paragraph mark as an inserted revision.
+
+        Adds an empty ``<w:ins>`` as the first child of the paragraph-mark
+        ``<w:pPr><w:rPr>`` (created in schema order when absent). Injection
+        stamps id/author/date and, inside an active ``_grouped`` scope, records
+        it as a group member. Returns the mark insertion's id.
+        """
+        rPr = self._paragraph_mark_rPr(p1)
+        ins = self.editor.dom.createElement("w:ins")
         rPr.insertBefore(ins, rPr.firstChild)
         self.editor._inject_attributes_to_nodes([ins])
         mark_id = int(ins.getAttribute("w:id"))
@@ -3099,9 +3141,14 @@ class RevisionManager:
     def _insert_ins_at_paragraph_start(self, paragraph, text: str) -> None:
         """Insert ``text`` as a tracked insertion at the start of ``paragraph``.
 
-        Lands right after ``w:pPr`` (before any moved tail content).
+        Lands right after ``w:pPr`` (before any moved tail content). The run
+        inherits the formatting (rPr) of the tail it sits directly before — the
+        moved boundary run — so a split-inserted segment matches the surrounding
+        text instead of dropping to document default.
         """
-        ins_xml = f"<w:ins><w:r><w:t>{_escape_xml(text)}</w:t></w:r></w:ins>"
+        runs = paragraph.getElementsByTagName("w:r")
+        rPr_xml = get_rPr_xml(runs[0]) if runs else ""
+        ins_xml = f"<w:ins><w:r>{rPr_xml}<w:t>{_escape_xml(text)}</w:t></w:r></w:ins>"
         pPr = _first_child_element(paragraph, "w:pPr")
         if pPr is not None:
             self.editor.insert_after(pPr, ins_xml)
@@ -3607,10 +3654,17 @@ class RevisionManager:
 
         The paragraph owning the mark survives (keeping its original
         properties, including any section mark); the following paragraph's
-        content is appended and that paragraph is removed. Order-independent
-        across a multi-split group: ``_resolve_ids`` dissolves the later (higher
-        id) marks first, so an intermediate paragraph is never removed while it
-        still owns a pending mark.
+        content is appended and that paragraph is removed.
+
+        If that following paragraph is itself an intermediate half of a
+        multi-split, its ``w:pPr`` carries its *own* pending mark (the break to
+        the paragraph after it). That mark is migrated onto the surviving
+        paragraph so the later break stays tracked — otherwise rejecting a
+        non-terminal mark individually (a public ``reject_revision``) would drop
+        it with ``p2``'s ``pPr``, leaving a permanent, untracked break.
+        ``reject_group``/``reject_changeset`` dissolve later (higher-id) marks
+        first, so ``p2`` has no mark by the time it is merged and this migration
+        is a no-op.
         """
         p1 = _ancestor_paragraph(mark_ins)
         rPr = mark_ins.parentNode
@@ -3627,12 +3681,21 @@ class RevisionManager:
         p2 = _next_element_sibling(p1.nextSibling)
         if p2 is None or getattr(p2, "tagName", "") != "w:p":
             return  # best effort: no following paragraph to rejoin into
+        downstream_mark = _paragraph_mark_ins(p2)
         p2_pPr = _first_child_element(p2, "w:pPr")
         for child in list(p2.childNodes):
             if child is p2_pPr:
                 continue
             p1.appendChild(child)
-        p2.parentNode.removeChild(p2)
+        p2_parent = p2.parentNode
+        if p2_parent is not None:  # a live sibling always has a parent; guards ty narrowing
+            p2_parent.removeChild(p2)
+        if downstream_mark is not None:
+            # p1 now ends where p2 did, so it inherits p2's break-to-successor
+            # mark (same id/author/date, still a live group member). insertBefore
+            # re-parents it out of p2's detached rPr automatically.
+            new_rPr = self._paragraph_mark_rPr(p1)
+            new_rPr.insertBefore(downstream_mark, new_rPr.firstChild)
 
 
 def _tokenize_words(text: str) -> list[str]:

--- a/docx_editor/track_changes.py
+++ b/docx_editor/track_changes.py
@@ -3019,10 +3019,17 @@ class RevisionManager:
         current_p = p1
         pos = split_pos
         for segment in segments:
+            # Formatting to fall back on when the new paragraph's tail is empty
+            # (a split at the end of the current paragraph): its trailing run
+            # carries the boundary formatting. This propagates through a run of
+            # empty tails (e.g. appending "A\nB\nC" past the last word), so every
+            # segment keeps the surrounding format instead of only the first.
+            boundary_runs = current_p.getElementsByTagName("w:r")
+            fallback_rPr = get_rPr_xml(boundary_runs[-1]) if boundary_runs else ""
             new_p, mark_id = self._split_paragraph_at_position(current_p, pos)
             member_id = mark_id
             if segment:
-                self._insert_ins_at_paragraph_start(new_p, segment)
+                self._insert_ins_at_paragraph_start(new_p, segment, fallback_rPr)
             current_p = new_p
             pos = len(segment)
         return member_id
@@ -3138,16 +3145,18 @@ class RevisionManager:
         self._paragraph_mark_ids.add(mark_id)
         return mark_id
 
-    def _insert_ins_at_paragraph_start(self, paragraph, text: str) -> None:
+    def _insert_ins_at_paragraph_start(self, paragraph, text: str, fallback_rPr_xml: str = "") -> None:
         """Insert ``text`` as a tracked insertion at the start of ``paragraph``.
 
         Lands right after ``w:pPr`` (before any moved tail content). The run
         inherits the formatting (rPr) of the tail it sits directly before — the
         moved boundary run — so a split-inserted segment matches the surrounding
-        text instead of dropping to document default.
+        text instead of dropping to document default. When the tail is empty (a
+        split at the paragraph's end), ``fallback_rPr_xml`` (the previous
+        paragraph's boundary formatting) is used instead.
         """
         runs = paragraph.getElementsByTagName("w:r")
-        rPr_xml = get_rPr_xml(runs[0]) if runs else ""
+        rPr_xml = get_rPr_xml(runs[0]) if runs else fallback_rPr_xml
         ins_xml = f"<w:ins><w:r>{rPr_xml}<w:t>{_escape_xml(text)}</w:t></w:r></w:ins>"
         pPr = _first_child_element(paragraph, "w:pPr")
         if pPr is not None:

--- a/docx_editor/track_changes.py
+++ b/docx_editor/track_changes.py
@@ -814,7 +814,7 @@ class RevisionManager:
         this, a reopened split — whose revisions span two paragraphs — would
         reconstruct as two separate inferred groups.
         """
-        if prev_para is None:
+        if prev_para is None:  # pragma: no cover - run_para is always set alongside run_key
             return False
         mark = _paragraph_mark_ins(prev_para)
         if mark is None:
@@ -3679,7 +3679,7 @@ class RevisionManager:
         if p1 is None:  # pragma: no cover - a mark-ins always sits in a paragraph
             return
         p2 = _next_element_sibling(p1.nextSibling)
-        if p2 is None or getattr(p2, "tagName", "") != "w:p":
+        if p2 is None or getattr(p2, "tagName", "") != "w:p":  # pragma: no cover - a mark implies a following paragraph
             return  # best effort: no following paragraph to rejoin into
         downstream_mark = _paragraph_mark_ins(p2)
         p2_pPr = _first_child_element(p2, "w:pPr")
@@ -3688,8 +3688,8 @@ class RevisionManager:
                 continue
             p1.appendChild(child)
         p2_parent = p2.parentNode
-        if p2_parent is not None:  # a live sibling always has a parent; guards ty narrowing
-            p2_parent.removeChild(p2)
+        assert p2_parent is not None  # a live sibling always has a parent (narrows for ty)
+        p2_parent.removeChild(p2)
         if downstream_mark is not None:
             # p1 now ends where p2 did, so it inherits p2's break-to-successor
             # mark (same id/author/date, still a live group member). insertBefore

--- a/docx_editor/xml_editor.py
+++ b/docx_editor/xml_editor.py
@@ -102,6 +102,41 @@ def _require_valid_occurrence(occurrence: int | None, label: str = "", allow_non
         raise ValueError(f"{label}occurrence must be >= 0, got {occurrence}")
 
 
+# C0 control characters (U+0000–U+001F) plus DEL (U+007F). Tab, CR, and LF all
+# fall in this range; LF ('\n') is handled separately — it means a tracked
+# paragraph split, not a rejected literal.
+_REJECTED_CONTROL_CHARS = frozenset(chr(c) for c in range(0x20) if c != 0x0A) | {"\x7f"}
+
+
+def _reject_control_chars(value: str, *, field: str, ctx: str = "", allow_newline: bool = False) -> None:
+    """Reject control characters that would corrupt the document text.
+
+    Tab, carriage return, and the other C0/DEL control characters would enter
+    a ``<w:t>`` as an invisible, unreviewable literal — a redline nobody can
+    see, and ``get_visible_text().splitlines()`` would break on it. ``\\n`` is
+    special: it means a *tracked paragraph split*, allowed in content inputs
+    (``allow_newline=True``) and rejected everywhere else (search/anchor and
+    comment text, where real paragraph text is never multi-line, so a ``\\n``
+    is always a caller bug that would otherwise fail as TextNotFoundError).
+
+    Non-str values are left for the caller's own type check.
+    """
+    if not isinstance(value, str):
+        return
+    if not allow_newline and "\n" in value:
+        raise ValueError(
+            f"{ctx}{field} must not contain a newline ('\\n') — paragraph text is never "
+            f"multi-line, so it can never match. Target text within a single paragraph."
+        )
+    for char in value:
+        if char in _REJECTED_CONTROL_CHARS:
+            raise ValueError(
+                f"{ctx}{field} must not contain control character {char!r} — it would become an "
+                f"invisible, unreviewable literal in the document. Use '\\n' for a tracked "
+                f"paragraph split; a real tab ('\\t') is deferred to the tabs feature (ISSUES.md #6)."
+            )
+
+
 def find_in_text_map(text_map: TextMap, search: str, occurrence: int = 0) -> TextMapMatch | None:
     """Find the nth occurrence of text in a text map.
 

--- a/skills/docx/SKILL.md
+++ b/skills/docx/SKILL.md
@@ -814,6 +814,49 @@ tracked delete removes text from that view; an insert adds to it). Across
 different paragraphs, operations are applied in reverse document order — a
 behavior that keeps one `list_paragraphs()` snapshot valid for the whole batch.
 
+### Paragraph Structure (splitting on `\n`)
+
+A `\n` in edit text means a **tracked paragraph split** at that point. There is
+no way to embed a literal newline in a paragraph's text — Word paragraphs are
+inherently single-line, and a raw `\n` in a run would be an invisible,
+unreviewable artifact. So the library gives `\n` its universal meaning:
+
+- **Mechanism.** The first paragraph's paragraph *mark* is flagged as an
+  inserted revision; the tail (everything after the split point) moves into a
+  new following paragraph as unchanged content. **Accepting** keeps the split;
+  **rejecting** removes the mark and **rejoins** the two paragraphs.
+- **Where it works.** Any content text: `replace(find, "a\nb")`,
+  `insert_after`/`insert_before`, `rewrite_paragraph`, and the same inside a
+  `batch_edit` `EditOperation`. Multiple `\n`s make multiple splits.
+- **One unit.** A `\n`-containing operation is ONE revision group covering the
+  deletion, the inserted runs in every resulting paragraph, and each inserted
+  mark — `reject_group` reverts the whole split atomically; one call is still
+  one changeset.
+
+```python
+# Split a paragraph while replacing text; both halves are tracked.
+r = doc.replace("...year.", "...year.\nA new clause follows.", paragraph="P4#a1b2")
+r.refs            # ("P4#…", "P5#…") — every resulting paragraph, in order
+r.refs[0] == r    # True — the string value is always the first paragraph
+doc.reject_group(r.group_id)   # rejoins into the original single paragraph
+
+# Explicit sugar for a pure split (no text change), cut before an anchor:
+res = doc.split_paragraph("P4#a1b2", before="However,")
+first_ref, second_ref = res.refs
+```
+
+**`EditResult.refs`** carries every resulting paragraph ref (length 1 for a
+normal edit, ≥2 for a split). A split shifts the index of every later
+paragraph, so **re-resolve** stale refs (`list_paragraphs()`/`find_text()`)
+before reusing them — this is the same re-resolve discipline that already
+applies after any edit.
+
+**Rejected characters.** Every other C0 control character is rejected at all
+text inputs with a teaching `ValueError` (`CommentError` for comment text):
+tab (`\t`), carriage return (`\r`), NUL, DEL, etc. — they would enter the
+document as invisible literals. Only `\n` is special (a split). A real tab
+(`\t` → `<w:tab/>`) is deferred to the tabs feature.
+
 ### Error Handling & Recovery
 
 All LLM-facing errors inherit from `DocxEditError` and carry structured fields so you can retry in-loop without re-reading the document. Catch the specific class or the base — both work.
@@ -826,7 +869,8 @@ All LLM-facing errors inherit from `DocxEditError` and carry structured fields s
 | `ParagraphIndexError`  | `index`, `total_paragraphs`                                                             | Clamp to `1..total_paragraphs` and retry with `get_paragraph(i)`, or call `list_paragraphs()` to pick a valid ref. |
 | `BatchOperationError`  | `operation_index`, `reason`, `original`                                                 | Fix the op at `operations[operation_index]` (or drop it) and retry the batch; `original` is the underlying typed error (e.g. use its `actual_hash` to re-target a stale ref), or None for batch-level rules with no underlying exception (a missing paragraph ref, an element that is not an `EditOperation`, or a duplicate paragraph in `batch_rewrite` — `batch_edit` allows repeats, applied sequentially). Batch methods never raise the inner types directly. |
 | `RevisionError`        | `revision_id`, `group_id`, `changeset_id` (whichever the error is about is set, the rest None) | Unknown `group_id` passed to `accept_group()`/`reject_group()`, or unknown `changeset_id` passed to `accept_changeset()`/`reject_changeset()`. Group and changeset ids are per-open-Document and renumbered on each open (recorded for this session's edits, inferred for pre-existing revisions): use an id from this session's `EditResult` or `list_revisions()`, never one saved from a previous session. |
-| `CommentError`         | `comment_id` (set when a comment id was targeted, else None)                            | Replying to a nonexistent comment id — call `list_comments()` and retry with a real id. With `comment_id=None` the arguments themselves were invalid; fix them per the message. |
+| `CommentError`         | `comment_id` (set when a comment id was targeted, else None)                            | Replying to a nonexistent comment id — call `list_comments()` and retry with a real id. With `comment_id=None` the arguments themselves were invalid; fix them per the message. A `\t`/`\r`/other control character in `anchor_text` or `comment_text` also raises this — strip it (comments hold no newlines either). |
+| `ValueError`           | *(builtin — message names the field)*                                                  | Bad argument caught before any mutation: a malformed ref, a bad `occurrence`, or a **control character** (`\t`, `\r`, NUL, …) in edit text. Only `\n` is allowed, and only in content (it means a tracked paragraph split); it is rejected in search/anchor text. Remove the control character — never smuggle layout as `\t`/`\r`. |
 | `DocumentClosedError`  | `path`                                                                                  | The `Document` was used after `close()`. Reopen with `Document.open(e.path)`; edits not saved before the `close()` were discarded with the workspace. |
 | `DocumentNotFoundError`| `path`                                                                                  | The file doesn't exist at `path` — fix the path (typo, wrong cwd) before retrying. |
 | `InvalidDocumentError` | `path`                                                                                  | The file at `path` is not a valid .docx — wrong suffix, a directory, empty/truncated/not a ZIP, missing word/document.xml, or malformed XML. Not an in-loop retry: the message names which check failed; fix or re-export the input file. |

--- a/tests/test_error_quality.py
+++ b/tests/test_error_quality.py
@@ -1396,3 +1396,9 @@ class TestControlCharRejection:
         doc, ref = hello_doc
         with pytest.raises(CommentError):
             doc.add_comment("Hel\nlo", "fine comment", paragraph=ref)
+
+    def test_reply_to_comment_rejects_control_char(self, hello_doc):
+        doc, ref = hello_doc
+        cid = doc.add_comment("Hello", "a comment", paragraph=ref)
+        with pytest.raises(CommentError, match="control character"):
+            doc.reply_to_comment(cid, "bad\treply")

--- a/tests/test_error_quality.py
+++ b/tests/test_error_quality.py
@@ -1304,3 +1304,95 @@ class TestOwnPidLockMessage:
             assert e.pid == os.getpid()
         finally:
             doc1.close()
+
+
+@pytest.fixture
+def hello_doc(doc_path):
+    """A document with one paragraph, opened; yields (doc, first-paragraph ref)."""
+    doc = _build_doc_with_paragraphs(doc_path, ["Hello world jumps over"])
+    ref = next(iter(doc.list_paragraphs(limit=None))).split("|")[0]
+    yield doc, ref
+    doc.close()
+
+
+class TestControlCharRejection:
+    """Tab, CR, and other C0/DEL controls are rejected at every text input;
+    only '\\n' passes (a tracked paragraph split). See ISSUES.md #58+61."""
+
+    def test_replace_rejects_tab_in_content(self, hello_doc):
+        doc, ref = hello_doc
+        with pytest.raises(ValueError, match="control character"):
+            doc.replace("world", "wor\tld", paragraph=ref)
+
+    def test_replace_allows_newline_in_content(self, hello_doc):
+        doc, ref = hello_doc
+        doc.replace("world", "wor\nld", paragraph=ref)  # \n splits — allowed
+        assert doc.paragraph_count() == 2
+
+    def test_replace_rejects_newline_in_find(self, hello_doc):
+        doc, ref = hello_doc
+        with pytest.raises(ValueError, match="newline"):
+            doc.replace("Hel\nlo", "x", paragraph=ref)
+
+    def test_delete_rejects_carriage_return(self, hello_doc):
+        doc, ref = hello_doc
+        with pytest.raises(ValueError, match="control character"):
+            doc.delete("wor\rld", paragraph=ref)
+
+    def test_insert_after_rejects_null_in_text(self, hello_doc):
+        doc, ref = hello_doc
+        with pytest.raises(ValueError, match="control character"):
+            doc.insert_after("Hello", "\x00bad", paragraph=ref)
+
+    def test_insert_after_rejects_newline_in_anchor(self, hello_doc):
+        doc, ref = hello_doc
+        with pytest.raises(ValueError, match="newline"):
+            doc.insert_after("Hel\nlo", "fine", paragraph=ref)
+
+    def test_insert_after_allows_newline_in_text(self, hello_doc):
+        doc, ref = hello_doc
+        doc.insert_after("Hello", "\nnew", paragraph=ref)  # \n splits — allowed
+        assert doc.paragraph_count() == 2
+
+    def test_rewrite_rejects_tab(self, hello_doc):
+        doc, ref = hello_doc
+        with pytest.raises(ValueError, match="control character"):
+            doc.rewrite_paragraph(ref, "new\ttext")
+
+    def test_rewrite_allows_newline(self, hello_doc):
+        doc, ref = hello_doc
+        doc.rewrite_paragraph(ref, "first\nsecond")  # split — allowed
+        assert doc.paragraph_count() == 2
+
+    def test_del_char_0x7f_rejected(self, hello_doc):
+        doc, ref = hello_doc
+        with pytest.raises(ValueError, match="control character"):
+            doc.replace("world", "wor\x7fld", paragraph=ref)
+
+    def test_editoperation_replace_rejects_tab_at_construction(self):
+        with pytest.raises(ValueError, match="control character"):
+            EditOperation.replace("a", "b\tc", paragraph="P1#0000")
+
+    def test_editoperation_replace_allows_newline_at_construction(self):
+        op = EditOperation.replace("a", "b\nc", paragraph="P1#0000")
+        assert op.replace_with == "b\nc"
+
+    def test_editoperation_delete_rejects_newline_at_construction(self):
+        with pytest.raises(ValueError, match="newline"):
+            EditOperation.delete("a\nb", paragraph="P1#0000")
+
+    def test_batch_rejects_raw_op_with_control_char(self, hello_doc):
+        doc, ref = hello_doc
+        raw = EditOperation(action="replace", paragraph=ref, find="world", replace_with="wor\tld")
+        with pytest.raises(BatchOperationError):
+            doc.batch_edit([raw])
+
+    def test_add_comment_rejects_control_char_in_comment(self, hello_doc):
+        doc, ref = hello_doc
+        with pytest.raises(CommentError, match="control character"):
+            doc.add_comment("Hello", "bad\tcomment", paragraph=ref)
+
+    def test_add_comment_rejects_newline_in_anchor(self, hello_doc):
+        doc, ref = hello_doc
+        with pytest.raises(CommentError):
+            doc.add_comment("Hel\nlo", "fine comment", paragraph=ref)

--- a/tests/test_paragraph_split.py
+++ b/tests/test_paragraph_split.py
@@ -14,7 +14,7 @@ import zipfile
 import pytest
 from conftest import find_ref, replace_document_xml
 
-from docx_editor import Document, EditOperation
+from docx_editor import Document, EditOperation, RevisionError
 from docx_editor.xml_editor import ParagraphRef
 
 
@@ -205,8 +205,6 @@ class TestEditResultRefs:
         assert result.refs == (str(result),)
 
     def test_split_refs_cover_both_paragraphs(self, doc):
-        from docx_editor.xml_editor import ParagraphRef
-
         ref = find_ref(doc, "quick brown fox")
         result = doc.replace("dog.", "dog.\nNew line.", paragraph=ref)
 
@@ -308,3 +306,68 @@ class TestReopenRejoin:
             assert gid is not None
             doc.reject_group(gid)
             assert doc.get_visible_text() == original
+
+
+class TestResplitRefused:
+    """A paragraph can hold at most one pending inserted mark (CT_ParaRPr allows
+    one w:ins). Re-splitting an already-split half is refused, atomically."""
+
+    def test_resplit_already_split_first_half_refused_and_atomic(self, doc):
+        ref = find_ref(doc, "quick brown fox")
+        doc.split_paragraph(ref, before="jumps")  # first half now carries a mark
+        first = find_ref(doc, "quick brown fox")  # re-resolve after the split
+        before_paras = doc.paragraph_count()
+        before_xml = doc._document_editor.dom.toxml()
+
+        with pytest.raises(RevisionError, match="already has a pending inserted paragraph mark"):
+            doc.split_paragraph(first, before="brown")
+
+        # Byte-for-byte unchanged — the refusal is up front, before any mutation.
+        assert doc.paragraph_count() == before_paras
+        assert doc._document_editor.dom.toxml() == before_xml
+
+
+class TestRejectNonTerminalMark:
+    """Rejecting the first mark of a multi-split individually must not orphan the
+    later break — it migrates onto the surviving paragraph and stays rejectable."""
+
+    def test_reject_first_mark_keeps_later_break_rejectable(self, doc):
+        ref = find_ref(doc, "quick brown fox")
+        original = doc.get_visible_text()
+        doc.replace("fox", "fox\nB\nC", paragraph=ref)
+        marks = sorted(r.id for r in doc.list_revisions() if r.type == "insertion" and r.text == "")
+        assert len(marks) == 2
+
+        doc.reject_revision(marks[0])  # the lowest-id (first) mark
+
+        # The second mark survived (migrated) and is still tracked/rejectable.
+        remaining = [r.id for r in doc.list_revisions() if r.type == "insertion" and r.text == ""]
+        assert remaining == [marks[1]]
+        assert doc.reject_revision(marks[1]) is True
+        # Both breaks rejected → the three text insertions collapse onto one line.
+        assert len(doc.get_visible_text().splitlines()) == len(original.splitlines())
+
+
+class TestRewriteMultiSplitRefused:
+    """A rewrite whose newlines diff into separate hunks would split one
+    paragraph in several places — refused atomically (a single hunk with several
+    newlines still threads fine)."""
+
+    def test_rewrite_newlines_in_separate_hunks_refused_and_atomic(self, doc):
+        ref = find_ref(doc, "quick brown fox")
+        before_paras = doc.paragraph_count()
+        before_xml = doc._document_editor.dom.toxml()
+
+        with pytest.raises(RevisionError, match="newlines that fall in separate edits"):
+            # Turning existing spaces into newlines diffs into separate \n hunks.
+            doc.rewrite_paragraph(ref, "The\nquick\nbrown fox jumps over the lazy dog.")
+
+        assert doc.paragraph_count() == before_paras
+        assert doc._document_editor.dom.toxml() == before_xml
+
+    def test_rewrite_single_contiguous_newline_change_still_splits(self, doc):
+        ref = find_ref(doc, "quick brown fox")
+        before = doc.paragraph_count()
+        # Wholesale replacement is one hunk containing the newline — allowed.
+        doc.rewrite_paragraph(ref, "First half.\nSecond half.")
+        assert doc.paragraph_count() == before + 1

--- a/tests/test_paragraph_split.py
+++ b/tests/test_paragraph_split.py
@@ -1,0 +1,310 @@
+"""Tests for tracked paragraph splits on ``\\n`` (ISSUES.md #58+61).
+
+A ``\\n`` in edit text means a *tracked paragraph split* at that point: the
+first paragraph's paragraph mark is flagged as an inserted revision, the tail
+runs move to a new paragraph as unchanged content. Accepting keeps the split;
+rejecting removes the mark and rejoins. One ``\\n``-containing operation is ONE
+revision group covering the deletion, the replacement runs in both paragraphs,
+and the inserted mark; ``reject_group`` reverts the whole split atomically.
+"""
+
+import re
+import zipfile
+
+import pytest
+from conftest import find_ref, replace_document_xml
+
+from docx_editor import Document, EditOperation
+from docx_editor.xml_editor import ParagraphRef
+
+
+@pytest.fixture
+def doc(temp_docx):
+    """An open Document over the simple.docx copy, closed after the test."""
+    document = Document.open(temp_docx)
+    yield document
+    document.close()
+
+
+def _lines(doc: Document) -> list[str]:
+    return doc.get_visible_text().splitlines()
+
+
+class TestReplaceSplitsParagraph:
+    def test_replace_with_newline_splits_into_two_paragraphs(self, doc):
+        ref = find_ref(doc, "quick brown fox")
+        before = doc.paragraph_count()
+
+        result = doc.replace("lazy dog.", "lazy dog.\nA new paragraph.", paragraph=ref)
+
+        assert doc.paragraph_count() == before + 1
+        lines = _lines(doc)
+        # The fox paragraph keeps its (deleted-then-reinserted) text; the new
+        # segment lands on its own line immediately after.
+        fox_idx = next(i for i, line in enumerate(lines) if "lazy dog." in line)
+        assert lines[fox_idx + 1] == "A new paragraph."
+        # No literal newline leaked into a run.
+        assert "\n" not in "".join(lines)
+        assert result.group_id is not None
+
+    def test_multi_newline_makes_multiple_splits_one_group(self, doc):
+        ref = find_ref(doc, "quick brown fox")
+        before = doc.paragraph_count()
+
+        result = doc.replace("fox", "fox\nSECOND\nTHIRD", paragraph=ref)
+
+        assert doc.paragraph_count() == before + 2
+        lines = _lines(doc)
+        i = next(idx for idx, line in enumerate(lines) if line.endswith("fox"))
+        assert lines[i + 1] == "SECOND"
+        assert lines[i + 2].startswith("THIRD")
+        # One operation = one group across every resulting paragraph.
+        groups = {rev.group_id for rev in doc.list_revisions()}
+        assert groups == {result.group_id}
+        # Two inserted paragraph marks (empty-text insertions), one per split.
+        marks = [rev for rev in doc.list_revisions() if rev.type == "insertion" and rev.text == ""]
+        assert len(marks) == 2
+
+    def test_accept_group_keeps_the_split(self, doc):
+        ref = find_ref(doc, "quick brown fox")
+        before = doc.paragraph_count()
+        result = doc.replace("dog.", "dog.\nKept line.", paragraph=ref)
+
+        doc.accept_group(result.group_id)
+
+        assert doc.paragraph_count() == before + 1
+        assert "Kept line." in _lines(doc)
+        # Nothing tracked remains after accepting.
+        assert doc.list_revisions() == []
+
+
+class TestRejectRejoins:
+    def test_reject_group_rejoins_exactly(self, doc):
+        ref = find_ref(doc, "quick brown fox")
+        original = doc.get_visible_text()
+        before = doc.paragraph_count()
+
+        result = doc.replace("dog.", "dog.\nExtra sentence.", paragraph=ref)
+        assert doc.paragraph_count() == before + 1
+
+        doc.reject_group(result.group_id)
+
+        assert doc.paragraph_count() == before
+        assert doc.get_visible_text() == original
+        assert doc.list_revisions() == []
+
+    def test_reject_group_rejoins_multi_split(self, doc):
+        ref = find_ref(doc, "quick brown fox")
+        original = doc.get_visible_text()
+        before = doc.paragraph_count()
+
+        result = doc.replace("fox", "fox\nB\nC\nD", paragraph=ref)
+        assert doc.paragraph_count() == before + 3
+
+        doc.reject_group(result.group_id)
+
+        assert doc.paragraph_count() == before
+        assert doc.get_visible_text() == original
+        assert doc.list_revisions() == []
+
+    def test_reject_all_rejoins(self, doc):
+        ref = find_ref(doc, "quick brown fox")
+        original = doc.get_visible_text()
+        before = doc.paragraph_count()
+
+        doc.replace("dog.", "dog.\nMore.", paragraph=ref)
+        doc.reject_all()
+
+        assert doc.paragraph_count() == before
+        assert doc.get_visible_text() == original
+
+    def test_reject_single_mark_revision_rejoins(self, doc):
+        ref = find_ref(doc, "quick brown fox")
+        before = doc.paragraph_count()
+        doc.replace("dog.", "dog.\nTail.", paragraph=ref)
+        # The paragraph-mark insertion is the empty-text insertion.
+        mark = next(r for r in doc.list_revisions() if r.type == "insertion" and r.text == "")
+
+        doc.reject_revision(mark.id)
+
+        assert doc.paragraph_count() == before
+
+
+class TestInsertAndRewriteSplit:
+    def test_insert_after_with_newline_splits(self, doc):
+        ref = find_ref(doc, "quick brown fox")
+        before = doc.paragraph_count()
+
+        doc.insert_after("fox", "\nInserted paragraph.", paragraph=ref)
+
+        assert doc.paragraph_count() == before + 1
+        lines = _lines(doc)
+        i = next(idx for idx, line in enumerate(lines) if line.endswith("fox"))
+        # The break falls right after "fox"; the inserted text opens the new
+        # paragraph, and the original tail follows it.
+        assert lines[i + 1].startswith("Inserted paragraph.")
+        assert lines[i + 1].endswith("jumps over the lazy dog.")
+
+    def test_insert_before_with_newline_splits(self, doc):
+        ref = find_ref(doc, "quick brown fox")
+        before = doc.paragraph_count()
+
+        doc.insert_before("jumps", "END.\n", paragraph=ref)
+
+        assert doc.paragraph_count() == before + 1
+        lines = _lines(doc)
+        i = next(idx for idx, line in enumerate(lines) if line.endswith("END."))
+        assert lines[i + 1].startswith("jumps")
+
+    def test_rewrite_paragraph_with_newline_splits(self, doc):
+        ref = find_ref(doc, "quick brown fox")
+        before = doc.paragraph_count()
+
+        doc.rewrite_paragraph(ref, "First half.\nSecond half.")
+
+        assert doc.paragraph_count() == before + 1
+        lines = _lines(doc)
+        assert "First half." in lines
+        assert "Second half." in lines
+
+
+class TestSplitParagraphSugar:
+    def test_split_paragraph_before_anchor(self, doc):
+        ref = find_ref(doc, "quick brown fox")
+        before = doc.paragraph_count()
+
+        doc.split_paragraph(ref, before="jumps")
+
+        assert doc.paragraph_count() == before + 1
+        lines = _lines(doc)
+        i = next(idx for idx, line in enumerate(lines) if line.startswith("jumps"))
+        assert lines[i - 1].endswith("fox ")
+        assert lines[i] == "jumps over the lazy dog."
+
+    def test_split_paragraph_reject_rejoins(self, doc):
+        ref = find_ref(doc, "quick brown fox")
+        original = doc.get_visible_text()
+        before = doc.paragraph_count()
+
+        result = doc.split_paragraph(ref, before="jumps")
+        doc.reject_group(result.group_id)
+
+        assert doc.paragraph_count() == before
+        assert doc.get_visible_text() == original
+
+    def test_split_paragraph_requires_before_keyword(self, doc):
+        ref = find_ref(doc, "quick brown fox")
+        with pytest.raises(TypeError):
+            doc.split_paragraph(ref, "jumps")  # `before` is keyword-only
+
+
+class TestEditResultRefs:
+    def test_non_split_edit_has_single_ref(self, doc):
+        ref = find_ref(doc, "quick brown fox")
+        result = doc.replace("quick", "speedy", paragraph=ref)
+        assert result.refs == (str(result),)
+
+    def test_split_refs_cover_both_paragraphs(self, doc):
+        from docx_editor.xml_editor import ParagraphRef
+
+        ref = find_ref(doc, "quick brown fox")
+        result = doc.replace("dog.", "dog.\nNew line.", paragraph=ref)
+
+        assert len(result.refs) == 2
+        assert result.refs[0] == str(result)
+        r1, r2 = result.refs
+        assert ParagraphRef.parse(r2).index == ParagraphRef.parse(r1).index + 1
+        # Both refs are usable for follow-up edits.
+        assert "New line." in doc.get_paragraph(ParagraphRef.parse(r2).index).text
+
+    def test_multi_split_has_three_refs(self, doc):
+        ref = find_ref(doc, "quick brown fox")
+        result = doc.replace("fox", "fox\nB\nC", paragraph=ref)
+        assert len(result.refs) == 3
+
+    def test_split_paragraph_refs(self, doc):
+        ref = find_ref(doc, "quick brown fox")
+        result = doc.split_paragraph(ref, before="jumps")
+        assert len(result.refs) == 2
+
+
+class TestBatchSplit:
+    def test_batch_with_split_op_is_one_changeset(self, doc):
+        fox = find_ref(doc, "quick brown fox")
+        sample = find_ref(doc, "sample document")
+        sample_index = ParagraphRef.parse(sample).index
+
+        results = doc.batch_edit([
+            EditOperation.replace("fox", "fox\nSPLIT", paragraph=fox),
+            EditOperation.replace("sample", "example", paragraph=sample),
+        ])
+
+        # The whole call is one changeset; each op keeps its own group.
+        changesets = {rev.changeset_id for rev in doc.list_revisions()}
+        assert len(changesets) == 1
+        assert results[0].group_id != results[1].group_id
+        # The split op reports both resulting paragraphs.
+        assert len(results[0].refs) == 2
+        # The later op's paragraph shifted down by the split; its result ref
+        # tracks the LIVE position, not the stale original index.
+        assert ParagraphRef.parse(results[1]).index == sample_index + 1
+        assert "example" in doc.get_paragraph(ParagraphRef.parse(results[1]).index).text
+
+    def test_reject_changeset_reverts_batch_split(self, doc):
+        original = doc.get_visible_text()
+        before = doc.paragraph_count()
+        fox = find_ref(doc, "quick brown fox")
+        sample = find_ref(doc, "sample document")
+
+        results = doc.batch_edit([
+            EditOperation.replace("fox", "fox\nSPLIT", paragraph=fox),
+            EditOperation.replace("sample", "example", paragraph=sample),
+        ])
+        doc.reject_changeset(results[0].changeset_id)
+
+        assert doc.paragraph_count() == before
+        assert doc.get_visible_text() == original
+
+
+class TestReopenRejoin:
+    def test_reopened_split_is_one_group_and_rejoins(self, temp_docx):
+        with Document.open(temp_docx) as doc:
+            ref = find_ref(doc, "quick brown fox")
+            original = doc.get_visible_text()
+            doc.replace("dog.", "dog.\nAppended.", paragraph=ref)
+            doc.save()
+
+        with Document.open(temp_docx) as doc:
+            revisions = doc.list_revisions()
+            gids = {r.group_id for r in revisions}
+            assert len(gids) == 1  # reconstructed as ONE inferred group across two paragraphs
+            assert all(r.group_source == "inferred" for r in revisions)
+            gid = gids.pop()
+            assert gid is not None
+            doc.reject_group(gid)
+            assert doc.get_visible_text() == original
+
+    def test_word_stripped_split_still_reconstructs_and_rejoins(self, temp_docx, tmp_path):
+        with Document.open(temp_docx) as doc:
+            ref = find_ref(doc, "quick brown fox")
+            original = doc.get_visible_text()
+            doc.replace("dog.", "dog.\nAppended.", paragraph=ref)
+            doc.save()
+
+        # Simulate Word normalizing on its own save: drop our extension
+        # attributes (rsids, dateUtc, paraId/textId). The rejoin rule must key
+        # only on the durable author+date+mark signal.
+        with zipfile.ZipFile(temp_docx) as z:
+            doc_xml = z.read("word/document.xml").decode("utf-8")
+        stripped = re.sub(r'\s+(w:rsid\w*|w16du:dateUtc|w14:paraId|w14:textId)="[^"]*"', "", doc_xml)
+        assert "w16du:dateUtc" not in stripped
+        dest = tmp_path / "stripped.docx"
+        replace_document_xml(temp_docx, dest, stripped)
+
+        with Document.open(dest) as doc:
+            revisions = doc.list_revisions()
+            assert len({r.group_id for r in revisions}) == 1
+            gid = revisions[0].group_id
+            assert gid is not None
+            doc.reject_group(gid)
+            assert doc.get_visible_text() == original

--- a/tests/test_paragraph_split.py
+++ b/tests/test_paragraph_split.py
@@ -371,3 +371,37 @@ class TestRewriteMultiSplitRefused:
         # Wholesale replacement is one hunk containing the newline — allowed.
         doc.rewrite_paragraph(ref, "First half.\nSecond half.")
         assert doc.paragraph_count() == before + 1
+
+    def test_rewrite_append_newline_is_an_insert_hunk_split(self, doc):
+        ref = find_ref(doc, "quick brown fox")
+        before = doc.paragraph_count()
+        current = doc.get_paragraph(ParagraphRef.parse(ref).index).text
+        # Keeping the old text and appending "\n..." diffs into a pure INSERT
+        # hunk, exercising the newline branch of _rewrite_insert_at (with an
+        # empty first segment).
+        doc.rewrite_paragraph(ref, current + "\nAppended tail.")
+        assert doc.paragraph_count() == before + 1
+        assert "Appended tail." in doc.get_visible_text().splitlines()
+
+    def test_rewrite_append_text_then_newline(self, doc):
+        ref = find_ref(doc, "quick brown fox")
+        before = doc.paragraph_count()
+        current = doc.get_paragraph(ParagraphRef.parse(ref).index).text
+        # Insert hunk whose first segment is non-empty ("... and more."), so the
+        # text lands in the original paragraph before the break opens a new one.
+        doc.rewrite_paragraph(ref, current + " And more.\nAppended tail.")
+        assert doc.paragraph_count() == before + 1
+        lines = doc.get_visible_text().splitlines()
+        assert any(line.endswith("And more.") for line in lines)
+        assert "Appended tail." in lines
+
+
+class TestSplitEmptyFirstSegment:
+    def test_replace_with_leading_newline(self, doc):
+        ref = find_ref(doc, "quick brown fox")
+        before = doc.paragraph_count()
+        # replace_with starts with "\n" → the first segment is empty (no text
+        # reinserted where the match was); the tail opens a new paragraph.
+        doc.replace("dog.", "\nTail after break.", paragraph=ref)
+        assert doc.paragraph_count() == before + 1
+        assert "Tail after break." in doc.get_visible_text().splitlines()

--- a/tests/test_revision_groups.py
+++ b/tests/test_revision_groups.py
@@ -489,7 +489,7 @@ class TestSplitReconstruction:
         # is not yet supported. It must refuse BEFORE mutating: a single edit has
         # no DOM rollback, so a partial delete/insert would otherwise be left
         # behind (the tail-collection raise used to fire mid-mutation).
-        body = f'<w:p><w:r><w:t>Hello</w:t></w:r>{_ins_xml(1, "WORLD", author=AUTHOR_A)}</w:p>'
+        body = f"<w:p><w:r><w:t>Hello</w:t></w:r>{_ins_xml(1, 'WORLD', author=AUTHOR_A)}</w:p>"
         manager = _make_manager(temp_xml(body))
         before = manager.editor.dom.toxml()
 

--- a/tests/test_revision_groups.py
+++ b/tests/test_revision_groups.py
@@ -500,6 +500,24 @@ class TestSplitReconstruction:
         # Byte-for-byte unchanged — no orphaned deletion/insertion.
         assert manager.editor.dom.toxml() == before
 
+    def test_split_inserted_segment_inherits_run_format(self, temp_xml):
+        # The segment inserted at the start of the new paragraph copies the rPr
+        # of the tail it sits before, so it keeps the surrounding formatting
+        # instead of dropping to document default.
+        body = "<w:p><w:r><w:rPr><w:b/></w:rPr><w:t>Hello World</w:t></w:r></w:p>"
+        manager = _make_manager(temp_xml(body))
+
+        manager.replace_text("Hello", "A\nB")
+
+        b_runs = [
+            r
+            for r in manager.editor.dom.getElementsByTagName("w:r")
+            if (ts := r.getElementsByTagName("w:t")) and ts[0].firstChild and ts[0].firstChild.data == "B"
+        ]
+        assert b_runs, "inserted 'B' run not found"
+        rprs = b_runs[0].getElementsByTagName("w:rPr")
+        assert rprs and rprs[0].getElementsByTagName("w:b"), "split-inserted segment lost its bold rPr"
+
 
 class TestForeignInsGrouping:
     """Author/attachment filters keep foreign fragments out of our groups."""

--- a/tests/test_revision_groups.py
+++ b/tests/test_revision_groups.py
@@ -419,6 +419,88 @@ class TestGroupSessionScope:
         assert doc.reject_group(result.group_id) == 2
 
 
+def _mark_ins_xml(rev_id, author: str = AUTHOR_A, date: str = DATE_A) -> str:
+    """A paragraph-mark insertion (empty <w:ins> inside <w:pPr><w:rPr>)."""
+    return f'<w:ins w:id="{rev_id}" w:author="{author}" w:date="{date}"/>'
+
+
+def _split_paragraph_xml(mark_id, content_id, text: str, **kw) -> str:
+    """A first-half paragraph: mark inserted, plus one inserted content run."""
+    return f"<w:p><w:pPr><w:rPr>{_mark_ins_xml(mark_id, **kw)}</w:rPr></w:pPr>{_ins_xml(content_id, text, **kw)}</w:p>"
+
+
+class TestSplitReconstruction:
+    """A reopened tracked split spans two paragraphs; the mark makes it one group."""
+
+    def test_reopened_split_reconstructs_as_one_group(self, temp_xml):
+        body = _split_paragraph_xml(2, 1, "first ") + f"<w:p>{_ins_xml(3, 'second')}</w:p>"
+        manager = _make_manager(temp_xml(body))
+
+        gid = manager.group_id_of(1)
+        assert gid is not None
+        assert {manager.group_id_of(i) for i in (1, 2, 3)} == {gid}
+        assert set(manager.group_revisions(gid)) == {1, 2, 3}
+        assert manager._group_sources[gid] == "inferred"
+
+    def test_reopened_multi_split_reconstructs_as_one_group(self, temp_xml):
+        body = _split_paragraph_xml(10, 1, "a") + _split_paragraph_xml(11, 3, "b") + f"<w:p>{_ins_xml(5, 'c')}</w:p>"
+        manager = _make_manager(temp_xml(body))
+
+        gid = manager.group_id_of(1)
+        assert gid is not None
+        assert {manager.group_id_of(i) for i in (1, 3, 5, 10, 11)} == {gid}
+
+    def test_adjacent_paragraphs_without_mark_stay_separate(self, temp_xml):
+        # Same author+date, adjacent paragraphs, but no inserted mark — the two
+        # edits are unrelated and must reconstruct as two groups (the rule's
+        # negative control).
+        body = f"<w:p>{_ins_xml(1, 'first')}</w:p><w:p>{_ins_xml(2, 'second')}</w:p>"
+        manager = _make_manager(temp_xml(body))
+
+        assert manager.group_id_of(1) != manager.group_id_of(2)
+
+    def test_split_continuation_needs_matching_author_and_date(self, temp_xml):
+        # A mark by a different author/date than the tail's revision is not a
+        # continuation — the durable signal must match on both.
+        body = (
+            _split_paragraph_xml(2, 1, "first ", author=AUTHOR_A)
+            + f"<w:p>{_ins_xml(3, 'second', author=AUTHOR_B, date=DATE_B)}</w:p>"
+        )
+        manager = _make_manager(temp_xml(body))
+
+        assert manager.group_id_of(1) != manager.group_id_of(3)
+
+    def test_split_refuses_paragraph_with_section_mark(self, temp_xml):
+        # A paragraph-level w:sectPr marks a section boundary; splitting it
+        # would corrupt the section structure, so it is refused (no mutation).
+        body = (
+            '<w:p><w:pPr><w:sectPr><w:type w:val="nextPage"/></w:sectPr></w:pPr>'
+            "<w:r><w:t>Section end here</w:t></w:r></w:p>"
+        )
+        manager = _make_manager(temp_xml(body))
+
+        with pytest.raises(RevisionError, match="section mark"):
+            manager.replace_text("end", "end\nsplit")
+        # No partial mutation: the original text is intact.
+        assert "Section end here" in manager.editor.dom.toxml()
+
+    def test_split_inside_existing_revision_is_atomic(self, temp_xml):
+        # A split whose boundary lands inside a pre-existing (foreign) insertion
+        # is not yet supported. It must refuse BEFORE mutating: a single edit has
+        # no DOM rollback, so a partial delete/insert would otherwise be left
+        # behind (the tail-collection raise used to fire mid-mutation).
+        body = f'<w:p><w:r><w:t>Hello</w:t></w:r>{_ins_xml(1, "WORLD", author=AUTHOR_A)}</w:p>'
+        manager = _make_manager(temp_xml(body))
+        before = manager.editor.dom.toxml()
+
+        with pytest.raises(RevisionError, match="existing revision"):
+            # match.end (after "Hello") lands at the start of the foreign <w:ins>.
+            manager.replace_text("Hello", "a\nb")
+
+        # Byte-for-byte unchanged — no orphaned deletion/insertion.
+        assert manager.editor.dom.toxml() == before
+
+
 class TestForeignInsGrouping:
     """Author/attachment filters keep foreign fragments out of our groups."""
 

--- a/tests/test_revision_groups.py
+++ b/tests/test_revision_groups.py
@@ -518,6 +518,55 @@ class TestSplitReconstruction:
         rprs = b_runs[0].getElementsByTagName("w:rPr")
         assert rprs and rprs[0].getElementsByTagName("w:b"), "split-inserted segment lost its bold rPr"
 
+    def test_split_formatted_paragraph_copies_and_cleans_pPr(self, temp_xml):
+        # Splitting a paragraph with rich properties: the tail copies pStyle +
+        # rPr formatting but drops the tracked pPrChange and the mark revision;
+        # the original keeps its pPr and takes the inserted split mark.
+        del_mark = '<w:del w:id="7" w:author="X" w:date="2024-01-01T00:00:00Z"/>'
+        ppr_change = '<w:pPrChange w:id="8" w:author="X" w:date="2024-01-01T00:00:00Z"><w:pPr/></w:pPrChange>'
+        body = (
+            f'<w:p><w:pPr><w:pStyle w:val="Heading1"/><w:rPr><w:b/>{del_mark}</w:rPr>{ppr_change}</w:pPr>'
+            "<w:r><w:rPr><w:b/></w:rPr><w:t>Hello World</w:t></w:r></w:p>"
+        )
+        manager = _make_manager(temp_xml(body))
+
+        manager.replace_text("Hello", "A\nB")
+
+        paras = manager.editor.dom.getElementsByTagName("w:p")
+        assert len(paras) == 2
+        tail_pPr = paras[1].getElementsByTagName("w:pPr")[0]
+        assert tail_pPr.getElementsByTagName("w:pStyle")  # formatting copied
+        assert not tail_pPr.getElementsByTagName("w:pPrChange")  # tracked change dropped
+        tail_rPr = tail_pPr.getElementsByTagName("w:rPr")
+        assert tail_rPr and tail_rPr[0].getElementsByTagName("w:b")  # rPr formatting copied
+        assert not tail_rPr[0].getElementsByTagName("w:del")  # mark dropped from the copy
+
+    def test_split_paragraph_pStyle_without_rPr(self, temp_xml):
+        # pPr present but no rPr: the mark check finds no ins mark, and flagging
+        # the split creates the rPr before the pPrChange anchor.
+        ppr_change = '<w:pPrChange w:id="9" w:author="X" w:date="2024-01-01T00:00:00Z"><w:pPr/></w:pPrChange>'
+        body = f'<w:p><w:pPr><w:pStyle w:val="Body"/>{ppr_change}</w:pPr><w:r><w:t>Hello World</w:t></w:r></w:p>'
+        manager = _make_manager(temp_xml(body))
+
+        manager.replace_text("Hello", "A\nB")
+
+        paras = manager.editor.dom.getElementsByTagName("w:p")
+        assert len(paras) == 2
+        p1_rPr = paras[0].getElementsByTagName("w:pPr")[0].getElementsByTagName("w:rPr")
+        assert p1_rPr and p1_rPr[0].getElementsByTagName("w:ins")  # split mark in the new rPr
+
+    def test_split_continuation_ignores_foreign_authored_mark(self, temp_xml):
+        # run_para carries a paragraph mark by a DIFFERENT author than the
+        # current run's revision, so the next paragraph is not a continuation.
+        body = (
+            f"<w:p><w:pPr><w:rPr>{_mark_ins_xml(1, author=AUTHOR_B, date=DATE_B)}</w:rPr></w:pPr>"
+            f"{_ins_xml(2, 'mine', author=AUTHOR_A, date=DATE_A)}</w:p>"
+            f"<w:p>{_ins_xml(3, 'next', author=AUTHOR_A, date=DATE_A)}</w:p>"
+        )
+        manager = _make_manager(temp_xml(body))
+
+        assert manager.group_id_of(2) != manager.group_id_of(3)
+
 
 class TestForeignInsGrouping:
     """Author/attachment filters keep foreign fragments out of our groups."""

--- a/tests/test_revision_groups.py
+++ b/tests/test_revision_groups.py
@@ -518,6 +518,38 @@ class TestSplitReconstruction:
         rprs = b_runs[0].getElementsByTagName("w:rPr")
         assert rprs and rprs[0].getElementsByTagName("w:b"), "split-inserted segment lost its bold rPr"
 
+    def test_multi_split_at_end_all_segments_inherit_format(self, temp_xml):
+        # Appending "A\nB\nC" past the last word makes every tail paragraph empty
+        # when its segment is inserted; each must still inherit the boundary
+        # formatting (not just the first segment).
+        body = "<w:p><w:r><w:rPr><w:b/></w:rPr><w:t>Hello</w:t></w:r></w:p>"
+        manager = _make_manager(temp_xml(body))
+
+        manager.insert_text_after("Hello", "A\nB\nC")
+
+        for seg in ("A", "B", "C"):
+            runs = [
+                r
+                for r in manager.editor.dom.getElementsByTagName("w:r")
+                if (ts := r.getElementsByTagName("w:t")) and ts[0].firstChild and ts[0].firstChild.data == seg
+            ]
+            assert runs, f"segment {seg!r} run not found"
+            rpr = runs[0].getElementsByTagName("w:rPr")
+            assert rpr and rpr[0].getElementsByTagName("w:b"), f"segment {seg!r} lost bold formatting"
+
+    def test_consecutive_newlines_make_an_empty_paragraph(self, temp_xml):
+        # "\n\nC" past the end makes an empty middle paragraph; the split whose
+        # current paragraph has no runs falls back to empty formatting cleanly.
+        body = "<w:p><w:r><w:t>Hello</w:t></w:r></w:p>"
+        manager = _make_manager(temp_xml(body))
+
+        manager.insert_text_after("Hello", "\n\nC")
+
+        # Hello | (empty) | C  — three paragraphs, no crash, no lost content.
+        assert len(manager.editor.dom.getElementsByTagName("w:p")) == 3
+        texts = [t.firstChild.data for t in manager.editor.dom.getElementsByTagName("w:t") if t.firstChild]
+        assert "C" in texts
+
     def test_split_formatted_paragraph_copies_and_cleans_pPr(self, temp_xml):
         # Splitting a paragraph with rich properties: the tail copies pStyle +
         # rPr formatting but drops the tracked pPrChange and the mark revision;


### PR DESCRIPTION
## Summary

A `\n` in any content text is now a **tracked paragraph split** at that point: the first paragraph's mark is flagged as an inserted revision and the tail moves into a new following paragraph as unchanged content. Accepting keeps the split; rejecting rejoins. Works in `replace` (`replace_with`), `insert_after`/`insert_before` (`text`), `rewrite_paragraph` (`new_text`), and inside `batch_edit` ops. Multiple `\n`s make multiple splits.

One `\n`-containing operation is **one revision group / one changeset** covering the delete, the per-paragraph insertions, and each inserted paragraph mark — `reject_group`/`reject_changeset` revert the whole split atomically.

## Details

- **Split primitives + newline dispatch** from `replace`/`insert`/`rewrite`. Reopen reconstruction keys on the durable author+date+mark signal so a reopened split stays one inferred group across both paragraphs (survives Word stripping our extension attributes).
- **`Document.split_paragraph(ref, *, before)`** — explicit sugar for a pure split.
- **`EditResult.refs`** — every resulting paragraph ref in document order, resolved by element identity so a split that shifts later indexes still reports live positions (batch/rewrite share one revision-element index; no-split edits stay DOM-walk-free).
- **Control-char rejection** — all other C0/DEL controls (tab, CR, NUL, …) are rejected at every text input with a teaching error; only `\n` is special.
- **Safe refusals** — refuses to split a paragraph carrying a `w:sectPr`, or at a boundary inside an existing revision. The latter is checked **up front** so a refused single-op split leaves no partial mutation (single edits have no DOM rollback).

## Verification

- Full suite: **1331 passed, 2 skipped**.
- `ruff check` clean; `ty check` exit 0.
- New `tests/test_paragraph_split.py` plus split-reconstruction and control-char coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tracked paragraph splitting when edit content includes `\n` (including insert/replace/rewrite and batch operations).
  * Introduced `split_paragraph` and extended `EditResult` with `refs` to describe all resulting paragraphs.
  * Added paragraph-split tracking/count support for revision groups.
* **Bug Fixes**
  * Improved split reconstruction across save/reopen and strengthened accept/reject recovery behavior.
* **Documentation**
  * Updated API and skill docs to cover `split_paragraph`, `EditResult.refs`, and newline/control-character rules.
* **Tests**
  * Expanded suites for control-character rejection, split edge cases, and reconstruction/atomicity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->